### PR TITLE
Fix Pressure Tell Tale

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/TireStatusTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/TireStatusTest.java
@@ -14,7 +14,7 @@ import org.json.JSONObject;
 
 /**
  * This is a unit test class for the SmartDeviceLink library project class : 
- * {@link com.smartdevicelink.rpc.TireStatus}
+ * {@link com.smartdevicelink.proxy.rpc.TireStatus}
  */
 public class TireStatusTest extends TestCase {
 	

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/TireStatus.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/TireStatus.java
@@ -101,7 +101,7 @@ import java.util.Hashtable;
  */
 
 public class TireStatus extends RPCStruct {
-	public static final String KEY_PRESSURE_TELL_TALE = "pressureTellTale";
+	public static final String KEY_PRESSURE_TELL_TALE = "pressureTelltale";
 	public static final String KEY_LEFT_FRONT = "leftFront";
 	public static final String KEY_RIGHT_FRONT = "rightFront";
 	public static final String KEY_LEFT_REAR = "leftRear";


### PR DESCRIPTION
Fixes #1057 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
I tested this fix with Manticore's vehicle data notifications and was able to receive the correct values

### Summary
Fix the `pressureTelltale` key in the `TireStatus` struct that was incorrect and did not match the RPC specs.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)