### PR TITLE
Bugfix/issue 941 Fix issue for automatic addition of VR commands for all choice sets

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -20,6 +20,7 @@ import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.protocol.enums.SessionType;
 import com.smartdevicelink.proxy.RPCMessage;
 import com.smartdevicelink.proxy.RPCRequest;
+import com.smartdevicelink.proxy.SDLCheckChoiceVROptionalOperation;
 import com.smartdevicelink.proxy.SdlProxyBase;
 import com.smartdevicelink.proxy.SystemCapabilityManager;
 import com.smartdevicelink.proxy.callbacks.OnServiceEnded;
@@ -29,6 +30,7 @@ import com.smartdevicelink.proxy.interfaces.ISdl;
 import com.smartdevicelink.proxy.interfaces.ISdlServiceListener;
 import com.smartdevicelink.proxy.interfaces.IVideoStreamListener;
 import com.smartdevicelink.proxy.interfaces.OnSystemCapabilityListener;
+import com.smartdevicelink.proxy.rpc.Choice;
 import com.smartdevicelink.proxy.rpc.RegisterAppInterfaceResponse;
 import com.smartdevicelink.proxy.rpc.SdlMsgVersion;
 import com.smartdevicelink.proxy.rpc.SetAppIcon;
@@ -228,6 +230,10 @@ public class SdlManager{
 			this.lockScreenManager.start(subManagerListener);
 		}
 		this.screenManager.start(subManagerListener);
