### PR TITLE
Handle origin modules (Rpc Version 1.0 & Protocol Version 1.0)

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -6302,8 +6302,14 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 
 		if (sdlMsgVersion == null) {
 			sdlMsgVersion = new SdlMsgVersion();
-			sdlMsgVersion.setMajorVersion(MAX_SUPPORTED_RPC_VERSION.getMajor());
-			sdlMsgVersion.setMinorVersion(MAX_SUPPORTED_RPC_VERSION.getMinor());
+			if(protocolVersion.getMajor() == 1) {
+				DebugTool.logInfo("Connected to an older module, must send 1.0.0 as RPC spec");
+				sdlMsgVersion.setMajorVersion(1);
+				sdlMsgVersion.setMinorVersion(0);
+			}else {
+				sdlMsgVersion.setMajorVersion(MAX_SUPPORTED_RPC_VERSION.getMajor());
+				sdlMsgVersion.setMinorVersion(MAX_SUPPORTED_RPC_VERSION.getMinor());
+			}
 		}
 		if (languageDesired == null) {
 			languageDesired = Language.EN_US;

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/DisplayCapabilities.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/DisplayCapabilities.java
@@ -36,6 +36,7 @@ import android.support.annotation.NonNull;
 import com.smartdevicelink.proxy.RPCStruct;
 import com.smartdevicelink.proxy.rpc.enums.DisplayType;
 import com.smartdevicelink.proxy.rpc.enums.MediaClockFormat;
+import com.smartdevicelink.util.Version;
 
 import java.util.Hashtable;
 import java.util.List;
@@ -142,6 +143,17 @@ public class DisplayCapabilities extends RPCStruct {
         setMediaClockFormats(mediaClockFormats);
         setGraphicSupported(graphicSupported);
     }
+
+    @Override
+    public void format(Version rpcVersion, boolean formatParams) {
+        super.format(rpcVersion, formatParams);
+        if(!store.containsKey(KEY_GRAPHIC_SUPPORTED)){
+            // At some point this was added to the RPC spec as mandatory but at least in v1.0.0
+            // it was not included.
+            store.put(KEY_GRAPHIC_SUPPORTED, new Boolean(false));
+        }
+    }
+
     /**
      * Get the type of display
      * @return the type of display

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/SoftButtonCapabilities.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/SoftButtonCapabilities.java
@@ -34,6 +34,7 @@ package com.smartdevicelink.proxy.rpc;
 import android.support.annotation.NonNull;
 
 import com.smartdevicelink.proxy.RPCStruct;
+import com.smartdevicelink.util.Version;
 
 import java.util.Hashtable;
 
@@ -114,7 +115,17 @@ public class SoftButtonCapabilities extends RPCStruct {
 		setUpDownAvailable(upDownAvailable);
 		setImageSupported(imageSupported);
 	}
-    
+
+    @Override
+    public void format(Version rpcVersion, boolean formatParams) {
+        super.format(rpcVersion, formatParams);
+        if(!store.containsKey(KEY_IMAGE_SUPPORTED)){
+            // At some point this was added to the RPC spec as mandatory but at least in v1.0.0
+            // it was not included.
+            store.put(KEY_IMAGE_SUPPORTED, new Boolean(false));
+        }
+    }
+
     /**
      * set the button supports a short press.
      * @param shortPressAvailable whether the button supports a short press.


### PR DESCRIPTION
Fixes #1051 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
 * See Bug Fixes

### Changelog

##### Bug Fixes
* Fixed issue in TransportManager that had unreachable code by overriding the previous method of receiving Legacy mode notifications
* Fix issue where the RAI was being sent with max version of RPC sepc the lib could handle, but modules will only accept 1.0.0
* Added format method calls to two RPCs that have mandatory parameters but v1.0 of the RPC spec didn't have the params


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
