### PR TITLE
Send default setDisplayLayout to fix issue with Sync3

### DIFF
--- a/hello_sdl_android/src/main/AndroidManifest.xml
+++ b/hello_sdl_android/src/main/AndroidManifest.xml
@@ -62,7 +62,7 @@
             </intent-filter>
         </receiver>
         <activity android:name="com.smartdevicelink.managers.lockscreen.SDLLockScreenActivity"
-                  android:launchMode="singleInstance"/>
+                  android:launchMode="singleTop"/>
     </application>
 
 </manifest>

--- a/sdl_android/build.gradle
+++ b/sdl_android/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 19
-        versionCode 7
-        versionName "4.6.3"
+        targetSdkVersion 26
+        versionCode 8
+        versionName "RC1-4.7.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         resValue "string", "SDL_LIB_VERSION", '\"' + versionName + '\"'
     }
@@ -41,7 +41,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.9.0'
     androidTestImplementation 'org.mockito:mockito-android:2.9.0'
-    api 'com.android.support:support-annotations:27.1.1'
+    api 'com.android.support:support-annotations:28.0.0'
 }
 
 buildscript {

--- a/sdl_android/build.gradle
+++ b/sdl_android/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:2.9.0'
     androidTestImplementation 'org.mockito:mockito-android:2.9.0'
     api 'com.android.support:support-annotations:28.0.0'
+    api "android.arch.lifecycle:extensions:1.1.1"
+    annotationProcessor "android.arch.lifecycle:compiler:1.1.1"
 }
 
 buildscript {

--- a/sdl_android/build.gradle
+++ b/sdl_android/build.gradle
@@ -6,7 +6,7 @@ android {
         minSdkVersion 8
         targetSdkVersion 26
         versionCode 8
-        versionName "RC1-4.7.0"
+        versionName "RC2-4.7.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         resValue "string", "SDL_LIB_VERSION", '\"' + versionName + '\"'
     }

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/AndroidTestCase2.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/AndroidTestCase2.java
@@ -1,0 +1,34 @@
+package com.smartdevicelink;
+
+import android.content.Context;
+import android.net.Uri;
+import android.support.test.InstrumentationRegistry;
+
+import junit.framework.TestCase;
+
+
+public class AndroidTestCase2 extends TestCase {
+
+    public Context mContext;
+
+    public AndroidTestCase2(){
+        mContext = InstrumentationRegistry.getTargetContext();
+    }
+
+    public Context getContext(){
+        return mContext;
+    }
+
+    public void setContext(Context context){}
+
+
+    public void assertActivityRequiresPermission(String packageName, String className, String permission){}
+    public void assertReadingContentUriRequiresPermission(Uri uri, String permission){}
+    public void assertWritingContentUriRequiresPermission(Uri uri, String permission){}
+
+
+    protected void	scrubClass(Class<?> testCaseClass){}
+    protected void setUp() throws Exception{}
+    protected void tearDown() throws Exception{}
+
+}

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/SdlConnection/SdlConnectionTest.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/SdlConnection/SdlConnectionTest.java
@@ -1,7 +1,6 @@
 package com.smartdevicelink.SdlConnection;
 
-import android.test.AndroidTestCase;
-
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.test.SdlUnitTestContants;
 import com.smartdevicelink.test.util.DeviceUtil;
 import com.smartdevicelink.transport.BTTransportConfig;
@@ -11,7 +10,7 @@ import com.smartdevicelink.transport.RouterServiceValidator;
 import com.smartdevicelink.transport.USBTransportConfig;
 import com.smartdevicelink.transport.enums.TransportType;
 
-public class SdlConnectionTest extends AndroidTestCase {
+public class SdlConnectionTest extends AndroidTestCase2 {
 	
 	private static final String TAG = "SdlConnection Tests";
 	

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/managers/SdlManagerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/managers/SdlManagerTests.java
@@ -1,8 +1,8 @@
 package com.smartdevicelink.managers;
 
 import android.content.Context;
-import android.test.AndroidTestCase;
 
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.exception.SdlException;
 import com.smartdevicelink.managers.lockscreen.LockScreenConfig;
 import com.smartdevicelink.protocol.enums.FunctionID;
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.mock;
  * This is a unit test class for the SmartDeviceLink library manager class :
  * {@link com.smartdevicelink.managers.SdlManager}
  */
-public class SdlManagerTests extends AndroidTestCase {
+public class SdlManagerTests extends AndroidTestCase2 {
 
 	public static BaseTransportConfig transport = null;
 	private Context mTestContext;

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/managers/audio/AudioStreamManagerTest.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/managers/audio/AudioStreamManagerTest.java
@@ -462,7 +462,9 @@ public class AudioStreamManagerTest extends TestCase {
         final int sampleRate = 16000;
 
         final File outputFile = new File(mContext.getCacheDir(), "test_audio_file.wav");
+        assertNotNull((outputFile));
         final FileOutputStream fileOutputStream = new FileOutputStream(outputFile);
+        assertNotNull(fileOutputStream);
         writeWaveHeader(fileOutputStream, sampleRate, sampleType << 3);
 
         IAudioStreamListener audioStreamListener = new IAudioStreamListener() {

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
@@ -2,8 +2,8 @@ package com.smartdevicelink.managers.file;
 
 import android.content.Context;
 import android.net.Uri;
-import android.test.AndroidTestCase;
 
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.managers.BaseSubManager;
 import com.smartdevicelink.managers.CompletionListener;
 import com.smartdevicelink.managers.file.filetypes.SdlArtwork;
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.mock;
  * This is a unit test class for the SmartDeviceLink library manager class :
  * {@link FileManager}
  */
-public class FileManagerTests extends AndroidTestCase {
+public class FileManagerTests extends AndroidTestCase2 {
 	public static final String TAG = "FileManagerTests";
 	private FileManager fileManager;
 	private Context mTestContext;

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lockscreen/LockScreenConfigTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lockscreen/LockScreenConfigTests.java
@@ -1,7 +1,6 @@
 package com.smartdevicelink.managers.lockscreen;
 
-import android.test.AndroidTestCase;
-
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.test.Test;
 
 
@@ -11,7 +10,7 @@ import com.smartdevicelink.test.Test;
  *
  * We currently do not need to test null values, as each currently is a primitive
  */
-public class LockScreenConfigTests extends AndroidTestCase {
+public class LockScreenConfigTests extends AndroidTestCase2 {
 
 	private LockScreenConfig lockScreenConfig;
 

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lockscreen/LockScreenManagerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lockscreen/LockScreenManagerTests.java
@@ -1,9 +1,8 @@
 package com.smartdevicelink.managers.lockscreen;
 
 import android.content.Context;
-import android.test.AndroidTestCase;
-import android.test.mock.MockContext;
 
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.proxy.interfaces.ISdl;
 import com.smartdevicelink.proxy.rpc.enums.LockScreenStatus;
 import com.smartdevicelink.test.Test;
@@ -14,7 +13,7 @@ import static org.mockito.Mockito.mock;
  * This is a unit test class for the SmartDeviceLink library manager class :
  * {@link com.smartdevicelink.managers.lockscreen.LockScreenManager}
  */
-public class LockScreenManagerTests extends AndroidTestCase {
+public class LockScreenManagerTests extends AndroidTestCase2 {
 
 	private LockScreenManager lockScreenManager;
 
@@ -24,7 +23,7 @@ public class LockScreenManagerTests extends AndroidTestCase {
 
 		ISdl internalInterface = mock(ISdl.class);
 
-		Context context = new MockContext();
+		Context context =  getContext();
 		// create config
 		LockScreenConfig lockScreenConfig = new LockScreenConfig();
 		lockScreenConfig.setCustomView(Test.GENERAL_INT);

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/managers/permission/PermissionManagerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/managers/permission/PermissionManagerTests.java
@@ -1,12 +1,8 @@
 package com.smartdevicelink.managers.permission;
 
 import android.support.annotation.NonNull;
-import android.test.AndroidTestCase;
 
-import com.smartdevicelink.managers.permission.OnPermissionChangeListener;
-import com.smartdevicelink.managers.permission.PermissionElement;
-import com.smartdevicelink.managers.permission.PermissionManager;
-import com.smartdevicelink.managers.permission.PermissionStatus;
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.proxy.interfaces.ISdl;
 import com.smartdevicelink.proxy.rpc.HMIPermissions;
@@ -32,7 +28,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
-public class PermissionManagerTests extends AndroidTestCase {
+public class PermissionManagerTests extends AndroidTestCase2 {
 
     private OnRPCNotificationListener onHMIStatusListener, onPermissionsChangeListener;
     private PermissionManager permissionManager;

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/ScreenManagerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/ScreenManagerTests.java
@@ -1,5 +1,6 @@
 package com.smartdevicelink.managers.screen;
 
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.managers.BaseSubManager;
 import com.smartdevicelink.managers.file.FileManager;
 import com.smartdevicelink.managers.file.filetypes.SdlArtwork;
@@ -7,7 +8,6 @@ import com.smartdevicelink.proxy.interfaces.ISdl;
 import com.smartdevicelink.proxy.rpc.enums.FileType;
 import com.smartdevicelink.proxy.rpc.enums.MetadataType;
 import com.smartdevicelink.proxy.rpc.enums.TextAlignment;
-import com.smartdevicelink.test.utl.AndroidToolsTests;
 
 import java.util.Arrays;
 import java.util.List;
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.mock;
  * This is a unit test class for the SmartDeviceLink library manager class :
  * {@link ScreenManager}
  */
-public class ScreenManagerTests extends AndroidToolsTests{
+public class ScreenManagerTests extends AndroidTestCase2 {
 	private ScreenManager screenManager;
 	private SdlArtwork testArtwork;
 

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -1,7 +1,7 @@
 package com.smartdevicelink.managers.screen;
 
-import android.test.AndroidTestCase;
 
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.managers.CompletionListener;
 import com.smartdevicelink.managers.file.FileManager;
 import com.smartdevicelink.managers.file.MultipleFileCompletionListener;
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.mock;
  * This is a unit test class for the SmartDeviceLink library manager class :
  * {@link SoftButtonManager}
  */
-public class SoftButtonManagerTests extends AndroidTestCase {
+public class SoftButtonManagerTests extends AndroidTestCase2 {
 
     private SoftButtonManager softButtonManager;
     private boolean fileManagerUploadArtworksGotCalled;

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/TextAndGraphicManagerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/TextAndGraphicManagerTests.java
@@ -3,6 +3,7 @@ package com.smartdevicelink.managers.screen;
 import android.content.Context;
 import android.net.Uri;
 
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.managers.BaseSubManager;
 import com.smartdevicelink.managers.file.FileManager;
 import com.smartdevicelink.managers.file.filetypes.SdlArtwork;
@@ -16,7 +17,6 @@ import com.smartdevicelink.proxy.rpc.enums.HMILevel;
 import com.smartdevicelink.proxy.rpc.enums.MetadataType;
 import com.smartdevicelink.proxy.rpc.enums.TextAlignment;
 import com.smartdevicelink.proxy.rpc.enums.TextFieldName;
-import com.smartdevicelink.test.utl.AndroidToolsTests;
 
 import org.json.JSONException;
 
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.mock;
  * This is a unit test class for the SmartDeviceLink library manager class :
  * {@link com.smartdevicelink.managers.screen.TextAndGraphicManager}
  */
-public class TextAndGraphicManagerTests extends AndroidToolsTests{
+public class TextAndGraphicManagerTests extends AndroidTestCase2 {
 
 	// SETUP / HELPERS
 	private TextAndGraphicManager textAndGraphicManager;

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/managers/video/VideoStreamManagerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/managers/video/VideoStreamManagerTests.java
@@ -3,11 +3,11 @@ package com.smartdevicelink.managers.video;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.test.AndroidTestCase;
 import android.view.Display;
 import android.view.MotionEvent;
 import android.view.View;
 
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.managers.CompletionListener;
 import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.protocol.enums.SessionType;
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.when;
  * This is a unit test class for the SmartDeviceLink video streaming manager class :
  * {@link VideoStreamManager}
  */
-public class VideoStreamManagerTests extends AndroidTestCase {
+public class VideoStreamManagerTests extends AndroidTestCase2 {
 	public static final String TAG = "VideoStreamManagerTests";
 	private Context mTestContext;
 	private static boolean touchEventOccured = false;

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/protocol/SdlPacketTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/protocol/SdlPacketTests.java
@@ -1,14 +1,13 @@
 package com.smartdevicelink.protocol;
 
-import android.test.AndroidTestCase;
-
 import com.livio.BSON.BsonEncoder;
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.protocol.enums.ControlFrameTags;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class SdlPacketTests extends AndroidTestCase {
+public class SdlPacketTests extends AndroidTestCase2 {
 	//TODO: Add tests to cover other parts of SdlPacket class
 
 	// Test variables

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/protocol/SdlProtocolTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/protocol/SdlProtocolTests.java
@@ -1,8 +1,8 @@
 package com.smartdevicelink.protocol;
 
-import android.test.AndroidTestCase;
 import android.util.Log;
 
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.SdlConnection.SdlConnection;
 import com.smartdevicelink.protocol.enums.SessionType;
 import com.smartdevicelink.protocol.SdlProtocol.MessageFrameAssembler;
@@ -22,7 +22,7 @@ import java.util.List;
 
 import static org.mockito.Mockito.mock;
 
-public class SdlProtocolTests  extends AndroidTestCase {
+public class SdlProtocolTests  extends AndroidTestCase2 {
 
     int max_int = 2147483647;
     byte[] payload;

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/protocol/WiProProtocolTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/protocol/WiProProtocolTests.java
@@ -1,9 +1,9 @@
 package com.smartdevicelink.protocol;
 
 import android.os.Bundle;
-import android.test.AndroidTestCase;
 import android.util.Log;
 
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.SdlConnection.SdlConnection;
 import com.smartdevicelink.protocol.WiProProtocol.MessageFrameAssembler;
 import com.smartdevicelink.protocol.enums.SessionType;
@@ -26,7 +26,7 @@ import java.util.Map;
  * This is a unit test class for the SmartDeviceLink library project class : 
  * {@link com.smartdevicelink.protocol.BinaryFrameHeader}
  */
-public class WiProProtocolTests extends AndroidTestCase {
+public class WiProProtocolTests extends AndroidTestCase2 {
 	
 	int max_int = 2147483647;
 	byte[] payload;

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/BaseRpcTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/BaseRpcTests.java
@@ -6,13 +6,12 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import android.test.AndroidTestCase;
-
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.proxy.RPCMessage;
 import com.smartdevicelink.proxy.RPCRequest;
 import com.smartdevicelink.proxy.RPCResponse;
 
-public abstract class BaseRpcTests extends AndroidTestCase {
+public abstract class BaseRpcTests extends AndroidTestCase2 {
 
     public static final int  SDL_VERSION_UNDER_TEST = Config.SDL_VERSION_UNDER_TEST;
 

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/protocol/BinaryFrameHeaderTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/protocol/BinaryFrameHeaderTests.java
@@ -2,14 +2,12 @@ package com.smartdevicelink.test.protocol;
 
 import junit.framework.Assert;
 
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.protocol.BinaryFrameHeader;
 import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.test.SampleRpc;
 
-import android.test.AndroidTestCase;
-import android.util.Log;
-
-public class BinaryFrameHeaderTests extends AndroidTestCase {
+public class BinaryFrameHeaderTests extends AndroidTestCase2 {
 	
 	public static final byte RPC_TYPE_REQUEST 		= 0x00;
 	public static final byte RPC_TYPE_RESPONSE 		= 0x01;

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/RPCRequestTest.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/RPCRequestTest.java
@@ -1,22 +1,15 @@
 package com.smartdevicelink.test.proxy;
 
-import android.test.AndroidTestCase;
 
-import com.smartdevicelink.protocol.enums.FunctionID;
-import com.smartdevicelink.proxy.RPCMessage;
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.proxy.RPCRequest;
-import com.smartdevicelink.proxy.RPCResponse;
 import com.smartdevicelink.proxy.rpc.GetSystemCapability;
 import com.smartdevicelink.test.Config;
-import com.smartdevicelink.test.JsonUtils;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import junit.framework.TestCase;
 
-import java.util.Iterator;
 
-public class RPCRequestTest extends AndroidTestCase {
+public class RPCRequestTest extends AndroidTestCase2 {
 
     public static final int  SDL_VERSION_UNDER_TEST = Config.SDL_VERSION_UNDER_TEST;
 

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SdlProxyBaseTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SdlProxyBaseTests.java
@@ -2,9 +2,9 @@ package com.smartdevicelink.test.proxy;
 
 import android.content.Context;
 import android.telephony.TelephonyManager;
-import android.test.AndroidTestCase;
 import android.util.Log;
 
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.exception.SdlException;
 import com.smartdevicelink.exception.SdlExceptionCause;
 import com.smartdevicelink.proxy.RPCRequest;
@@ -97,7 +97,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 
-public class SdlProxyBaseTests extends AndroidTestCase{
+public class SdlProxyBaseTests extends AndroidTestCase2 {
     public static final String TAG = "SdlProxyBaseTests";
 
     @Override

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SystemCapabilityManagerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SystemCapabilityManagerTests.java
@@ -1,7 +1,6 @@
 package com.smartdevicelink.test.proxy;
 
-import android.test.AndroidTestCase;
-
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.protocol.enums.SessionType;
 import com.smartdevicelink.proxy.RPCRequest;
@@ -38,7 +37,7 @@ import com.smartdevicelink.util.Version;
 
 import java.util.List;
 
-public class SystemCapabilityManagerTests extends AndroidTestCase {
+public class SystemCapabilityManagerTests extends AndroidTestCase2 {
 	public static final String TAG = "SystemCapabilityManagerTests";
 	public static SystemCapabilityManager systemCapabilityManager;
 

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/RPCConstructorsTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/RPCConstructorsTests.java
@@ -1,6 +1,7 @@
 package com.smartdevicelink.test.rpc;
 
-import android.test.AndroidTestCase;
+
+import com.smartdevicelink.AndroidTestCase2;
 
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
@@ -23,7 +24,7 @@ import java.util.Map;
  * It makes sure that for each RPC, all mandatory parameters are set in a constructor
  */
 
-public class RPCConstructorsTests extends AndroidTestCase {
+public class RPCConstructorsTests extends AndroidTestCase2 {
 
     private final String XML_FILE_NAME = "xml/MOBILE_API_4.5.0.xml";
     private final String RPC_PACKAGE_PREFIX = "com.smartdevicelink.proxy.rpc.";

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/security/SdlSecurityBaseTest.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/security/SdlSecurityBaseTest.java
@@ -4,8 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import android.test.AndroidTestCase;
-
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.SdlConnection.ISdlConnectionListener;
 import com.smartdevicelink.SdlConnection.SdlSession;
 import com.smartdevicelink.protocol.ProtocolMessage;
@@ -17,7 +16,7 @@ import com.smartdevicelink.transport.BaseTransportConfig;
 import com.smartdevicelink.transport.MultiplexTransportConfig;
 import com.smartdevicelink.transport.enums.TransportType;
 
-public class SdlSecurityBaseTest extends AndroidTestCase {
+public class SdlSecurityBaseTest extends AndroidTestCase2 {
 		
 	@Override
 	protected void setUp() throws Exception {

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/streaming/video/SdlRemoteDisplayTest.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/streaming/video/SdlRemoteDisplayTest.java
@@ -4,12 +4,11 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Bundle;
 import android.os.Looper;
-import android.test.AndroidTestCase;
+import android.support.test.InstrumentationRegistry;
 import android.view.Display;
 import android.view.MotionEvent;
 import android.widget.RelativeLayout;
 
-import com.smartdevicelink.R;
 import com.smartdevicelink.encoder.VirtualDisplayEncoder;
 import com.smartdevicelink.proxy.interfaces.IVideoStreamListener;
 import com.smartdevicelink.streaming.video.SdlRemoteDisplay;
@@ -21,7 +20,7 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.FutureTask;
 
 
-public class SdlRemoteDisplayTest extends AndroidTestCase {
+public class SdlRemoteDisplayTest extends TestCase {
 
     MockRemoteDisplayCallback rdCallback = new MockRemoteDisplayCallback();
 
@@ -38,7 +37,7 @@ public class SdlRemoteDisplayTest extends AndroidTestCase {
         assertNotNull(encoder);
 
 
-        SdlRemoteDisplay.Creator creator = new SdlRemoteDisplay.Creator(this.getContext(), encoder.getVirtualDisplay(), null, MockRemoteDisplay.class, rdCallback);
+        SdlRemoteDisplay.Creator creator = new SdlRemoteDisplay.Creator(InstrumentationRegistry.getContext(), encoder.getVirtualDisplay(), null, MockRemoteDisplay.class, rdCallback);
         assertNotNull(creator);
         FutureTask<Boolean> fTask = new FutureTask<Boolean>(creator);
         Thread showPresentation = new Thread(fTask);
@@ -49,7 +48,7 @@ public class SdlRemoteDisplayTest extends AndroidTestCase {
     public void testConstructor(){
         VirtualDisplayEncoder encoder = createVDE();
         assertNotNull(encoder);
-        MockRemoteDisplay remoteDisplay = new MockRemoteDisplay(getContext(), encoder.getVirtualDisplay());
+        MockRemoteDisplay remoteDisplay = new MockRemoteDisplay(InstrumentationRegistry.getContext(), encoder.getVirtualDisplay());
         assertNotNull(remoteDisplay);
 
         encoder.shutDown();
@@ -60,7 +59,7 @@ public class SdlRemoteDisplayTest extends AndroidTestCase {
     public void testTouchEvents(){
         VirtualDisplayEncoder encoder = createVDE();
         assertNotNull(encoder);
-        MockRemoteDisplay remoteDisplay = new MockRemoteDisplay(getContext(), encoder.getVirtualDisplay());
+        MockRemoteDisplay remoteDisplay = new MockRemoteDisplay(InstrumentationRegistry.getContext(), encoder.getVirtualDisplay());
         assertNotNull(remoteDisplay);
         remoteDisplay.show();
 
@@ -80,7 +79,7 @@ public class SdlRemoteDisplayTest extends AndroidTestCase {
     public VirtualDisplayEncoder createVDE(){
         try{
             VirtualDisplayEncoder displayEncoder = new VirtualDisplayEncoder();
-            displayEncoder.init(getContext(), new MockVideoStreamListener(), new VideoStreamingParameters());
+            displayEncoder.init(InstrumentationRegistry.getContext(), new MockVideoStreamListener(), new VideoStreamingParameters());
             displayEncoder.start();
             return displayEncoder;
         }catch (Exception e ){

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/transport/MultiplexTransportConfigTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/transport/MultiplexTransportConfigTests.java
@@ -1,10 +1,10 @@
 package com.smartdevicelink.test.transport;
 
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.transport.MultiplexTransportConfig;
 
-import android.test.AndroidTestCase;
 
-public class MultiplexTransportConfigTests extends AndroidTestCase {
+public class MultiplexTransportConfigTests extends AndroidTestCase2 {
 
 	
 	public void testDefaultSecurity(){

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/util/SdlAppInfoTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/util/SdlAppInfoTests.java
@@ -38,8 +38,8 @@ import android.content.pm.PackageInfo;
 import android.content.pm.ResolveInfo;
 import android.content.pm.ServiceInfo;
 import android.os.Bundle;
-import android.test.AndroidTestCase;
 
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.R;
 import com.smartdevicelink.util.SdlAppInfo;
 
@@ -51,7 +51,7 @@ import java.util.List;
  * Created by Joey Grover on 2/20/18.
  */
 
-public class SdlAppInfoTests extends AndroidTestCase {
+public class SdlAppInfoTests extends AndroidTestCase2 {
 
     Context context;
     ResolveInfo defaultResolveInfo;

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/util/VersionTest.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/util/VersionTest.java
@@ -1,10 +1,9 @@
 package com.smartdevicelink.test.util;
 
-import android.test.AndroidTestCase;
-
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.util.Version;
 
-public class VersionTest extends AndroidTestCase {
+public class VersionTest extends AndroidTestCase2 {
 
     private static final String TEST_VERSION = "1.2.3";
 

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/utl/AndroidToolsTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/utl/AndroidToolsTests.java
@@ -2,11 +2,11 @@ package com.smartdevicelink.test.utl;
 
 import junit.framework.Assert;
 import android.content.ComponentName;
-import android.test.AndroidTestCase;
 
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.util.AndroidTools;
 
-public class AndroidToolsTests extends AndroidTestCase{
+public class AndroidToolsTests extends AndroidTestCase2 {
 	
 	
 	public void testIsServiceExportedNormal(){

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/LocalRouterServiceTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/LocalRouterServiceTests.java
@@ -3,9 +3,10 @@ package com.smartdevicelink.transport;
 import android.content.ComponentName;
 import android.content.Intent;
 import android.os.Parcel;
-import android.test.AndroidTestCase;
 
-public class LocalRouterServiceTests extends AndroidTestCase {
+import com.smartdevicelink.AndroidTestCase2;
+
+public class LocalRouterServiceTests extends AndroidTestCase2 {
 
 	private static final int TEST_WITH_CONSTRUCTOR 	= 0;
 	private static final int TEST_WITH_CREATOR 		= 1;

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/MultiplexTransportTest.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/MultiplexTransportTest.java
@@ -1,14 +1,13 @@
 package com.smartdevicelink.transport;
 
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.protocol.SdlPacket;
 import com.smartdevicelink.test.SdlUnitTestContants;
 import com.smartdevicelink.transport.enums.TransportType;
 
-import android.test.AndroidTestCase;
-
 import junit.framework.Assert;
 
-public class MultiplexTransportTest extends AndroidTestCase {
+public class MultiplexTransportTest extends AndroidTestCase2 {
 
 	private static final int TIMEOUT = 2000;
 	

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/RSVTestCase.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/RSVTestCase.java
@@ -5,9 +5,9 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
-import android.test.AndroidTestCase;
 import android.util.Log;
 
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.transport.RouterServiceValidator.TrustedAppStore;
 import com.smartdevicelink.util.HttpRequestTask.HttpRequestTaskCallback;
 
@@ -21,7 +21,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.concurrent.Semaphore;
 
-public class RSVTestCase extends AndroidTestCase {
+public class RSVTestCase extends AndroidTestCase2 {
 	private static final String TAG = "RSVTestCase";
 	
 	private static final long REFRESH_TRUSTED_APP_LIST_TIME_DAY 	= 3600000 * 24; // A day in ms

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/RegisteredAppTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/RegisteredAppTests.java
@@ -1,16 +1,16 @@
 package com.smartdevicelink.transport;
 
-import android.os.Handler;
 import android.os.Looper;
 import android.os.Messenger;
-import android.test.AndroidTestCase;
+
+import com.smartdevicelink.AndroidTestCase2;
 
 
 /**
  * Created by brettywhite on 4/4/17.
  */
 
-public class RegisteredAppTests extends AndroidTestCase {
+public class RegisteredAppTests extends AndroidTestCase2 {
 
     private static final String APP_ID = "123451123";
     private static final Messenger messenger = null;

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/SdlRouterServiceTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/SdlRouterServiceTests.java
@@ -5,11 +5,11 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
-import android.test.AndroidTestCase;
 import android.util.Log;
 import android.util.SparseArray;
 import android.util.SparseIntArray;
 
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.marshal.JsonRPCMarshaller;
 import com.smartdevicelink.protocol.BinaryFrameHeader;
 import com.smartdevicelink.protocol.ProtocolMessage;
@@ -29,7 +29,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 
-public class SdlRouterServiceTests extends AndroidTestCase {
+public class SdlRouterServiceTests extends AndroidTestCase2 {
 
     public static final String TAG = "SdlRouterServiceTests";
     private final int SAMPLE_RPC_CORRELATION_ID = 630;

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/TransportBrokerTest.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/TransportBrokerTest.java
@@ -5,12 +5,12 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
 import android.os.Messenger;
-import android.test.AndroidTestCase;
 
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.test.SdlUnitTestContants;
 import com.smartdevicelink.test.util.DeviceUtil;
 
-public class TransportBrokerTest extends AndroidTestCase {
+public class TransportBrokerTest extends AndroidTestCase2 {
 	RouterServiceValidator rsvp;
 	//		public TransportBrokerThread(Context context, String appId, ComponentName service){
 

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/TransportManagerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/TransportManagerTests.java
@@ -5,8 +5,8 @@ import android.os.Bundle;
 import android.os.Looper;
 import android.os.Message;
 import android.os.Parcelable;
-import android.test.AndroidTestCase;
 
+import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.protocol.SdlPacket;
 import com.smartdevicelink.protocol.SdlPacketFactory;
 import com.smartdevicelink.protocol.enums.SessionType;
@@ -18,7 +18,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class TransportManagerTests extends AndroidTestCase {
+public class TransportManagerTests extends AndroidTestCase2 {
 
     MultiplexTransportConfig config;
     final TransportRecord defaultBtRecord = new TransportRecord(TransportType.BLUETOOTH, "12:34:56:78:90");

--- a/sdl_android/src/main/AndroidManifest.xml
+++ b/sdl_android/src/main/AndroidManifest.xml
@@ -1,2 +1,4 @@
-<manifest package="com.smartdevicelink" xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest package="com.smartdevicelink"
+          xmlns:tools="http://schemas.android.com/tools">
+    <uses-sdk tools:overrideLibrary="android.arch.lifecycle, android.arch.lifecycle.extensions, android.arch.lifecycle.livedata, android.arch.lifecycle.livedata.core, android.arch.core, android.arch.lifecycle.viewmodel, android.support.fragment, android.support.coreui, android.support.coreutils, android.support.compat" />
 </manifest>

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/BaseSubManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/BaseSubManager.java
@@ -50,7 +50,7 @@ public abstract class BaseSubManager {
 		transitionToState(SHUTDOWN);
 	}
 
-	protected void transitionToState(int state) {
+	public void transitionToState(int state) {
 		synchronized (STATE_LOCK) {
 			this.state = state;
 		}

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -31,10 +31,12 @@ import com.smartdevicelink.proxy.interfaces.IVideoStreamListener;
 import com.smartdevicelink.proxy.interfaces.OnSystemCapabilityListener;
 import com.smartdevicelink.proxy.rpc.SdlMsgVersion;
 import com.smartdevicelink.proxy.rpc.SetAppIcon;
+import com.smartdevicelink.proxy.rpc.SetDisplayLayout;
 import com.smartdevicelink.proxy.rpc.TTSChunk;
 import com.smartdevicelink.proxy.rpc.TemplateColorScheme;
 import com.smartdevicelink.proxy.rpc.enums.AppHMIType;
 import com.smartdevicelink.proxy.rpc.enums.Language;
+import com.smartdevicelink.proxy.rpc.enums.PredefinedLayout;
 import com.smartdevicelink.proxy.rpc.enums.SdlDisconnectedReason;
 import com.smartdevicelink.proxy.rpc.enums.SystemCapabilityType;
 import com.smartdevicelink.proxy.rpc.listeners.OnMultipleRequestListener;
@@ -195,6 +197,15 @@ public class SdlManager{
 				_internalInterface.sendRPCRequest(msg);
 			}
 		}
+
+
+		// Send a setDisplayLayout
+		// This is necessary due to a Ford Sync 3 bug. Sync 3 sends wrong supported text fields info in DisplayCapability in the RegisterAppInterfaceResponse
+		// Sending SetDisplayLayout will allow the SystemCapabilityManager to get the correct supported text fields from DisplayCapability in SetDisplayLayoutResponse
+		SetDisplayLayout setDisplayLayoutRequest = new SetDisplayLayout();
+		setDisplayLayoutRequest.setDisplayLayout(PredefinedLayout.DEFAULT.toString());
+		_internalInterface.sendRPCRequest(setDisplayLayoutRequest);
+
 	}
 
 	protected void initialize(){

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -31,12 +31,10 @@ import com.smartdevicelink.proxy.interfaces.IVideoStreamListener;
 import com.smartdevicelink.proxy.interfaces.OnSystemCapabilityListener;
 import com.smartdevicelink.proxy.rpc.SdlMsgVersion;
 import com.smartdevicelink.proxy.rpc.SetAppIcon;
-import com.smartdevicelink.proxy.rpc.SetDisplayLayout;
 import com.smartdevicelink.proxy.rpc.TTSChunk;
 import com.smartdevicelink.proxy.rpc.TemplateColorScheme;
 import com.smartdevicelink.proxy.rpc.enums.AppHMIType;
 import com.smartdevicelink.proxy.rpc.enums.Language;
-import com.smartdevicelink.proxy.rpc.enums.PredefinedLayout;
 import com.smartdevicelink.proxy.rpc.enums.SdlDisconnectedReason;
 import com.smartdevicelink.proxy.rpc.enums.SystemCapabilityType;
 import com.smartdevicelink.proxy.rpc.listeners.OnMultipleRequestListener;
@@ -197,15 +195,6 @@ public class SdlManager{
 				_internalInterface.sendRPCRequest(msg);
 			}
 		}
-
-
-		// Send a setDisplayLayout
-		// This is necessary due to a Ford Sync 3 bug. Sync 3 sends wrong supported text fields info in DisplayCapability in the RegisterAppInterfaceResponse
-		// Sending SetDisplayLayout will allow the SystemCapabilityManager to get the correct supported text fields from DisplayCapability in SetDisplayLayoutResponse
-		SetDisplayLayout setDisplayLayoutRequest = new SetDisplayLayout();
-		setDisplayLayoutRequest.setDisplayLayout(PredefinedLayout.DEFAULT.toString());
-		_internalInterface.sendRPCRequest(setDisplayLayoutRequest);
-
 	}
 
 	protected void initialize(){

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -143,8 +143,8 @@ public class SdlManager{
 			if (permissionManager.getState() == BaseSubManager.READY && fileManager.getState() == BaseSubManager.READY && screenManager.getState() == BaseSubManager.READY && (!lockScreenConfig.isEnabled() || lockScreenManager.getState() == BaseSubManager.READY)) {
 				DebugTool.logInfo("Starting sdl manager, all sub managers are in ready state");
 				transitionToState(BaseSubManager.READY);
-				notifyDevListener(null);
 				onReady();
+				notifyDevListener(null);
 			} else if (permissionManager.getState() == BaseSubManager.ERROR && fileManager.getState() == BaseSubManager.ERROR && screenManager.getState() == BaseSubManager.ERROR && (!lockScreenConfig.isEnabled() || lockScreenManager.getState() == BaseSubManager.ERROR)) {
 				String info = "ERROR starting sdl manager, all sub managers are in error state";
 				Log.e(TAG, info);
@@ -157,8 +157,8 @@ public class SdlManager{
 			} else {
 				Log.w(TAG, "LIMITED starting sdl manager, some sub managers are in error or limited state and the others finished setting up");
 				transitionToState(BaseSubManager.LIMITED);
-				notifyDevListener(null);
 				onReady();
+				notifyDevListener(null);
 			}
 		} else {
 			// We should never be here, but somehow one of the sub-sub managers is null

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
@@ -1,6 +1,9 @@
 package com.smartdevicelink.managers.lockscreen;
 
-import android.app.ActivityManager;
+import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.LifecycleObserver;
+import android.arch.lifecycle.OnLifecycleEvent;
+import android.arch.lifecycle.ProcessLifecycleOwner;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
@@ -41,6 +44,8 @@ public class LockScreenManager extends BaseSubManager {
 	private OnRPCNotificationListener systemRequestListener, ddListener, hmiListener;
 	private String deviceIconUrl;
 	private boolean driverDistStatus;
+	private volatile boolean isApplicationForegrounded;
+	private LifecycleObserver lifecycleObserver;
 	protected boolean lockScreenEnabled, deviceLogoEnabled;
 	protected int lockScreenIcon, lockScreenColor, customView;
 	protected Bitmap deviceLogo;
@@ -84,6 +89,19 @@ public class LockScreenManager extends BaseSubManager {
 		}
 		deviceLogo = null;
 		deviceIconUrl = null;
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+			try {
+				if (ProcessLifecycleOwner.get() != null && lifecycleObserver != null) {
+					ProcessLifecycleOwner.get().getLifecycle().removeObserver(lifecycleObserver);
+				}
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+
+			lifecycleObserver = null;
+		}
+
 		super.dispose();
 	}
 
@@ -152,6 +170,30 @@ public class LockScreenManager extends BaseSubManager {
 			};
 			internalInterface.addOnRPCNotificationListener(FunctionID.ON_SYSTEM_REQUEST, systemRequestListener);
 		}
+
+		// Set up listener for Application Foreground / Background events
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+			try {
+				lifecycleObserver = new LifecycleObserver() {
+					@OnLifecycleEvent(Lifecycle.Event.ON_START)
+					public void onMoveToForeground() {
+						isApplicationForegrounded = true;
+						launchLockScreenActivity();
+					}
+
+					@OnLifecycleEvent(Lifecycle.Event.ON_STOP)
+					public void onMoveToBackground() {
+						isApplicationForegrounded = false;
+					}
+				};
+
+				if (ProcessLifecycleOwner.get() != null) {
+					ProcessLifecycleOwner.get().getLifecycle().addObserver(lifecycleObserver);
+				}
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
 	}
 
 	////
@@ -168,7 +210,7 @@ public class LockScreenManager extends BaseSubManager {
 	private void launchLockScreenActivity(){
 		// intent to open SDLLockScreenActivity
 		// pass in icon, background color, and custom view
-		if (lockScreenEnabled && isForegrounded() && context.get() != null) {
+		if (lockScreenEnabled && isApplicationForegrounded && context.get() != null) {
 			LockScreenStatus status = getLockScreenStatus();
 			if (status == LockScreenStatus.REQUIRED) {
 				Intent showLockScreenIntent = new Intent(context.get(), SDLLockScreenActivity.class);
@@ -185,15 +227,6 @@ public class LockScreenManager extends BaseSubManager {
 				context.get().sendBroadcast(new Intent(SDLLockScreenActivity.CLOSE_LOCK_SCREEN_ACTION));
 			}
 		}
-	}
-
-	private boolean isForegrounded() {
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-			ActivityManager.RunningAppProcessInfo myProcess = new ActivityManager.RunningAppProcessInfo();
-			ActivityManager.getMyMemoryState(myProcess);
-			return myProcess.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND;
-		}
-		return true;
 	}
 
 	////

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
@@ -102,6 +102,8 @@ public class LockScreenManager extends BaseSubManager {
 			lifecycleObserver = null;
 		}
 
+		isApplicationForegrounded = false;
+
 		super.dispose();
 	}
 
@@ -193,6 +195,8 @@ public class LockScreenManager extends BaseSubManager {
 			} catch (Exception e) {
 				e.printStackTrace();
 			}
+		} else{
+			isApplicationForegrounded = true;
 		}
 	}
 

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
@@ -1,9 +1,5 @@
 package com.smartdevicelink.managers.lockscreen;
 
-import android.arch.lifecycle.Lifecycle;
-import android.arch.lifecycle.LifecycleObserver;
-import android.arch.lifecycle.OnLifecycleEvent;
-import android.arch.lifecycle.ProcessLifecycleOwner;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
@@ -45,7 +41,7 @@ public class LockScreenManager extends BaseSubManager {
 	private String deviceIconUrl;
 	private boolean driverDistStatus;
 	private volatile boolean isApplicationForegrounded;
-	private LifecycleObserver lifecycleObserver;
+	private android.arch.lifecycle.LifecycleObserver lifecycleObserver;
 	protected boolean lockScreenEnabled, deviceLogoEnabled;
 	protected int lockScreenIcon, lockScreenColor, customView;
 	protected Bitmap deviceLogo;
@@ -92,8 +88,8 @@ public class LockScreenManager extends BaseSubManager {
 
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
 			try {
-				if (ProcessLifecycleOwner.get() != null && lifecycleObserver != null) {
-					ProcessLifecycleOwner.get().getLifecycle().removeObserver(lifecycleObserver);
+				if (android.arch.lifecycle.ProcessLifecycleOwner.get() != null && lifecycleObserver != null) {
+					android.arch.lifecycle.ProcessLifecycleOwner.get().getLifecycle().removeObserver(lifecycleObserver);
 				}
 			} catch (Exception e) {
 				e.printStackTrace();
@@ -176,21 +172,21 @@ public class LockScreenManager extends BaseSubManager {
 		// Set up listener for Application Foreground / Background events
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
 			try {
-				lifecycleObserver = new LifecycleObserver() {
-					@OnLifecycleEvent(Lifecycle.Event.ON_START)
+				lifecycleObserver = new android.arch.lifecycle.LifecycleObserver() {
+					@android.arch.lifecycle.OnLifecycleEvent(android.arch.lifecycle.Lifecycle.Event.ON_START)
 					public void onMoveToForeground() {
 						isApplicationForegrounded = true;
 						launchLockScreenActivity();
 					}
 
-					@OnLifecycleEvent(Lifecycle.Event.ON_STOP)
+					@android.arch.lifecycle.OnLifecycleEvent(android.arch.lifecycle.Lifecycle.Event.ON_STOP)
 					public void onMoveToBackground() {
 						isApplicationForegrounded = false;
 					}
 				};
 
-				if (ProcessLifecycleOwner.get() != null) {
-					ProcessLifecycleOwner.get().getLifecycle().addObserver(lifecycleObserver);
+				if (android.arch.lifecycle.ProcessLifecycleOwner.get() != null) {
+					android.arch.lifecycle.ProcessLifecycleOwner.get().getLifecycle().addObserver(lifecycleObserver);
 				}
 			} catch (Exception e) {
 				e.printStackTrace();

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/screen/ScreenManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/screen/ScreenManager.java
@@ -71,7 +71,7 @@ public class ScreenManager extends BaseSubManager {
 		super.start(listener);
 	}
 
-	private void onReady(){
+	private void onReady() {
 		// Send a DEFAULT SetDisplayLayout
 		// This is necessary due to a Ford Sync 3 bug. Sync 3 sends wrong supported text fields info in DisplayCapability in the RegisterAppInterfaceResponse
 		// Sending SetDisplayLayout will allow the SystemCapabilityManager to get the correct supported text fields from DisplayCapability in SetDisplayLayoutResponse
@@ -95,6 +95,7 @@ public class ScreenManager extends BaseSubManager {
 		internalInterface.sendRPCRequest(setDisplayLayoutRequest);
 
 	}
+
 	private void initialize(){
 		if (fileManager.get() != null) {
 			this.softButtonManager = new SoftButtonManager(internalInterface, fileManager.get());

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/screen/ScreenManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/screen/ScreenManager.java
@@ -41,7 +41,7 @@ public class ScreenManager extends BaseSubManager {
 		}
 	};
 
-	private void checkState() {
+	void checkState() {
 		if (softButtonManager != null && textAndGraphicManager != null) {
 			if (softButtonManager.getState() == BaseSubManager.READY && textAndGraphicManager.getState() == BaseSubManager.READY && setDisplayLayoutSuccess != null && setDisplayLayoutSuccess) {
 				DebugTool.logInfo("Starting screen manager, all sub managers are in ready state");
@@ -120,6 +120,14 @@ public class ScreenManager extends BaseSubManager {
 		softButtonManager.dispose();
 		textAndGraphicManager.dispose();
 		super.dispose();
+	}
+
+	SoftButtonManager getSoftButtonManager(){
+		return this.softButtonManager;
+	}
+
+	TextAndGraphicManager getTextAndGraphicManager(){
+		return this.textAndGraphicManager;
 	}
 
 	/**

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -90,6 +90,7 @@ import com.smartdevicelink.trace.enums.InterfaceActivityDirection;
 import com.smartdevicelink.transport.BaseTransportConfig;
 import com.smartdevicelink.transport.MultiplexTransportConfig;
 import com.smartdevicelink.transport.SiphonServer;
+import com.smartdevicelink.transport.USBTransportConfig;
 import com.smartdevicelink.transport.enums.TransportType;
 import com.smartdevicelink.util.CorrelationIdGenerator;
 import com.smartdevicelink.util.DebugTool;
@@ -111,6 +112,8 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Vector;
@@ -1471,6 +1474,24 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		_systemCapabilityManager = new SystemCapabilityManager(_internalInterface);
 		// Setup SdlConnection
 		synchronized(CONNECTION_REFERENCE_LOCK) {
+
+			//Handle legacy USB connections
+			if(_transportConfig != null
+					&& TransportType.USB.equals(_transportConfig.getTransportType())){
+				//A USB transport config was provided
+				USBTransportConfig usbTransportConfig = (USBTransportConfig)_transportConfig;
+				if(usbTransportConfig.getUsbAccessory() == null){
+					DebugTool.logInfo("Legacy USB transport config was used, but received null for accessory. Attempting to connect with router service");
+					//The accessory was null which means it came from a router service
+					MultiplexTransportConfig multiplexTransportConfig = new MultiplexTransportConfig(usbTransportConfig.getUSBContext(),_appID);
+					multiplexTransportConfig.setRequiresHighBandwidth(true);
+					multiplexTransportConfig.setSecurityLevel(MultiplexTransportConfig.FLAG_MULTI_SECURITY_OFF);
+					multiplexTransportConfig.setPrimaryTransports(Collections.singletonList(TransportType.USB));
+					multiplexTransportConfig.setSecondaryTransports(new ArrayList<TransportType>());
+					_transportConfig = multiplexTransportConfig;
+				}
+			}
+
 			if(_transportConfig.getTransportType().equals(TransportType.MULTIPLEX)){
 				this.sdlSession = new SdlSession2(_interfaceBroker,(MultiplexTransportConfig)_transportConfig);
 			}else{

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/AddSubMenu.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/AddSubMenu.java
@@ -56,7 +56,7 @@ import java.util.Hashtable;
  * 			<td>Image to be be shown along with the submenu item</td>
  *                 <td>N</td>
  * 			<td></td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  *  </table>
  *  <b>Response</b>

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/DisplayCapabilities.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/DisplayCapabilities.java
@@ -37,7 +37,7 @@ import static com.smartdevicelink.proxy.constants.Names.displayType;
  * 			<td>String</td>
  * 			<td>The name of the display
  *			</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * 		<tr>
  * 			<td>textField</td>

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/GetVehicleData.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/GetVehicleData.java
@@ -176,7 +176,7 @@ import static com.smartdevicelink.proxy.rpc.CreateInteractionChoiceSet.KEY_CHOIC
  * 			<td>The estimated percentage of remaining oil life of the engine</td>
  *                 <td>N</td>
  *                 <td>Subscribable</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * 		<tr>
  * 			<td>accPedalPosition</td>
@@ -200,7 +200,7 @@ import static com.smartdevicelink.proxy.rpc.CreateInteractionChoiceSet.KEY_CHOIC
  * 			<td>@see TurnSignal</td>
  * 			<td>N</td>
  * 			<td>Subscribable</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  *  </table>
  *  

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/OnHMIStatus.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/OnHMIStatus.java
@@ -57,7 +57,7 @@ import java.util.Hashtable;
  * <td>videoStreamingState</td>
  * <td>{@linkplain VideoStreamingState}</td>
  * <td>If it is NOT_STREAMABLE, the app must stop streaming video to SDL Core(stop service).</td>
- * <td>SmartDeviceLink 4.6</td>
+ * <td>SmartDeviceLink 5.0</td>
  * </tr>
  * <tr>
  * <td>systemContext</td>

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/OnSystemRequest.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/OnSystemRequest.java
@@ -44,7 +44,7 @@ import java.util.List;
  * 			<td>This parameter is filled for supporting OEM proprietary data exchanges.</td>
  *                 <td>N</td>
  *                 <td>Max Length: 255</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * 		<tr>
  * 			<td>url</td>

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/OnVehicleData.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/OnVehicleData.java
@@ -230,7 +230,7 @@ import static com.smartdevicelink.proxy.constants.Names.timeout;
  * 			<td>The estimated percentage of remaining oil life of the engine</td>
  *                 <td>N</td>
  * 			<td>minvalue:0; maxvalue:100</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * 		<tr>
  * 			<td>accPedalPosition</td>

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RGBColor.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RGBColor.java
@@ -19,24 +19,24 @@ import java.util.Hashtable;
  * 			<td>Integer</td>
  * 			<td>Y</td>
  * 			<td><ul><li>minvalue="0"</li><li>maxvalue="255"</li></ul></td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * 		<tr>
  * 			<td>green</td>
  * 			<td>Integer</td>
  * 			<td>Y</td>
  * 			<td><ul><li>minvalue="0"</li><li>maxvalue="255"</li></ul></td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * 		<tr>
  * 			<td>blue</td>
  * 			<td>Integer</td>
  * 			<td>Y</td>
  * 			<td><ul><li>minvalue="0"</li><li>maxvalue="255"</li></ul></td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * </table>
- * @since SmartDeviceLink 4.6
+ * @since SmartDeviceLink 5.0
  */
 public class RGBColor extends RPCStruct{
     public static final String KEY_RED = "red";

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterface.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterface.java
@@ -189,7 +189,7 @@ import java.util.List;
  * 			<td>ID used to validate app with policy table entries</td>
  *                 <td>N</td>
  *                 <td>Maxlength: 100</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * 		<tr>
  * 			<td>hmiCapabilities</td>
@@ -224,7 +224,7 @@ import java.util.List;
  * 			<td>The color scheme that is used for day.</td>
  *                 <td>N</td>
  *                 <td></td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  *
  * 		<tr>
@@ -233,7 +233,7 @@ import java.util.List;
  * 			<td>The color scheme that is used for night.</td>
  *                 <td>N</td>
  *                 <td></td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  *  </table>
  *  <p></p>
@@ -619,7 +619,7 @@ public class RegisterAppInterface extends RPCRequest {
 	 *
 	 * @return String - a String value representing the unique ID, which an app
 	 *         will be given when approved
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	public String getFullAppID() {
 		return getString(KEY_FULL_APP_ID);
@@ -633,7 +633,7 @@ public class RegisterAppInterface extends RPCRequest {
 	 *            given when approved
 	 *            <p></p>
 	 *            <b>Notes: </b>Maxlength = 100
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	public void setFullAppID(String fullAppID) {
 		if (fullAppID != null) {
@@ -666,7 +666,7 @@ public class RegisterAppInterface extends RPCRequest {
 	 *
 	 * @return TemplateColorScheme - a TemplateColorScheme object representing the colors that are used
 	 * for day color scheme
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
     public TemplateColorScheme getDayColorScheme(){
 		return (TemplateColorScheme) getObject(TemplateColorScheme.class, KEY_DAY_COLOR_SCHEME);
@@ -677,7 +677,7 @@ public class RegisterAppInterface extends RPCRequest {
 	 *
 	 * @param templateColorScheme a TemplateColorScheme object representing the colors that will be
 	 * used for day color scheme
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
     public void setDayColorScheme(TemplateColorScheme templateColorScheme){
 		setParameters(KEY_DAY_COLOR_SCHEME, templateColorScheme);
@@ -688,7 +688,7 @@ public class RegisterAppInterface extends RPCRequest {
 	 *
 	 * @return TemplateColorScheme - a TemplateColorScheme object representing the colors that are used
 	 * for night color scheme
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	public TemplateColorScheme getNightColorScheme(){
 		return (TemplateColorScheme) getObject(TemplateColorScheme.class, KEY_NIGHT_COLOR_SCHEME);
@@ -699,7 +699,7 @@ public class RegisterAppInterface extends RPCRequest {
 	 *
 	 * @param templateColorScheme a TemplateColorScheme object representing the colors that will be
 	 * used for night color scheme
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	public void setNightColorScheme(TemplateColorScheme templateColorScheme){
 		setParameters(KEY_NIGHT_COLOR_SCHEME, templateColorScheme);

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SetDisplayLayout.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SetDisplayLayout.java
@@ -36,7 +36,7 @@ import java.util.Hashtable;
  * 			<td>The color scheme that is used for day.</td>
  *                 <td>N</td>
  *                 <td></td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  *
  * 		<tr>
@@ -45,7 +45,7 @@ import java.util.Hashtable;
  * 			<td>The color scheme that is used for night.</td>
  *                 <td>N</td>
  *                 <td></td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  *
  *  </table>
@@ -119,7 +119,7 @@ public class SetDisplayLayout extends RPCRequest {
 	 *
 	 * @return TemplateColorScheme - a TemplateColorScheme object representing the colors that are used
 	 * for day color scheme
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	public TemplateColorScheme getDayColorScheme(){
 		return (TemplateColorScheme) getObject(TemplateColorScheme.class, KEY_DAY_COLOR_SCHEME);
@@ -130,7 +130,7 @@ public class SetDisplayLayout extends RPCRequest {
 	 *
 	 * @param templateColorScheme a TemplateColorScheme object representing the colors that will be
 	 * used for day color scheme
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	public void setDayColorScheme(TemplateColorScheme templateColorScheme){
 		setParameters(KEY_DAY_COLOR_SCHEME, templateColorScheme);
@@ -141,7 +141,7 @@ public class SetDisplayLayout extends RPCRequest {
 	 *
 	 * @return TemplateColorScheme - a TemplateColorScheme object representing the colors that are used
 	 * for night color scheme
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	public TemplateColorScheme getNightColorScheme(){
 		return (TemplateColorScheme) getObject(TemplateColorScheme.class, KEY_NIGHT_COLOR_SCHEME);
@@ -152,7 +152,7 @@ public class SetDisplayLayout extends RPCRequest {
 	 *
 	 * @param templateColorScheme a TemplateColorScheme object representing the colors that will be
 	 * used for night color scheme
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	public void setNightColorScheme(TemplateColorScheme templateColorScheme){
 		setParameters(KEY_NIGHT_COLOR_SCHEME, templateColorScheme);

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SetMediaClockTimer.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SetMediaClockTimer.java
@@ -60,7 +60,7 @@ import java.util.Hashtable;
  * 			<td></td>
  *                 <td>N</td>
  * 			<td></td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  *
  *  </table>

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SingleTireStatus.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SingleTireStatus.java
@@ -32,13 +32,13 @@ import java.util.Hashtable;
  * 			<td>The status of TPMS according to the particular tire.
  * 					See {@linkplain com.smartdevicelink.proxy.rpc.enums.TPMS}
  * 			</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * 		<tr>
  * 			<td>pressure</td>
  * 			<td>Float</td>
  * 			<td>The pressure value of the particular tire in kilo pascal.</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  *  </table>
  * @since SmartDeviceLink 2.0

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SubscribeVehicleData.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SubscribeVehicleData.java
@@ -168,7 +168,7 @@ import java.util.Hashtable;
  * 			<td>The estimated percentage of remaining oil life of the engine</td>
  *                 <td>N</td>
  *                 <td>Subscribable</td>
- * 			<td>SmartDeviceLink 4.6 </td>
+ * 			<td>SmartDeviceLink 5.0 </td>
  * 		</tr>
  * 		<tr>
  * 			<td>accPedalPosition</td>
@@ -232,7 +232,7 @@ import java.util.Hashtable;
  * 			<td>@see TurnSignal</td>
  *				<td>N</td>
  *				<td>Subscribable</td>
- * 			<td>SmartDeviceLink 4.6 </td>
+ * 			<td>SmartDeviceLink 5.0 </td>
  * 		</tr>
  *  </table>
  *  

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SystemRequest.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SystemRequest.java
@@ -35,7 +35,7 @@ import java.util.List;
  * 			<td>This parameter is filled for supporting OEM proprietary data exchanges.</td>
  *                 <td>N</td>
  *                 <td>Max Length: 255</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * 		<tr>
  * 			<td>fileName</td>

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/TemplateColorScheme.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/TemplateColorScheme.java
@@ -19,24 +19,24 @@ import java.util.Hashtable;
  * 			<td>RGBColor</td>
  * 			<td>The primary "accent" color</td>
  * 			<td>N</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * 		<tr>
  * 			<td>secondaryColor</td>
  * 			<td>RGBColor</td>
  * 			<td>The secondary "accent" color</td>
  * 			<td>N</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * 		<tr>
  * 			<td>backgroundColor</td>
  * 			<td>RGBColor</td>
  * 			<td>The color of the background</td>
  * 			<td>N</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * </table>
- * @since SmartDeviceLink 4.6
+ * @since SmartDeviceLink 5.0
  */
 public class TemplateColorScheme extends RPCStruct {
 

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/UnsubscribeVehicleData.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/UnsubscribeVehicleData.java
@@ -163,7 +163,7 @@ import com.smartdevicelink.proxy.RPCRequest;
  * 			<td>The estimated percentage of remaining oil life of the engine</td>
  *                 <td>N</td>
  *                 <td>Subscribable</td>
- * 			<td>SmartDeviceLink 4.6 </td>
+ * 			<td>SmartDeviceLink 5.0 </td>
  * 		</tr>
  * 		<tr>
  * 			<td>accPedalPosition</td>
@@ -227,7 +227,7 @@ import com.smartdevicelink.proxy.RPCRequest;
  * 			<td>@see TurnSignal</td>
  *				<td>N</td>
  *				<td>Subscribable</td>
- * 			<td>SmartDeviceLink 4.6 </td>
+ * 			<td>SmartDeviceLink 5.0 </td>
  * 		</tr>
  *  </table>
  * <p><b> Response</b></p>

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/VideoStreamingCapability.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/VideoStreamingCapability.java
@@ -26,10 +26,22 @@ public class VideoStreamingCapability extends RPCStruct {
 		return (ImageResolution) getObject(ImageResolution.class, KEY_PREFERRED_RESOLUTION);
 	}
 
+	/**
+	 * Set the max bitrate supported by this module.
+	 *
+	 * <b>NOTE: </b> Unit is in kbps.
+	 * @param maxBitrate in kbps
+	 */
 	public void setMaxBitrate(Integer maxBitrate){
 		setValue(KEY_MAX_BITRATE, maxBitrate);
 	}
 
+	/**
+	 * Retrieves the max bitrate supported by this module.
+	 *
+	 * <b>NOTE: </b> Unit is in kbps.
+	 * @return max bitrate in kbps
+	 */
 	public Integer getMaxBitrate(){
 		return getInteger(KEY_MAX_BITRATE);
 	}

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/AudioStreamingIndicator.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/AudioStreamingIndicator.java
@@ -3,32 +3,32 @@ package com.smartdevicelink.proxy.rpc.enums;
 /**
  * Identifies the playback status of a media app
  *
- * @since SmartDeviceLink 4.6
+ * @since SmartDeviceLink 5.0
  */
 public enum AudioStreamingIndicator {
 	/**
 	 * Default playback indicator.
 	 *
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	PLAY_PAUSE,
 
 	/**
 	 * Indicates that a button press of the Play/Pause button would start the playback.
 	 *
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	PLAY,
 	/**
 	 * Indicates that a button press of the Play/Pause button would pause the current playback.
 	 *
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	PAUSE,
 	/**
 	 * Indicates that a button press of the Play/Pause button would stop the current playback.
 	 *
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	STOP,
 	;

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/ImageFieldName.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/ImageFieldName.java
@@ -69,7 +69,7 @@ public enum ImageFieldName {
 	/**
 	 * The secondary graphic image field
 	 *
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	secondaryGraphic,
 	;

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/RequestType.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/RequestType.java
@@ -69,7 +69,7 @@ public enum RequestType {
      */
     FOTA,
     /**
-     * @since SmartDeviceLink 4.6
+     * @since SmartDeviceLink 5.0
      */
     OEM_SPECIFIC,
 	;

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/TPMS.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/TPMS.java
@@ -3,7 +3,7 @@ package com.smartdevicelink.proxy.rpc.enums;
 /**
  * Enums for Tire Pressure Monitoring Systems
  *
- * @since SmartDeviceLink 4.6
+ * @since SmartDeviceLink 5.0
  */
 public enum TPMS {
 

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/TurnSignal.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/TurnSignal.java
@@ -3,7 +3,7 @@ package com.smartdevicelink.proxy.rpc.enums;
 /**
  * Enumeration that describes the status of the turn light indicator.
  *
- * @since SmartDeviceLink 4.6
+ * @since SmartDeviceLink 5.0
  */
 public enum TurnSignal {
 

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/VideoStreamingState.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/VideoStreamingState.java
@@ -2,15 +2,15 @@ package com.smartdevicelink.proxy.rpc.enums;
 
 /**
  * Enumeration that describes possible states of video streaming.
- * @since SmartDeviceLink 4.6
+ * @since SmartDeviceLink 5.0
  */
 public enum VideoStreamingState {
 	/**
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	STREAMABLE,
 	/**
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	NOT_STREAMABLE;
     public static VideoStreamingState valueForString(String value) {

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexTransportConfig.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexTransportConfig.java
@@ -157,6 +157,13 @@ public class MultiplexTransportConfig extends BaseTransportConfig{
 	 * Set whether or not this app requires the use of a transport that supports high bandwidth
 	 * services. Common use is when an app uses the video/audio streaming services and there is no
 	 * other integration that could be useful to the user.
+	 * <br><br> <b>For example:</b>
+	 * <br><b>1. </b>If an app intends to perform audio or video streaming and does not wish
+	 * to appear on the module when that isn't possible, a value of true should be sent.
+	 * <br><b>2. </b>If the same app wishes to appear on the module even when those services aren't available
+	 * a value of true should be sent. In this case, the app could display a message prompting the
+	 * user to "Please connect USB or Wifi" or it could have a separate integration like giving turn
+	 * by turn directions in place of streaming the full navigation map.
 	 * @param requiresHighBandwidth whether the app should be treated as requiring a high
 	 *                                 bandwidth transport.
 	 */
@@ -242,13 +249,13 @@ public class MultiplexTransportConfig extends BaseTransportConfig{
 		 * @param connectedTransports the currently connected transports
 		 * @param audioStreamTransportAvail true if there is either an audio streaming supported
 		 *                                        transport currently connected or a transport is
-		 *                                        available to connect with. false if there is no
+		 *                                        available to connect with. False if there is no
 		 *                                        transport connected to support audio streaming and
 		 *                                        no possibility in the foreseeable future.
-		 * @param videoStreamTransportAvail true if there is either an audio streaming supported
+		 * @param videoStreamTransportAvail true if there is either a video streaming supported
 		 *                                        transport currently connected or a transport is
-		 *                                        available to connect with. false if there is no
-		 *                                        transport connected to support audio streaming and
+		 *                                        available to connect with. False if there is no
+		 *                                        transport connected to support video streaming and
 		 *                                        no possibility in the foreseeable future.
 		 */
 		void onTransportEvent(List<TransportRecord> connectedTransports, boolean audioStreamTransportAvail,boolean videoStreamTransportAvail);

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/RouterServiceValidator.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/RouterServiceValidator.java
@@ -23,6 +23,7 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.ResolveInfo;
 import android.content.pm.ServiceInfo;
 import android.os.Build;
+import android.support.annotation.NonNull;
 import android.util.Log;
 
 import com.smartdevicelink.util.AndroidTools;
@@ -99,6 +100,14 @@ public class RouterServiceValidator {
 		inDebugMode = inDebugMode();
 		this.service = service;
 	}
+
+	public RouterServiceValidator(@NonNull MultiplexTransportConfig config){
+		this.context = config.context;
+		this.service = config.service;
+		setSecurityLevel(config.securityLevel);
+		inDebugMode = inDebugMode();
+	}
+	
 	/**
 	 * Main function to call to ensure we are connecting to a validated router service
 	 * @return whether or not the currently running router service can be trusted.

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -44,11 +44,14 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.hardware.usb.UsbManager;
 import android.os.Build;
+import android.os.Parcelable;
 import android.util.Log;
 
 import com.smartdevicelink.R;
 import com.smartdevicelink.transport.RouterServiceValidator.TrustedListCallback;
+import com.smartdevicelink.transport.enums.TransportType;
 import com.smartdevicelink.util.AndroidTools;
 import com.smartdevicelink.util.SdlAppInfo;
 import com.smartdevicelink.util.ServiceFinder;
@@ -164,6 +167,12 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 								//List obtained. Let's start our service
 								queuedService = componentName;
 								finalIntent.setAction("com.sdl.noaction"); //Replace what's there so we do go into some unintended loop
+								String  transportType = finalIntent.getStringExtra(TransportConstants.START_ROUTER_SERVICE_TRANSPORT_CONNECTED);
+								if(transportType!= null ){
+									if(TransportType.USB.toString().equals(transportType)){
+										finalIntent.putExtra(UsbManager.EXTRA_ACCESSORY, (Parcelable)null);
+									}
+								}
 								onSdlEnabled(finalContext, finalIntent);
 							}
 							

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1593,6 +1593,11 @@ public class SdlRouterService extends Service{
 		startService.putExtra(TransportConstants.FORCE_TRANSPORT_CONNECTED, true);
 		startService.putExtra(TransportConstants.START_ROUTER_SERVICE_SDL_ENABLED_APP_PACKAGE, getBaseContext().getPackageName());
 		startService.putExtra(TransportConstants.START_ROUTER_SERVICE_SDL_ENABLED_CMP_NAME, new ComponentName(this, this.getClass()));
+
+		if(record!= null && record.getType() != null){
+			startService.putExtra(TransportConstants.START_ROUTER_SERVICE_TRANSPORT_CONNECTED, record.getType().toString());
+		}
+
 		if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
 			startService.addFlags(Intent.FLAG_RECEIVER_FOREGROUND);
 		}

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/TransportConstants.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/TransportConstants.java
@@ -27,6 +27,7 @@ public class TransportConstants {
 	public static final String START_ROUTER_SERVICE_SDL_ENABLED_EXTRA		= "sdl_enabled";
 	public static final String START_ROUTER_SERVICE_SDL_ENABLED_APP_PACKAGE = "package_name";
 	public static final String START_ROUTER_SERVICE_SDL_ENABLED_CMP_NAME    = "component_name";
+	public static final String START_ROUTER_SERVICE_TRANSPORT_CONNECTED   	= "transport_connected"; //Extra for the transport that just connected
 	public static final String START_ROUTER_SERVICE_SDL_ENABLED_PING		= "ping";
 	@Deprecated
 	public static final String FORCE_TRANSPORT_CONNECTED					= "force_connect"; //This is legacy, do not refactor this. 

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/TransportManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/TransportManager.java
@@ -82,7 +82,7 @@ public class TransportManager {
             config.service = SdlBroadcastReceiver.consumeQueuedRouterService();
         }
 
-        RouterServiceValidator validator = new RouterServiceValidator(config.context,config.service);
+        RouterServiceValidator validator = new RouterServiceValidator(config);
         if(validator.validate()){
             transport = new TransportBrokerImpl(config.context, config.appId,config.service);
         }else{

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/USBTransportConfig.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/USBTransportConfig.java
@@ -5,28 +5,78 @@ import com.smartdevicelink.transport.enums.TransportType;
 import android.content.Context;
 import android.hardware.usb.UsbAccessory;
 
+/**
+ * <b>NOTE: </b> This should no longer be used. See the MultplexTransportConfig and guides to
+ * understand how to implement USB multiplexing. This class and method of USB connection will be
+ * removed in the next major release. If a router service is available to handle multiplexing of the
+ * usb transport it will be used, and this app will connect to whatever router service hosts the USB
+ * connection.
+ * @see MultiplexTransportConfig
+ */
 @Deprecated
 public class USBTransportConfig extends BaseTransportConfig {
 	
 	private Context mainActivity = null;
 	private UsbAccessory usbAccessory = null;
 	private Boolean queryUsbAcc = true;
-	
+
+	/**
+	 * <b>NOTE: </b> This should no longer be used. See the MultplexTransportConfig and guides to
+	 * understand how to implement USB multiplexing. This class and method of USB connection will be
+	 * removed in the next major release. If a router service is available to handle multiplexing of the
+	 *  usb transport it will be used, and this app will connect to whatever router service hosts the USB
+	 *  connection.
+	 * @param mainActivity context used to start USB transport
+	 * @see MultiplexTransportConfig
+	 */
 	public USBTransportConfig (Context mainActivity) {
 		this.mainActivity = mainActivity;
 	}
-	
+
+	/**
+	 * <b>NOTE: </b> This should no longer be used. See the MultplexTransportConfig and guides to
+	 * understand how to implement USB multiplexing. This class and method of USB connection will be
+	 * removed in the next major release. If a router service is available to handle multiplexing of the
+	 * usb transport it will be used, and this app will connect to whatever router service hosts the USB
+	 * connection.
+	 * @param mainActivity context used to start USB transport
+	 * @param usbAccessory the accessory that was given to this app
+	 * @see MultiplexTransportConfig
+	 */
 	public USBTransportConfig (Context mainActivity, UsbAccessory usbAccessory) {
 		this.mainActivity = mainActivity;
 		this.usbAccessory = usbAccessory;
 	}
-	
+
+	/**
+	 * <b>NOTE: </b> This should no longer be used. See the MultplexTransportConfig and guides to
+	 * understand how to implement USB multiplexing. This class and method of USB connection will be
+	 * removed in the next major release. If a router service is available to handle multiplexing of the
+	 * usb transport it will be used, and this app will connect to whatever router service hosts the USB
+	 * connection.
+	 * @param mainActivity context used to start USB transport
+	 * @param shareConnection enable other sessions on this app to use this USB connection
+	 * @param queryUsbAcc attempt to query the USB accessory if none is provided
+	 * @see MultiplexTransportConfig
+	 */
 	public USBTransportConfig (Context mainActivity, boolean shareConnection, boolean queryUsbAcc) {
 		this.mainActivity = mainActivity;
 		this.queryUsbAcc = queryUsbAcc;
 		super.shareConnection = shareConnection;
 	}
-	
+
+	/**
+	 * <b>NOTE: </b> This should no longer be used. See the MultplexTransportConfig and guides to
+	 * understand how to implement USB multiplexing. This class and method of USB connection will be
+	 * removed in the next major release. If a router service is available to handle multiplexing of the
+	 * usb transport it will be used, and this app will connect to whatever router service hosts the USB
+	 * connection.
+	 * @param mainActivity context used to start USB transport
+	 * @param usbAccessory the accessory that was given to this app
+	 * @param shareConnection enable other sessions on this app to use this USB connection
+	 * @param queryUsbAcc attempt to query the USB accessory if none is provided
+	 * @see MultiplexTransportConfig
+	 */
 	public USBTransportConfig (Context mainActivity, UsbAccessory usbAccessory, boolean shareConnection, boolean queryUsbAcc) {
 		this.mainActivity = mainActivity;
 		this.queryUsbAcc = queryUsbAcc;

--- a/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
@@ -126,8 +126,8 @@ public class AndroidTools {
 	 * Sends the provided intent to the specified destinations making it an explicit intent, rather
 	 * than an implicit intent. A direct replacement of sendBroadcast(Intent). As of Android 8.0
 	 * (API 26+) implicit broadcasts are no longer sent to broadcast receivers that are declared via
-	 * the AndroidManifest. Ihe method will also send the broadcast implicitly if no list of apps is
-	 * provided for backwards comparability.
+	 * the AndroidManifest. If no apps are found to receive the intent, this method will send the
+	 * broadcast implicitly if no list of apps is provided.
 	 *
 	 * @param intent - the intent to send explicitly
 	 * @param apps - the list of apps that this broadcast will be sent to. If null is passed in


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan

- Make sure that no `SetDisplayLayout` is sent in the app
- Set app type to `DEFAULT`
- Set 4 text fields using `ScreenManager`
- Make sure that text field 4 is displayed on TDK


### Summary
This PR fixes an issue in Sync 3. Which sends wrong supported text fields info in display capability in the `RegisterAppInterfaceResponse`. So this PR Sends `SetDisplayLayout` internally to allow the SystemCapabilityManager to get the correct supported text fields from display capability in `SetDisplayLayoutResponse`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)