+
+		//check optional VR
+		SDLCheckChoiceVROptionalOperation choiceOptionalVRCheck = SDLCheckChoiceVROptionalOperation.getInstance();
+		choiceOptionalVRCheck.SetRPCInterface(_internalInterface,permissionManager);
 	}
 
 	/**

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -30,7 +30,6 @@ import com.smartdevicelink.proxy.interfaces.ISdl;
 import com.smartdevicelink.proxy.interfaces.ISdlServiceListener;
 import com.smartdevicelink.proxy.interfaces.IVideoStreamListener;
 import com.smartdevicelink.proxy.interfaces.OnSystemCapabilityListener;
-import com.smartdevicelink.proxy.rpc.Choice;
 import com.smartdevicelink.proxy.rpc.RegisterAppInterfaceResponse;
 import com.smartdevicelink.proxy.rpc.SdlMsgVersion;
 import com.smartdevicelink.proxy.rpc.SetAppIcon;

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SDLCheckChoiceVROptionalOperation.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SDLCheckChoiceVROptionalOperation.java
@@ -1,0 +1,126 @@
+package com.smartdevicelink.proxy;
+
+import android.util.Log;
+
+import com.smartdevicelink.managers.permission.OnPermissionChangeListener;
+import com.smartdevicelink.managers.permission.PermissionManager;
+import com.smartdevicelink.protocol.enums.FunctionID;
+import com.smartdevicelink.proxy.interfaces.ISdl;
+import com.smartdevicelink.proxy.rpc.Choice;
+import com.smartdevicelink.proxy.rpc.CreateInteractionChoiceSet;
+import com.smartdevicelink.proxy.rpc.OnPermissionsChange;
+import com.smartdevicelink.proxy.rpc.enums.Result;
+import com.smartdevicelink.proxy.rpc.listeners.OnRPCNotificationListener;
+import com.smartdevicelink.proxy.rpc.listeners.OnRPCResponseListener;
+
+import java.util.ArrayList;
+
+public class SDLCheckChoiceVROptionalOperation {
+
+    private final static String TAG = "CheckChoiceVROptional";
+
+    public final int VR_TEST_CHOICE_ID = 0;
+
+    //Choice VR test states
+    private final int VR_CMD_TEST_ONGOING_STATE = -2;
+    private final int VR_CMD_UNKNOWN_STATE = -1;
+    private final int VR_CMD_REQUIRED_STATE = 1;
+    private final int VR_CMD_NOT_REQUIRED_STATE = 0;
+
+    //test result variables
+    private int isVRCommandCheckExecuted = VR_CMD_UNKNOWN_STATE;
+    private final Object vr_test_lock = new Object();
+
+    //interface to send RPC
+    private ISdl mISDL = null;
+    private PermissionManager mPermissionManager = null;
+
+    private static final SDLCheckChoiceVROptionalOperation instance = new SDLCheckChoiceVROptionalOperation();
+
+    public static SDLCheckChoiceVROptionalOperation getInstance() {
+        return instance;
+    }
+
+    private SDLCheckChoiceVROptionalOperation() {
+    }
+
+    private void performVRCommandCheckForChoices(){
+
+        if(null == mISDL ){
+            return;
+        }
+        synchronized (vr_test_lock) {
+            if (VR_CMD_UNKNOWN_STATE == isVRCommandCheckExecuted) {
+                isVRCommandCheckExecuted = VR_CMD_TEST_ONGOING_STATE;
+                Choice choice = new Choice();
+                choice.setChoiceID(VR_TEST_CHOICE_ID);
+                choice.setMenuName("Test "+TAG);
+                ArrayList<Choice> list = new ArrayList<>();
+                list.add(choice);
+
+                CreateInteractionChoiceSet choiceSet = new CreateInteractionChoiceSet();
+                choiceSet.setChoiceSet(list);
+                choiceSet.setInteractionChoiceSetID(VR_TEST_CHOICE_ID);
+
+                choiceSet.setOnRPCResponseListener(new OnRPCResponseListener() {
+                    @Override
+                    public void onResponse(int correlationId, RPCResponse response) {
+                        if (response.getSuccess()) {
+                            Log.i(TAG, "ChoiceSet does not require VR ");
+                            isVRCommandCheckExecuted = VR_CMD_NOT_REQUIRED_STATE;
+                        } else {
+                            Log.i(TAG, "ChoiceSet require VR ");
+                            isVRCommandCheckExecuted = VR_CMD_REQUIRED_STATE;
+                        }
+                    }
+
+                    @Override
+                    public void onError(int correlationId, Result resultCode, String info) {
+                        isVRCommandCheckExecuted = VR_CMD_REQUIRED_STATE;
+                    }
+                });
+                mISDL.sendRPC(choiceSet);
+            }
+        }
+    }
+
+    public void SetRPCInterface(ISdl sendRPCInterface, PermissionManager permissionManager){
+        if(null == sendRPCInterface){
+            Log.e(TAG,"SDL proxy interface null...");
+            return;
+        }
+
+        if (null == permissionManager){
+            Log.e(TAG,"permission manager is null...");
+            return;
+        }
+
+        mISDL = sendRPCInterface;
+        mPermissionManager = permissionManager;
+
+        mISDL.addOnRPCNotificationListener(FunctionID.ON_HMI_STATUS, new OnRPCNotificationListener(){
+
+            @Override
+            public void onNotified(RPCNotification notification) {
+                if(mPermissionManager.isRPCAllowed(FunctionID.CREATE_INTERACTION_CHOICE_SET) &&
+                        VR_CMD_UNKNOWN_STATE == isVRCommandCheckExecuted){
+                    performVRCommandCheckForChoices();
+                }
+            }
+        });
+    }
+
+    public boolean isChoiceVRRequired(){
+        boolean retVal = true;
+        Log.e(TAG,"choice VR optional state: "+isVRCommandCheckExecuted);
+        switch (isVRCommandCheckExecuted){
+            case VR_CMD_REQUIRED_STATE:
+                retVal = true;
+                break;
+            case VR_CMD_NOT_REQUIRED_STATE:
+                retVal = false;
+                break;
+        }
+        return retVal;
+    }
+}

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/Choice.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/Choice.java
@@ -1,7 +1,6 @@
 package com.smartdevicelink.proxy.rpc;
 
 import android.support.annotation.NonNull;
-import android.util.Log;
 
 import com.smartdevicelink.proxy.RPCStruct;
 import com.smartdevicelink.proxy.SDLCheckChoiceVROptionalOperation;
@@ -130,8 +129,6 @@ public class Choice extends RPCStruct {
             boolean check = (null == existingVrCommands || 0 == existingVrCommands.size());
             check &= (vrCheck.isChoiceVRRequired());
             check &= (vrCheck.VR_TEST_CHOICE_ID != getChoiceID());
-
-            Log.d("CheckChoiceVROptional"," value: "+check);
 
             if (check) {
                 // if no commands set, set one due to a legacy head unit requirement

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/Choice.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/Choice.java
@@ -1,8 +1,10 @@
 package com.smartdevicelink.proxy.rpc;
 
 import android.support.annotation.NonNull;
+import android.util.Log;
 
 import com.smartdevicelink.proxy.RPCStruct;
+import com.smartdevicelink.proxy.SDLCheckChoiceVROptionalOperation;
 import com.smartdevicelink.util.Version;
 
 import java.util.ArrayList;
@@ -122,10 +124,16 @@ public class Choice extends RPCStruct {
 
         if (rpcVersion == null || rpcVersion.getMajor() < 5){
 
-            // make sure there is at least one vr param
+            SDLCheckChoiceVROptionalOperation vrCheck = SDLCheckChoiceVROptionalOperation.getInstance();
             List<String> existingVrCommands = getVrCommands();
 
-            if (existingVrCommands == null || existingVrCommands.size() == 0) {
+            boolean check = (null == existingVrCommands || 0 == existingVrCommands.size());
+            check &= (vrCheck.isChoiceVRRequired());
+            check &= (vrCheck.VR_TEST_CHOICE_ID != getChoiceID());
+
+            Log.d("CheckChoiceVROptional"," value: "+check);
+
+            if (check) {
                 // if no commands set, set one due to a legacy head unit requirement
                 Integer choiceID = getChoiceID();
                 List<String> vrCommands = new ArrayList<>();


### PR DESCRIPTION

Fixes #941 Fix issue for automatic addition of VR commands for all choice sets

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Tested with Ford SYNC modules 

### Summary
Previous implementation were adding VR commands for all choice set requests, when App does not provide it. This auto addition of VR commands is extended with a check for VR commands in choice set. 

### Changelog
##### Breaking Changes
* NA

##### Enhancements
* added Java class that would check if VR commands are mandatory in choice set 

##### Bug Fixes
* #941 

### Tasks Remaining:
*NA

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
