### PR TITLE
Notify dev about transport update when packet.version is less than 5

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlProtocol.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlProtocol.java
@@ -1036,6 +1036,8 @@ public class SdlProtocol {
                     hashID = BitConverter.intFromByteArray(packet.payload, 0);
                 }
             }
+
+            notifyDevTransportListener();
         }
 
         iSdlProtocol.onProtocolSessionStarted(serviceType, (byte) packet.getSessionId(), (byte)protocolVersion.getMajor(), "", hashID, packet.isEncrypted());


### PR DESCRIPTION
### Summary
This PR just adds a mssing call to `notifyDevTransportListener()` to notify the developer about transport connection updates when packet.version <5

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)