### PR TITLE
Bugfix/issue_461

### DIFF
--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/RSVTestCase.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/RSVTestCase.java
@@ -418,7 +418,7 @@ public class RSVTestCase extends AndroidTestCase {
 		RouterServiceValidatorTest trsvp = new RouterServiceValidatorTest(mContext);
 		trsvp.setSecurityLevel(MultiplexTransportConfig.FLAG_MULTI_SECURITY_LOW);
 		//Test null SdlApps list handling
-		assertFalse(RouterServiceValidatorTest.createTrustedListRequest(mContext, true, null, null));
+		assertTrue(RouterServiceValidatorTest.createTrustedListRequest(mContext, true, null, null));
 		//Verify that trusted list is unchanged afterwards
 		assertEquals(trustedListBefore, RouterServiceValidatorTest.getTrustedList(mContext));
 
@@ -478,11 +478,6 @@ public class RSVTestCase extends AndroidTestCase {
 						continue;
 					}
 				}
-			} else {	//Return here and do not bother to make request since there's no app to send
-				if (listCallback != null) {
-					listCallback.onListObtained(true);
-				}
-				return false;
 			}
 
 			try {object.put(JSON_PUT_ARRAY_TAG, array);} catch (JSONException e) {e.printStackTrace();}

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/RouterServiceValidator.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/RouterServiceValidator.java
@@ -429,11 +429,6 @@ public class RouterServiceValidator {
 					continue;
 				}
 			}
-		} else {	//Return here and do not bother to make request since there's no app to send
-			if (listCallback != null) {
-				listCallback.onListObtained(true);
-			}
-			return false;
 		}
 		
 		try {object.put(JSON_PUT_ARRAY_TAG, array);} catch (JSONException e) {e.printStackTrace();}
@@ -475,7 +470,7 @@ public class RouterServiceValidator {
 		}
 
 		new HttpRequestTask(cb).execute(REQUEST_PREFIX,HttpRequestTask.REQUEST_TYPE_POST,object.toString(),"application/json","application/json");
-		
+
 		return true;
 	}
 	

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/RouterServiceValidator.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/RouterServiceValidator.java
@@ -351,7 +351,7 @@ public class RouterServiceValidator {
 		List<SdlApp> apps = new ArrayList<SdlApp>();
 		PackageManager packageManager = context.getPackageManager();
 		Intent intent = new Intent();
-		intent.setAction("sdl.router.startservice");
+		intent.setAction(TransportConstants.START_ROUTER_SERVICE_ACTION);
 		List<ResolveInfo> infoList = packageManager.queryBroadcastReceivers(intent, 0);
 		if(infoList!=null){
 			//We want to sort our list so that we know it's the same everytime

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/RouterServiceValidator.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/RouterServiceValidator.java
@@ -429,6 +429,11 @@ public class RouterServiceValidator {
 					continue;
 				}
 			}
+		} else {
+			if (listCallback != null) {
+				listCallback.onListObtained(false);
+			}
+			return false;
 		}
 		
 		try {object.put(JSON_PUT_ARRAY_TAG, array);} catch (JSONException e) {e.printStackTrace();}


### PR DESCRIPTION
Fix issue [#461](https://github.com/smartdevicelink/sdl_android/issues/461)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Extend RouterServiceValidator.java, overriding findAllSdlApps method and return null for testing then call findAllSdlApps and handle null value.
New unit tests passed.

### Summary
Although it's almost guaranteed to have findAllSdlApps to return a non null list.  We will attempt to handle the null case and prevent a npe crash here.
