### PR TITLE
Fix: TCP secondary transport isn't set up as soon as it's available

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlProtocol.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlProtocol.java
@@ -1379,6 +1379,25 @@ public class SdlProtocol {
                     bundle.putString(TransportConstants.TRANSPORT_TYPE, TransportType.TCP.name());
                     secondaryTransportParams.put(TransportType.TCP, bundle);
 
+                    DebugTool.logInfo("Initiating TCP secondary transport after receiving IP address and port number");
+
+                    // add a dummy listener so that secondary transport registration is initiated
+                    // in onTransportsConnectedUpdate() once the connection sets up
+                    List<ISecondaryTransportListener> listenerList = secondaryTransportListeners.get(TransportType.TCP);
+                    if(listenerList == null){
+                        listenerList = new ArrayList<>();
+                        secondaryTransportListeners.put(TransportType.TCP, listenerList);
+                    }
+
+                    listenerList.add(new ISecondaryTransportListener() {
+                        @Override
+                        public void onConnectionSuccess(TransportRecord transportRecord) {}
+                        @Override
+                        public void onConnectionFailure() {}
+                    });
+
+                    transportManager.requestSecondaryTransportConnection((byte)-1, bundle);
+
                     //A new secondary transport just became available. Notify the developer.
                     notifyDevTransportListener();
                 }


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_android/issues/919

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes. However, it will impact the sequence to open TCP secondary transport, which should be stated as a risk.

### Testing Plan
- Repeat the reproduction steps mentioned in https://github.com/smartdevicelink/sdl_android/issues/919 and verify that secondary transport is registered prior to the app starting NAV or PCM service.
- A unit test to cover the new sequence is added.

### Summary
This PR adds a trigger to initiate TCP secondary transport set up after receiving a _TransportEventUpdate_ control frame with valid IP address and port number.

### Changelog
##### Breaking Changes
* None

##### Enhancements
* None

##### Bug Fixes
* Fix the issue where TCP secondary transport isn't set up as soon as it's available

### Tasks Remaining:
- None

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)