### PR TITLE
Close library when unable to connect to router service

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/TransportManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/TransportManager.java
@@ -94,7 +94,12 @@ public class TransportManager extends TransportManagerBase{
     @Override
     public void start(){
         if(transport != null){
-            transport.start();
+            if (!transport.start()){
+                //Unable to connect to a router service
+                if(transportListener != null){
+                    transportListener.onError("Unable to connect with the router service");
+                }
+            }
         }else if(legacyBluetoothTransport != null){
             legacyBluetoothTransport.start();
         }


### PR DESCRIPTION
Fixes #1064

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
- Added a check to ensure that the TransportBroker instance actually started correctly. If it fails, close out the transport manager. 

### Changelog

##### Bug Fixes
* Handle case with older library using AOA connection that starts up newer apps.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
