### PR TITLE
Update SdlManager state when dispose() is called 

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/SdlManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/SdlManagerTests.java
@@ -288,6 +288,11 @@ public class SdlManagerTests extends AndroidTestCase2 {
 		sdlManager.getLockScreenManager().transitionToState(BaseSubManager.SETTING_UP);
 		sdlManager.checkState();
 		assertEquals(BaseSubManager.LIMITED, sdlManager.getState());
+
+
+		// Case 6
+		sdlManager.dispose();
+		assertEquals(BaseSubManager.SHUTDOWN, sdlManager.getState());
 	}
 
 	public void testSendRPC(){

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -287,6 +287,8 @@ public class SdlManager extends BaseSdlManager{
 			managerListener.onDestroy();
 			managerListener = null;
 		}
+
+		transitionToState(BaseSubManager.SHUTDOWN);
 	}
 
 	// MANAGER GETTERS
@@ -589,6 +591,7 @@ public class SdlManager extends BaseSdlManager{
 				initNotificationQueue();
 
 			} catch (SdlException e) {
+				transitionToState(BaseSubManager.ERROR);
 				if (managerListener != null) {
 					managerListener.onError("Unable to start manager", e);
 				}

--- a/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -242,6 +242,8 @@ public class SdlManager extends BaseSdlManager{
 			managerListener.onDestroy(this);
 			managerListener = null;
 		}
+
+		transitionToState(BaseSubManager.SHUTDOWN);
 	}
 
 


### PR DESCRIPTION
Fixes #1052 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
A test case has been added to check the state. Also, this test can be run to confirm: 

1. Connect sdl app to Core
2. Check `SdlManager` state (should be READY)
3. Disconnect from Core
4. Check `SdlManager` state (should be SHUTDOWN)

### Summary
This PR transitions the state of the `SdlManager` to `SHUTDOWN` once `SdlManager.dispose()` is called. It also transitions the manager state to `ERROR` when an error happens.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
