### PR TITLE
Fix issues in sendRPCs and sendSequentialRPCs

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/SdlManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/SdlManagerTests.java
@@ -344,8 +344,6 @@ public class SdlManagerTests extends AndroidTestCase2 {
 
 	private void testSendMultipleRPCs(boolean sequentialSend){
 		listenerCalledCounter = 0;
-		final List<RPCRequest> rpcsList = Arrays.asList(new GetVehicleData(), new Show());
-
 
 		// When sdlProxyBase.sendRPCRequests() is called, call listener.onFinished() to fake the response
 		final Answer<Void> answer = new Answer<Void>() {
@@ -353,10 +351,6 @@ public class SdlManagerTests extends AndroidTestCase2 {
 			public Void answer(InvocationOnMock invocation) {
 				Object[] args = invocation.getArguments();
 				OnMultipleRequestListener listener = (OnMultipleRequestListener) args[1];
-				int rpcsCount = rpcsList.size();
-				while (rpcsCount != 0) {
-					listener.onUpdate(--rpcsCount);
-				}
 				listener.onFinished();
 				return null;
 			}
@@ -374,11 +368,10 @@ public class SdlManagerTests extends AndroidTestCase2 {
 
 
 		// Test send RPC requests
+		List<RPCMessage> rpcsList = Arrays.asList(new GetVehicleData(), new Show(), new OnAppServiceData(), new GetAppServiceDataResponse());
 		OnMultipleRequestListener onMultipleRequestListener = new OnMultipleRequestListener() {
 			@Override
-			public void onUpdate(int remainingRequests) {
-				listenerCalledCounter++;
-			}
+			public void onUpdate(int remainingRequests) { }
 
 			@Override
 			public void onFinished() {
@@ -399,7 +392,7 @@ public class SdlManagerTests extends AndroidTestCase2 {
 
 
 		// Make sure the listener is called exactly once
-		assertEquals("Listener was not called or called more/less frequently than expected", listenerCalledCounter, rpcsList.size() + 1);
+		assertEquals("Listener was not called or called more/less frequently than expected", listenerCalledCounter, 1);
 	}
 
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/SdlManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/SdlManagerTests.java
@@ -344,6 +344,8 @@ public class SdlManagerTests extends AndroidTestCase2 {
 
 	private void testSendMultipleRPCs(boolean sequentialSend){
 		listenerCalledCounter = 0;
+		final List<RPCRequest> rpcsList = Arrays.asList(new GetVehicleData(), new Show());
+
 
 		// When sdlProxyBase.sendRPCRequests() is called, call listener.onFinished() to fake the response
 		final Answer<Void> answer = new Answer<Void>() {
@@ -351,6 +353,10 @@ public class SdlManagerTests extends AndroidTestCase2 {
 			public Void answer(InvocationOnMock invocation) {
 				Object[] args = invocation.getArguments();
 				OnMultipleRequestListener listener = (OnMultipleRequestListener) args[1];
+				int rpcsCount = rpcsList.size();
+				while (rpcsCount != 0) {
+					listener.onUpdate(--rpcsCount);
+				}
 				listener.onFinished();
 				return null;
 			}
@@ -368,10 +374,11 @@ public class SdlManagerTests extends AndroidTestCase2 {
 
 
 		// Test send RPC requests
-		List<RPCMessage> rpcsList = Arrays.asList(new GetVehicleData(), new Show(), new OnAppServiceData(), new GetAppServiceDataResponse());
 		OnMultipleRequestListener onMultipleRequestListener = new OnMultipleRequestListener() {
 			@Override
-			public void onUpdate(int remainingRequests) { }
+			public void onUpdate(int remainingRequests) {
+				listenerCalledCounter++;
+			}
 
 			@Override
 			public void onFinished() {
@@ -392,7 +399,7 @@ public class SdlManagerTests extends AndroidTestCase2 {
 
 
 		// Make sure the listener is called exactly once
-		assertEquals("Listener was not called or called more/less frequently than expected", listenerCalledCounter, 1);
+		assertEquals("Listener was not called or called more/less frequently than expected", listenerCalledCounter, rpcsList.size() + 1);
 	}
 
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SdlProxyBaseTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SdlProxyBaseTests.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.mock;
 public class SdlProxyBaseTests extends AndroidTestCase2 {
     public static final String TAG = "SdlProxyBaseTests";
 
-    int onUpdateListenerCounter, onFinishedListenerCounter, onResponseListenerCounter, onErrorListenerCounter;
+    int onUpdateListenerCounter, onFinishedListenerCounter, onResponseListenerCounter, onErrorListenerCounter, remainingRequestsExpected;
 
     @Override
     protected void setUp() throws Exception{
@@ -213,10 +213,12 @@ public class SdlProxyBaseTests extends AndroidTestCase2 {
 
 
         // Send RPCs
+        remainingRequestsExpected = rpcsList.size();
         OnMultipleRequestListener onMultipleRequestListener = new OnMultipleRequestListener() {
             @Override
             public void onUpdate(int remainingRequests) {
                 onUpdateListenerCounter++;
+                assertEquals(remainingRequestsExpected, remainingRequests);
             }
 
             @Override
@@ -227,11 +229,13 @@ public class SdlProxyBaseTests extends AndroidTestCase2 {
             @Override
             public void onError(int correlationId, Result resultCode, String info) {
                 onErrorListenerCounter++;
+                remainingRequestsExpected--;
             }
 
             @Override
             public void onResponse(int correlationId, RPCResponse response) {
                 onResponseListenerCounter++;
+                remainingRequestsExpected--;
             }
         };
         try {

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SdlProxyBaseTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SdlProxyBaseTests.java
@@ -148,7 +148,7 @@ public class SdlProxyBaseTests extends AndroidTestCase2 {
         testSendMultipleRPCs(false, 1);
     }
 
-    public void testSendRPCsSomeFails(){
+    public void testSendRPCsSomeFail(){
         testSendMultipleRPCs(false, 2);
     }
 
@@ -156,7 +156,7 @@ public class SdlProxyBaseTests extends AndroidTestCase2 {
         testSendMultipleRPCs(true, 1);
     }
 
-    public void testSendSequentialRPCsSomeFails(){
+    public void testSendSequentialRPCsSomeFail(){
         testSendMultipleRPCs(true, 2);
     }
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SdlProxyBaseTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SdlProxyBaseTests.java
@@ -7,106 +7,45 @@ import android.util.Log;
 import com.smartdevicelink.AndroidTestCase2;
 import com.smartdevicelink.exception.SdlException;
 import com.smartdevicelink.exception.SdlExceptionCause;
+import com.smartdevicelink.proxy.RPCMessage;
 import com.smartdevicelink.proxy.RPCRequest;
 import com.smartdevicelink.proxy.RPCResponse;
 import com.smartdevicelink.proxy.SdlProxyALM;
 import com.smartdevicelink.proxy.SdlProxyBase;
 import com.smartdevicelink.proxy.SdlProxyBuilder;
 import com.smartdevicelink.proxy.SdlProxyConfigurationResources;
-import com.smartdevicelink.proxy.callbacks.OnServiceEnded;
-import com.smartdevicelink.proxy.callbacks.OnServiceNACKed;
 import com.smartdevicelink.proxy.interfaces.IProxyListenerALM;
-import com.smartdevicelink.proxy.rpc.AddCommandResponse;
-import com.smartdevicelink.proxy.rpc.AddSubMenuResponse;
-import com.smartdevicelink.proxy.rpc.AlertManeuverResponse;
-import com.smartdevicelink.proxy.rpc.AlertResponse;
-import com.smartdevicelink.proxy.rpc.ButtonPressResponse;
-import com.smartdevicelink.proxy.rpc.ChangeRegistrationResponse;
-import com.smartdevicelink.proxy.rpc.CreateInteractionChoiceSetResponse;
-import com.smartdevicelink.proxy.rpc.DeleteCommandResponse;
-import com.smartdevicelink.proxy.rpc.DeleteFileResponse;
-import com.smartdevicelink.proxy.rpc.DeleteInteractionChoiceSetResponse;
-import com.smartdevicelink.proxy.rpc.DeleteSubMenuResponse;
-import com.smartdevicelink.proxy.rpc.DiagnosticMessageResponse;
-import com.smartdevicelink.proxy.rpc.DialNumberResponse;
-import com.smartdevicelink.proxy.rpc.EndAudioPassThruResponse;
-import com.smartdevicelink.proxy.rpc.GenericResponse;
-import com.smartdevicelink.proxy.rpc.GetAppServiceDataResponse;
-import com.smartdevicelink.proxy.rpc.GetCloudAppPropertiesResponse;
-import com.smartdevicelink.proxy.rpc.GetDTCsResponse;
-import com.smartdevicelink.proxy.rpc.GetFileResponse;
-import com.smartdevicelink.proxy.rpc.GetInteriorVehicleDataResponse;
-import com.smartdevicelink.proxy.rpc.GetSystemCapabilityResponse;
-import com.smartdevicelink.proxy.rpc.GetVehicleDataResponse;
-import com.smartdevicelink.proxy.rpc.GetWayPointsResponse;
-import com.smartdevicelink.proxy.rpc.ListFilesResponse;
-import com.smartdevicelink.proxy.rpc.OnAppServiceData;
-import com.smartdevicelink.proxy.rpc.OnAudioPassThru;
-import com.smartdevicelink.proxy.rpc.OnButtonEvent;
-import com.smartdevicelink.proxy.rpc.OnButtonPress;
-import com.smartdevicelink.proxy.rpc.OnCommand;
-import com.smartdevicelink.proxy.rpc.OnDriverDistraction;
-import com.smartdevicelink.proxy.rpc.OnHMIStatus;
-import com.smartdevicelink.proxy.rpc.OnHashChange;
-import com.smartdevicelink.proxy.rpc.OnInteriorVehicleData;
-import com.smartdevicelink.proxy.rpc.OnKeyboardInput;
-import com.smartdevicelink.proxy.rpc.OnLanguageChange;
-import com.smartdevicelink.proxy.rpc.OnLockScreenStatus;
-import com.smartdevicelink.proxy.rpc.OnPermissionsChange;
-import com.smartdevicelink.proxy.rpc.OnRCStatus;
-import com.smartdevicelink.proxy.rpc.OnStreamRPC;
-import com.smartdevicelink.proxy.rpc.OnSystemCapabilityUpdated;
-import com.smartdevicelink.proxy.rpc.OnSystemRequest;
-import com.smartdevicelink.proxy.rpc.OnTBTClientState;
-import com.smartdevicelink.proxy.rpc.OnTouchEvent;
-import com.smartdevicelink.proxy.rpc.OnVehicleData;
-import com.smartdevicelink.proxy.rpc.OnWayPointChange;
-import com.smartdevicelink.proxy.rpc.PerformAppServiceInteractionResponse;
-import com.smartdevicelink.proxy.rpc.PerformAudioPassThruResponse;
-import com.smartdevicelink.proxy.rpc.PerformInteractionResponse;
-import com.smartdevicelink.proxy.rpc.PublishAppServiceResponse;
-import com.smartdevicelink.proxy.rpc.PutFileResponse;
-import com.smartdevicelink.proxy.rpc.ReadDIDResponse;
-import com.smartdevicelink.proxy.rpc.ResetGlobalPropertiesResponse;
-import com.smartdevicelink.proxy.rpc.ScrollableMessageResponse;
-import com.smartdevicelink.proxy.rpc.SendHapticDataResponse;
-import com.smartdevicelink.proxy.rpc.SendLocationResponse;
-import com.smartdevicelink.proxy.rpc.SetAppIconResponse;
-import com.smartdevicelink.proxy.rpc.SetCloudAppPropertiesResponse;
-import com.smartdevicelink.proxy.rpc.SetDisplayLayoutResponse;
-import com.smartdevicelink.proxy.rpc.SetGlobalPropertiesResponse;
-import com.smartdevicelink.proxy.rpc.SetInteriorVehicleDataResponse;
-import com.smartdevicelink.proxy.rpc.SetMediaClockTimerResponse;
 import com.smartdevicelink.proxy.rpc.Show;
-import com.smartdevicelink.proxy.rpc.ShowConstantTbtResponse;
 import com.smartdevicelink.proxy.rpc.ShowResponse;
-import com.smartdevicelink.proxy.rpc.SliderResponse;
+import com.smartdevicelink.proxy.rpc.Speak;
 import com.smartdevicelink.proxy.rpc.SpeakResponse;
-import com.smartdevicelink.proxy.rpc.StreamRPCResponse;
-import com.smartdevicelink.proxy.rpc.SubscribeButtonResponse;
-import com.smartdevicelink.proxy.rpc.SubscribeVehicleDataResponse;
-import com.smartdevicelink.proxy.rpc.SubscribeWayPointsResponse;
-import com.smartdevicelink.proxy.rpc.SystemRequestResponse;
-import com.smartdevicelink.proxy.rpc.UnsubscribeButtonResponse;
-import com.smartdevicelink.proxy.rpc.UnsubscribeVehicleDataResponse;
-import com.smartdevicelink.proxy.rpc.UnsubscribeWayPointsResponse;
-import com.smartdevicelink.proxy.rpc.UpdateTurnListResponse;
 import com.smartdevicelink.proxy.rpc.enums.Result;
-import com.smartdevicelink.proxy.rpc.enums.SdlDisconnectedReason;
 import com.smartdevicelink.proxy.rpc.listeners.OnMultipleRequestListener;
+import com.smartdevicelink.proxy.rpc.listeners.OnRPCResponseListener;
 import com.smartdevicelink.streaming.video.SdlRemoteDisplay;
 import com.smartdevicelink.streaming.video.VideoStreamingParameters;
 import com.smartdevicelink.test.streaming.video.SdlRemoteDisplayTest;
 
 import junit.framework.Assert;
 
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 
 public class SdlProxyBaseTests extends AndroidTestCase2 {
     public static final String TAG = "SdlProxyBaseTests";
+
+    int onUpdateListenerCounter, onFinishedListenerCounter, onResponseListenerCounter, onErrorListenerCounter;
 
     @Override
     protected void setUp() throws Exception{
@@ -124,7 +63,7 @@ public class SdlProxyBaseTests extends AndroidTestCase2 {
      */
     public void testNullSdlProxyConfigurationResources() {
         SdlProxyALM proxy = null;
-        SdlProxyBuilder.Builder builder = new SdlProxyBuilder.Builder(new ProxyListenerTest(), "appId", "appName", true, getContext());
+        SdlProxyBuilder.Builder builder = new SdlProxyBuilder.Builder(mock(IProxyListenerALM.class), "appId", "appName", true, getContext());
         SdlProxyConfigurationResources config = new SdlProxyConfigurationResources("path", (TelephonyManager) getContext().getSystemService(Context.TELEPHONY_SERVICE));
         //Construct with a non-null SdlProxyConfigurationResources
         builder.setSdlProxyConfigurationResources(config);
@@ -190,7 +129,7 @@ public class SdlProxyBaseTests extends AndroidTestCase2 {
 
     public void testRemoteDisplayStreaming(){
         SdlProxyALM proxy = null;
-        SdlProxyBuilder.Builder builder = new SdlProxyBuilder.Builder(new ProxyListenerTest(), "appId", "appName", true, getContext());
+        SdlProxyBuilder.Builder builder = new SdlProxyBuilder.Builder(mock(IProxyListenerALM.class), "appId", "appName", true, getContext());
         try{
             proxy = builder.build();
             //	public void startRemoteDisplayStream(Context context, final Class<? extends SdlRemoteDisplay> remoteDisplay, final VideoStreamingParameters parameters, final boolean encrypted){
@@ -205,498 +144,149 @@ public class SdlProxyBaseTests extends AndroidTestCase2 {
         }
     }
 
-    public void testMultipleRPCSendSynchronous() {
-
-		List<RPCRequest> rpcs = new ArrayList<>();
-
-		// rpc 1
-		Show show = new Show();
-		show.setMainField1("hey y'all");
-		show.setMainField2("");
-		show.setMainField3("");
-		show.setMainField4("");
-		rpcs.add(show);
-
-		// rpc 2
-		Show show2 = new Show();
-		show2.setMainField1("");
-		show2.setMainField2("It is Wednesday My Dudes");
-		show2.setMainField3("");
-		show2.setMainField4("");
-		rpcs.add(show2);
-
-		OnMultipleRequestListener mrl = new OnMultipleRequestListener() {
-			@Override
-			public void onUpdate(int remainingRequests) {
-
-			}
-
-			@Override
-			public void onFinished() {
-
-			}
-
-			@Override
-			public void onError(int correlationId, Result resultCode, String info) {
-				assert false;
-			}
-
-			@Override
-			public void onResponse(int correlationId, RPCResponse response) {
-
-			}
-		};
-		try{
-			// public void sendRequests(List<RPCRequest> rpcs, final OnMultipleRequestListener listener) throws SdlException {
-			Method m = SdlProxyBase.class.getDeclaredMethod("sendRequests", SdlProxyBase.class);
-			assertNotNull(m);
-			m.setAccessible(true);
-			m.invoke(rpcs,mrl);
-			assert true;
-
-		}catch (Exception e){
-			assert false;
-		}
-	}
-
-	public void testMultipleRPCSendAsynchronous() {
-
-		List<RPCRequest> rpcs = new ArrayList<>();
-
-		// rpc 1
-		Show show = new Show();
-		show.setMainField1("hey y'all");
-		show.setMainField2("");
-		show.setMainField3("");
-		show.setMainField4("");
-		rpcs.add(show);
-
-		// rpc 2
-		Show show2 = new Show();
-		show2.setMainField1("");
-		show2.setMainField2("It is Wednesday My Dudes");
-		show2.setMainField3("");
-		show2.setMainField4("");
-		rpcs.add(show2);
-
-		OnMultipleRequestListener mrl = new OnMultipleRequestListener() {
-			@Override
-			public void onUpdate(int remainingRequests) {
-
-			}
-
-			@Override
-			public void onFinished() {
-
-			}
-
-			@Override
-			public void onError(int correlationId, Result resultCode, String info) {
-				assert false;
-			}
-
-			@Override
-			public void onResponse(int correlationId, RPCResponse response) {
-
-			}
-		};
-		try{
-			// public void sendSequentialRequests(List<RPCRequest> rpcs, final OnMultipleRequestListener listener) throws SdlException {
-			Method m = SdlProxyBase.class.getDeclaredMethod("sendSequentialRequests", SdlProxyBase.class);
-			assertNotNull(m);
-			m.setAccessible(true);
-			m.invoke(rpcs,mrl);
-			assert true;
+    public void testSendRPCsAllSucceed(){
+        testSendMultipleRPCs(false, 1);
+    }
+
+    public void testSendRPCsSomeFails(){
+        testSendMultipleRPCs(false, 2);
+    }
+
+    public void testSendSequentialRPCsAllSucceed(){
+        testSendMultipleRPCs(true, 1);
+    }
+
+    public void testSendSequentialRPCsSomeFails(){
+        testSendMultipleRPCs(true, 2);
+    }
+
+    private void testSendMultipleRPCs(boolean sequentialSend, int caseNumber){
+        final List<RPCRequest> rpcsList = new ArrayList<>();
+        final List<RPCRequest> rpcsTempList = new ArrayList<>();
+        final HashMap<RPCRequest, OnRPCResponseListener> requestsMap = new HashMap<>();
+        onUpdateListenerCounter = 0;
+        onFinishedListenerCounter = 0;
+        onResponseListenerCounter = 0;
+        onErrorListenerCounter = 0;
+
+
+        // We extend the SdlProxyBase to be able to override getIsConnected() &  sendRPCMessagePrivate() methods so they don't cause issues when trying to send RPCs
+        // Because otherwise, they will throw exception cause there not actual connection to head unit
+        SdlProxyBase proxy = new SdlProxyBase() {
+
+            @Override
+            public Boolean getIsConnected() {
+                return true;
+            }
+
+            @Override
+            protected void sendRPCMessagePrivate(RPCMessage message) {
+                // Do nothing
+            }
+        };
+
+
+        // We need to get list of all OnRPCResponseListeners so we can trigger onResponse/onError for each RPC to fake a response from Core
+        final Answer<Void> answer = new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                Object[] args = invocation.getArguments();
+                RPCRequest request = (RPCRequest) invocation.getMock();
+                OnRPCResponseListener listener = (OnRPCResponseListener) args[0];
+                requestsMap.put(request, listener);
+                rpcsTempList.add(request);
+                return null;
+            }
+        };
+
+
+        // Prepare RPCs to send
+        Speak speak = mock(Speak.class);
+        doReturn(RPCMessage.KEY_REQUEST).when(speak).getMessageType();
+        doAnswer(answer).when(speak).setOnRPCResponseListener(any(OnRPCResponseListener.class));
+        rpcsList.add(speak);
+
+        Show show = mock(Show.class);
+        doReturn(RPCMessage.KEY_REQUEST).when(show).getMessageType();
+        doAnswer(answer).when(show).setOnRPCResponseListener(any(OnRPCResponseListener.class));
+        rpcsList.add(show);
+
+
+        // Send RPCs
+        OnMultipleRequestListener onMultipleRequestListener = new OnMultipleRequestListener() {
+            @Override
+            public void onUpdate(int remainingRequests) {
+                onUpdateListenerCounter++;
+            }
+
+            @Override
+            public void onFinished() {
+                onFinishedListenerCounter++;
+            }
+
+            @Override
+            public void onError(int correlationId, Result resultCode, String info) {
+                onErrorListenerCounter++;
+            }
+
+            @Override
+            public void onResponse(int correlationId, RPCResponse response) {
+                onResponseListenerCounter++;
+            }
+        };
+        try {
+            if (sequentialSend) {
+                proxy.sendSequentialRequests(rpcsList, onMultipleRequestListener);
+            } else {
+                proxy.sendRequests(rpcsList, onMultipleRequestListener);
+            }
+            assertTrue(true);
+        } catch (SdlException e) {
+            e.printStackTrace();
+            fail();
+        }
 
-		}catch (Exception e){
-			assert false;
-		}
-	}
 
-    public class ProxyListenerTest implements IProxyListenerALM {
-
-        @Override
-        public void onProxyClosed(String s, Exception e, SdlDisconnectedReason reason) {
-
-        }
-
-        @Override
-        public void onOnHMIStatus(OnHMIStatus status) {
-
-        }
-
-        @Override
-        public void onListFilesResponse(ListFilesResponse response) {
-        }
-
-        @Override
-        public void onPutFileResponse(PutFileResponse response) {
-        }
-
-        @Override
-        public void onOnLockScreenNotification(OnLockScreenStatus notification) {
-        }
-
-        @Override
-        public void onOnCommand(OnCommand notification){
-        }
-
-        /**
-         *  Callback method that runs when the add command response is received from SDL.
-         */
-        @Override
-        public void onAddCommandResponse(AddCommandResponse response) {
-        }
-
-        @Override
-        public void onOnPermissionsChange(OnPermissionsChange notification) {
-
-        }
-
-        @Override
-        public void onSubscribeVehicleDataResponse(SubscribeVehicleDataResponse response) {
-        }
-
-        @Override
-        public void onOnVehicleData(OnVehicleData notification) {
-        }
-
-        /**
-         * Rest of the SDL callbacks from the head unit
-         */
-
-        @Override
-        public void onAddSubMenuResponse(AddSubMenuResponse response) {
-        }
-
-        @Override
-        public void onCreateInteractionChoiceSetResponse(CreateInteractionChoiceSetResponse response) {
-        }
-
-        @Override
-        public void onAlertResponse(AlertResponse response) {
-        }
-
-        @Override
-        public void onDeleteCommandResponse(DeleteCommandResponse response) {
-        }
-
-        @Override
-        public void onDeleteInteractionChoiceSetResponse(DeleteInteractionChoiceSetResponse response) {
-        }
-
-        @Override
-        public void onDeleteSubMenuResponse(DeleteSubMenuResponse response) {
-        }
-
-        @Override
-        public void onPerformInteractionResponse(PerformInteractionResponse response) {
-        }
-
-        @Override
-        public void onResetGlobalPropertiesResponse(
-                ResetGlobalPropertiesResponse response) {
-        }
-
-        @Override
-        public void onSetGlobalPropertiesResponse(SetGlobalPropertiesResponse response) {
-        }
-
-        @Override
-        public void onSetMediaClockTimerResponse(SetMediaClockTimerResponse response) {
-        }
-
-        @Override
-        public void onShowResponse(ShowResponse response) {
-        }
-
-        @Override
-        public void onSpeakResponse(SpeakResponse response) {
-            Log.i(TAG, "SpeakCommand response from SDL: " + response.getResultCode().name() + " Info: " + response.getInfo());
-        }
-
-        @Override
-        public void onOnButtonEvent(OnButtonEvent notification) {
-        }
-
-        @Override
-        public void onOnButtonPress(OnButtonPress notification) {
-        }
-
-        @Override
-        public void onSubscribeButtonResponse(SubscribeButtonResponse response) {
-        }
-
-        @Override
-        public void onUnsubscribeButtonResponse(UnsubscribeButtonResponse response) {
-        }
-
-
-        @Override
-        public void onOnTBTClientState(OnTBTClientState notification) {
-        }
-
-        @Override
-        public void onUnsubscribeVehicleDataResponse(
-                UnsubscribeVehicleDataResponse response) {
-
-        }
-
-        @Override
-        public void onGetVehicleDataResponse(GetVehicleDataResponse response) {
-
-        }
-
-        @Override
-        public void onReadDIDResponse(ReadDIDResponse response) {
-
-        }
-
-        @Override
-        public void onGetDTCsResponse(GetDTCsResponse response) {
-
-        }
-
-
-        @Override
-        public void onPerformAudioPassThruResponse(PerformAudioPassThruResponse response) {
-
-        }
-
-        @Override
-        public void onEndAudioPassThruResponse(EndAudioPassThruResponse response) {
-
-        }
-
-        @Override
-        public void onOnAudioPassThru(OnAudioPassThru notification) {
-
-        }
-
-        @Override
-        public void onDeleteFileResponse(DeleteFileResponse response) {
-
-        }
-
-        @Override
-        public void onSetAppIconResponse(SetAppIconResponse response) {
-
-        }
-
-        @Override
-        public void onScrollableMessageResponse(ScrollableMessageResponse response) {
-
-        }
-
-        @Override
-        public void onChangeRegistrationResponse(ChangeRegistrationResponse response) {
-
-        }
-
-        @Override
-        public void onSetDisplayLayoutResponse(SetDisplayLayoutResponse response) {
-
-        }
-
-        @Override
-        public void onOnLanguageChange(OnLanguageChange notification) {
-
-        }
-
-        @Override
-        public void onSliderResponse(SliderResponse response) {
-
-        }
-
-
-        @Override
-        public void onOnHashChange(OnHashChange notification) {
-
-        }
-
-        @Override
-        public void onOnSystemRequest(OnSystemRequest notification) {
-        }
-
-        @Override
-        public void onSystemRequestResponse(SystemRequestResponse response) {
-
-        }
-
-        @Override
-        public void onOnKeyboardInput(OnKeyboardInput notification) {
-
-        }
-
-        @Override
-        public void onOnTouchEvent(OnTouchEvent notification) {
-
-        }
-
-        @Override
-        public void onDiagnosticMessageResponse(DiagnosticMessageResponse response) {
-
-        }
-
-        @Override
-        public void onOnStreamRPC(OnStreamRPC notification) {
-
-        }
-
-        @Override
-        public void onStreamRPCResponse(StreamRPCResponse response) {
-
-        }
-
-        @Override
-        public void onDialNumberResponse(DialNumberResponse response) {
-
-        }
-
-        @Override
-        public void onSendLocationResponse(SendLocationResponse response) {
-            Log.i(TAG, "SendLocation response from SDL: " + response.getResultCode().name() + " Info: " + response.getInfo());
-
-        }
-
-        @Override
-        public void onServiceEnded(OnServiceEnded serviceEnded) {
-
-        }
-
-        @Override
-        public void onServiceNACKed(OnServiceNACKed serviceNACKed) {
-
-        }
-
-        @Override
-        public void onShowConstantTbtResponse(ShowConstantTbtResponse response) {
-            Log.i(TAG, "ShowConstantTbt response from SDL: " + response.getResultCode().name() + " Info: " + response.getInfo());
-
-        }
-
-        @Override
-        public void onAlertManeuverResponse(AlertManeuverResponse response) {
-            Log.i(TAG, "AlertManeuver response from SDL: " + response.getResultCode().name() + " Info: " + response.getInfo());
-
-        }
-
-        @Override
-        public void onUpdateTurnListResponse(UpdateTurnListResponse response) {
-            Log.i(TAG, "UpdateTurnList response from SDL: " + response.getResultCode().name() + " Info: " + response.getInfo());
-
-        }
-
-        @Override
-        public void onServiceDataACK(int dataSize) {
-        }
-
-        @Override
-        public void onGetWayPointsResponse(GetWayPointsResponse response) {
-            Log.i(TAG, "GetWayPoints response from SDL: " + response.getResultCode().name() + " Info: " + response.getInfo());
-        }
-
-        @Override
-        public void onSubscribeWayPointsResponse(SubscribeWayPointsResponse response) {
-            Log.i(TAG, "SubscribeWayPoints response from SDL: " + response.getResultCode().name() + " Info: " + response.getInfo());
-        }
-
-        @Override
-        public void onUnsubscribeWayPointsResponse(UnsubscribeWayPointsResponse response) {
-            Log.i(TAG, "UnsubscribeWayPoints response from SDL: " + response.getResultCode().name() + " Info: " + response.getInfo());
-        }
-
-        @Override
-        public void onOnWayPointChange(OnWayPointChange notification) {
-            Log.i(TAG, "OnWayPointChange notification from SDL: " + notification);
-        }
-
-        @Override
-        public void onGetSystemCapabilityResponse(GetSystemCapabilityResponse response) {
-            Log.i(TAG, "GetSystemCapability response from SDL: " + response);
-        }
-
-        @Override
-        public void onGetInteriorVehicleDataResponse(GetInteriorVehicleDataResponse response) {
-            Log.i(TAG, "GetInteriorVehicleData response from SDL: " + response);
-        }
-
-        @Override
-        public void onButtonPressResponse(ButtonPressResponse response) {
-            Log.i(TAG, "ButtonPress response from SDL: " + response);
-        }
-
-        @Override
-        public void onSetInteriorVehicleDataResponse(SetInteriorVehicleDataResponse response) {
-            Log.i(TAG, "SetInteriorVehicleData response from SDL: " + response);
-        }
-
-        @Override
-        public void onOnInteriorVehicleData(OnInteriorVehicleData notification) {
-
-        }
-
-        @Override
-        public void onOnDriverDistraction(OnDriverDistraction notification) {
-            // Some RPCs (depending on region) cannot be sent when driver distraction is active.
-        }
-
-        @Override
-        public void onError(String info, Exception e) {
-        }
-
-        @Override
-        public void onGenericResponse(GenericResponse response) {
-            Log.i(TAG, "Generic response from SDL: " + response.getResultCode().name() + " Info: " + response.getInfo());
-        }
-
-        @Override
-		public void onSendHapticDataResponse(SendHapticDataResponse response) {
-			Log.i(TAG, "SendHapticDataResponse response from SDL: " + response);
-		}
-
-		@Override
-		public void onOnRCStatus(OnRCStatus notification) {
-		}
-
-        @Override
-        public void onSetCloudAppProperties(SetCloudAppPropertiesResponse response) {
-
-        }
-
-        @Override
-        public void onGetCloudAppProperties(GetCloudAppPropertiesResponse response) {
-
-        }
-
-        @Override
-        public void onPublishAppServiceResponse(PublishAppServiceResponse response) {
-
-        }
-
-        @Override
-        public void onGetAppServiceDataResponse(GetAppServiceDataResponse response) {
-
-        }
-
-        @Override
-        public void onGetFileResponse(GetFileResponse response) {
-
-        }
-
-        @Override
-        public void onPerformAppServiceInteractionResponse(PerformAppServiceInteractionResponse response) {
-
-        }
-
-        @Override
-        public void onOnAppServiceData(OnAppServiceData notification) {
-
-        }
-
-        @Override
-        public void onOnSystemCapabilityUpdated(OnSystemCapabilityUpdated notification) {
-
-        }
+        // Trigger fake RPC responses
+        int onUpdateListenerCounterExpected = 0, onFinishedListenerCounterExpected = 0, onResponseListenerCounterExpected = 0, onErrorListenerCounterExpected = 0;
+        switch (caseNumber){
+            case 1: // All RPCs succeed
+                onUpdateListenerCounterExpected = 2;
+                onFinishedListenerCounterExpected = 1;
+                onResponseListenerCounterExpected = 2;
+                onErrorListenerCounterExpected = 0;
+
+                while (rpcsTempList.size() != 0){
+                    RPCRequest request = rpcsTempList.remove(0);
+                    if (request instanceof Speak) {
+                        requestsMap.get(request).onResponse(request.getCorrelationID(), new SpeakResponse(true, Result.SUCCESS));
+                    } else if (request instanceof Show) {
+                        requestsMap.get(request).onResponse(request.getCorrelationID(), new ShowResponse(true, Result.SUCCESS));
+                    }
+                }
+                break;
+            case 2: // Some RPCs fail
+                onUpdateListenerCounterExpected = 2;
+                onFinishedListenerCounterExpected = 1;
+                onResponseListenerCounterExpected = 1;
+                onErrorListenerCounterExpected = 1;
+
+                while (rpcsTempList.size() != 0){
+                    RPCRequest request = rpcsTempList.remove(0);
+                    if (request instanceof Speak) {
+                        requestsMap.get(request).onError(request.getCorrelationID(), Result.DISALLOWED, "ERROR");
+                    } else if (request instanceof Show) {
+                        requestsMap.get(request).onResponse(request.getCorrelationID(), new ShowResponse(true, Result.SUCCESS));
+                    }
+                }
+                break;
+        }
+
+
+        // Make sure the listener is called correctly
+        assertEquals("onUpdate Listener was not called or called more/less frequently than expected", onUpdateListenerCounterExpected, onUpdateListenerCounter);
+        assertEquals("onFinished Listener was not called or called more/less frequently than expected", onFinishedListenerCounterExpected, onFinishedListenerCounter);
+        assertEquals("onResponse Listener was not called or called more/less frequently than expected", onResponseListenerCounterExpected, onResponseListenerCounter);
+        assertEquals("onError Listener was not called or called more/less frequently than expected", onErrorListenerCounterExpected, onErrorListenerCounter);
     }
 }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -4381,6 +4381,18 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		} else {
 			// Notifications and Responses
 			sendRPCMessagePrivate(rpc);
+			if (listener != null && rpcs.size() > 0) {
+				listener.onUpdate(rpcs.size());
+			}
+			// recurse after sending a notification or response as there is no response.
+			try {
+				sendSequentialRequests(rpcs, listener);
+			} catch (SdlException e) {
+				e.printStackTrace();
+				if (listener != null) {
+					listener.onError(0, Result.GENERIC_ERROR, e.toString());
+				}
+			}
 		}
 
 
@@ -4459,6 +4471,13 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			}else {
 				// Notifications and Responses
 				sendRPCMessagePrivate(rpc);
+				if (listener != null){
+					if (rpcs.size() > 0){
+						listener.onUpdate(rpcs.size());
+					} else {
+						listener.onFinished();
+					}
+				}
 			}
 		}
 	}

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -768,6 +768,8 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		}
 	}
 
+	protected SdlProxyBase(){}
+
 	/**
 	 * Used by the SdlManager
 	 *
@@ -2094,7 +2096,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	/************* END Functions used by the Message Dispatching Queues ****************/
 	
 	// Private sendRPCMessagePrivate method. All RPCMessages are funneled through this method after error checking.
-	private void sendRPCMessagePrivate(RPCMessage message) throws SdlException {
+	protected void sendRPCMessagePrivate(RPCMessage message) throws SdlException {
 		try {
 			SdlTrace.logRPCEvent(InterfaceActivityDirection.Transmit, message, SDL_LIB_TRACE_KEY);
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -4315,10 +4315,10 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			throw new SdlException("You must send some RPCs", SdlExceptionCause.INVALID_ARGUMENT);
 		}
 
-		final int requestCount = rpcs.size();
+		final int rpcCount = rpcs.size();
 
 		// Break out of recursion, we have finished the requests
-		if (requestCount == 0) {
+		if (rpcCount == 0) {
 			if(listener != null){
 				listener.onFinished();
 			}
@@ -4342,7 +4342,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					}
 					if (listener != null) {
 						listener.onResponse(correlationId, response);
-						listener.onUpdate(requestCount);
+						listener.onUpdate(rpcCount);
 
 					}
 					try {
@@ -4363,7 +4363,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					}
 					if (listener != null) {
 						listener.onError(correlationId, resultCode, info);
-						listener.onUpdate(requestCount);
+						listener.onUpdate(rpcCount);
 					}
 					try {
 						// recurse after onError
@@ -4381,7 +4381,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			// Notifications and Responses
 			sendRPCMessagePrivate(rpc);
 			if (listener != null) {
-				listener.onUpdate(requestCount);
+				listener.onUpdate(rpcCount);
 			}
 			// recurse after sending a notification or response as there is no response.
 			try {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -4313,7 +4313,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			throw new SdlException("You must send some RPCs", SdlExceptionCause.INVALID_ARGUMENT);
 		}
 
-		int requestCount = rpcs.size();
+		final int requestCount = rpcs.size();
 
 		// Break out of recursion, we have finished the requests
 		if (requestCount == 0) {
@@ -4340,9 +4340,8 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					}
 					if (listener != null) {
 						listener.onResponse(correlationId, response);
-						if (rpcs.size() > 0) {
-							listener.onUpdate(rpcs.size());
-						}
+						listener.onUpdate(requestCount);
+
 					}
 					try {
 						// recurse after onResponse
@@ -4362,9 +4361,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					}
 					if (listener != null) {
 						listener.onError(correlationId, resultCode, info);
-						if (rpcs.size() > 0) {
-							listener.onUpdate(rpcs.size());
-						}
+						listener.onUpdate(requestCount);
 					}
 					try {
 						// recurse after onError
@@ -4381,8 +4378,8 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		} else {
 			// Notifications and Responses
 			sendRPCMessagePrivate(rpc);
-			if (listener != null && rpcs.size() > 0) {
-				listener.onUpdate(rpcs.size());
+			if (listener != null) {
+				listener.onUpdate(requestCount);
 			}
 			// recurse after sending a notification or response as there is no response.
 			try {
@@ -4472,9 +4469,8 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// Notifications and Responses
 				sendRPCMessagePrivate(rpc);
 				if (listener != null){
-					if (rpcs.size() > 0){
-						listener.onUpdate(rpcs.size());
-					} else {
+					listener.onUpdate(rpcs.size());
+					if (rpcs.size() == 0){
 						listener.onFinished();
 					}
 				}

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -4315,10 +4315,8 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			throw new SdlException("You must send some RPCs", SdlExceptionCause.INVALID_ARGUMENT);
 		}
 
-		final int rpcCount = rpcs.size();
-
 		// Break out of recursion, we have finished the requests
-		if (rpcCount == 0) {
+		if (rpcs.size() == 0) {
 			if(listener != null){
 				listener.onFinished();
 			}
@@ -4342,7 +4340,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					}
 					if (listener != null) {
 						listener.onResponse(correlationId, response);
-						listener.onUpdate(rpcCount);
+						listener.onUpdate(rpcs.size());
 
 					}
 					try {
@@ -4363,7 +4361,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					}
 					if (listener != null) {
 						listener.onError(correlationId, resultCode, info);
-						listener.onUpdate(rpcCount);
+						listener.onUpdate(rpcs.size());
 					}
 					try {
 						// recurse after onError
@@ -4381,7 +4379,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			// Notifications and Responses
 			sendRPCMessagePrivate(rpc);
 			if (listener != null) {
-				listener.onUpdate(rpcCount);
+				listener.onUpdate(rpcs.size());
 			}
 			// recurse after sending a notification or response as there is no response.
 			try {

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/listeners/OnMultipleRequestListener.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/listeners/OnMultipleRequestListener.java
@@ -65,9 +65,8 @@ public abstract class OnMultipleRequestListener extends OnRPCResponseListener {
 
 			private synchronized void update(int correlationId){
 				correlationIds.remove(Integer.valueOf(correlationId));
-				if(correlationIds.size()>0){
-					onUpdate(correlationIds.size());
-				}else{
+				onUpdate(correlationIds.size());
+				if(correlationIds.size() == 0){
 					onFinished();
 				}
 			}

--- a/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -202,10 +202,8 @@ public class LifecycleManager extends BaseLifecycleManager {
 
     private void sendSequentialRPCs(final List<? extends RPCMessage> messages, final OnMultipleRequestListener listener){
        if (messages != null){
-           final int rpcCount = messages.size();
-
            // Break out of recursion, we have finished the requests
-           if (rpcCount == 0) {
+           if (messages.size() == 0) {
                if(listener != null){
                    listener.onFinished();
                }
@@ -229,7 +227,7 @@ public class LifecycleManager extends BaseLifecycleManager {
                        }
                        if (listener != null) {
                            listener.onResponse(correlationId, response);
-                           listener.onUpdate(rpcCount);
+                           listener.onUpdate(messages.size());
                        }
                        // recurse after onResponse
                        sendSequentialRPCs(messages, listener);
@@ -242,7 +240,7 @@ public class LifecycleManager extends BaseLifecycleManager {
                        }
                        if (listener != null) {
                            listener.onError(correlationId, resultCode, info);
-                           listener.onUpdate(rpcCount);
+                           listener.onUpdate(messages.size());
 
                        }
                        // recurse after onError
@@ -254,7 +252,7 @@ public class LifecycleManager extends BaseLifecycleManager {
                // Notifications and Responses
                sendRPCMessagePrivate(rpc);
                if (listener != null) {
-                   listener.onUpdate(rpcCount);
+                   listener.onUpdate(messages.size());
                }
                // recurse after sending a notification or response as there is no response.
                sendSequentialRPCs(messages, listener);

--- a/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -190,9 +190,8 @@ public class LifecycleManager extends BaseLifecycleManager {
                     // Notifications and Responses
                     sendRPCMessagePrivate(message);
                     if (listener != null){
-                        if (messages.size() > 0){
-                            listener.onUpdate(messages.size());
-                        } else {
+                        listener.onUpdate(messages.size());
+                        if (messages.size() == 0){
                             listener.onFinished();
                         }
                     }
@@ -203,10 +202,10 @@ public class LifecycleManager extends BaseLifecycleManager {
 
     private void sendSequentialRPCs(final List<? extends RPCMessage> messages, final OnMultipleRequestListener listener){
        if (messages != null){
-           int requestCount = messages.size();
+           final int rpcCount = messages.size();
 
            // Break out of recursion, we have finished the requests
-           if (requestCount == 0) {
+           if (rpcCount == 0) {
                if(listener != null){
                    listener.onFinished();
                }
@@ -230,9 +229,7 @@ public class LifecycleManager extends BaseLifecycleManager {
                        }
                        if (listener != null) {
                            listener.onResponse(correlationId, response);
-                           if (messages.size() > 0) {
-                               listener.onUpdate(messages.size());
-                           }
+                           listener.onUpdate(rpcCount);
                        }
                        // recurse after onResponse
                        sendSequentialRPCs(messages, listener);
@@ -245,9 +242,8 @@ public class LifecycleManager extends BaseLifecycleManager {
                        }
                        if (listener != null) {
                            listener.onError(correlationId, resultCode, info);
-                           if (messages.size() > 0) {
-                               listener.onUpdate(messages.size());
-                           }
+                           listener.onUpdate(rpcCount);
+
                        }
                        // recurse after onError
                        sendSequentialRPCs(messages, listener);
@@ -257,8 +253,8 @@ public class LifecycleManager extends BaseLifecycleManager {
            } else {
                // Notifications and Responses
                sendRPCMessagePrivate(rpc);
-               if (listener != null && messages.size() > 0) {
-                   listener.onUpdate(messages.size());
+               if (listener != null) {
+                   listener.onUpdate(rpcCount);
                }
                // recurse after sending a notification or response as there is no response.
                sendSequentialRPCs(messages, listener);

--- a/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -189,6 +189,13 @@ public class LifecycleManager extends BaseLifecycleManager {
                 }else {
                     // Notifications and Responses
                     sendRPCMessagePrivate(message);
+                    if (listener != null){
+                        if (messages.size() > 0){
+                            listener.onUpdate(messages.size());
+                        } else {
+                            listener.onFinished();
+                        }
+                    }
                 }
             }
         }
@@ -250,7 +257,7 @@ public class LifecycleManager extends BaseLifecycleManager {
            } else {
                // Notifications and Responses
                sendRPCMessagePrivate(rpc);
-               if (listener != null) {
+               if (listener != null && messages.size() > 0) {
                    listener.onUpdate(messages.size());
                }
                // recurse after sending a notification or response as there is no response.


### PR DESCRIPTION
Fixes #1061

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Summary
This PR fixes some issue in `sendRPCs` and `sendSequentialRPCs` methods:
- Calls the `onResponse/onError` for every RPC's `OnRPCResponseListener` 
- Calls the `onResponse/onError` in the `OnMultipleRequestListener` for every RPC 
- Continue sending RPCs if one failed
- `onUpdate` in `OnMultipleRequestListener`  is called for every RPC incuding the failed ones 

### Testing Plan
- Create a list of RPCs that you want to send and make sure one of them at least fails. The one that fails should not be the last one.
- Set an `OnRPCResponseListener` listener for all RPCs
- Send the RPCs using `sendSequentialRPCs`
- Make sure that `onResponse/onError` is called for every RPC in both the RPC's `OnRPCResponseListener` and the `OnMultipleRequestListener`
- Make sure that `onUpdate` is called for every RPC in the `OnMultipleRequestListener` and that `onFinished()` is called once in the end
- Repeat the same test using `sendRPCs`
- Repeat the tests again for both `sendRPCs` and `sendSequentialRPCs` in JavaSE library

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
