### PR TITLE
Add support for handling multiple TouchEvents in one OnTouchEvent notification 

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ from within the project (JavaSE or JavaEE) and a JAR should be generated in the 
 ![Java Suite Folder Structure](JavaSuiteFolderStructure.png)
 
 #### base Folder
-The base folder contains the source set that is shared between all of the compilable projects. This folder does not contain a a compilable project. 
+The base folder contains the source set that is shared between all of the compilable projects. This folder does not contain a compilable project. 
 
 #### baseAndroid Folder
-The baseAndroid folder contains symbolic links to files and folders from the base folder. This has been included since the Java Suite refactor is a minor version release and the base folder contains breaking changes for the Android project. This folder does not contain a a compilable project. 
+The baseAndroid folder contains symbolic links to files and folders from the base folder. This has been included since the Java Suite refactor is a minor version release and the base folder contains breaking changes for the Android project. This folder does not contain a compilable project. 
 
 #### android Folder 
 The android folder contains the SDL Android library as well as the sample project for Android. Both of those are compilable projects. 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/video/VideoStreamManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/video/VideoStreamManagerTests.java
@@ -17,6 +17,7 @@ import com.smartdevicelink.proxy.interfaces.IVideoStreamListener;
 import com.smartdevicelink.proxy.interfaces.OnSystemCapabilityListener;
 import com.smartdevicelink.proxy.rpc.OnHMIStatus;
 import com.smartdevicelink.proxy.rpc.OnTouchEvent;
+import com.smartdevicelink.proxy.rpc.TouchCoord;
 import com.smartdevicelink.proxy.rpc.TouchEvent;
 import com.smartdevicelink.proxy.rpc.enums.HMILevel;
 import com.smartdevicelink.proxy.rpc.enums.SystemCapabilityType;
@@ -31,8 +32,11 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -247,40 +251,46 @@ public class VideoStreamManagerTests extends AndroidTestCase2 {
 
 	public void testConvertTouchEvent(){
 		ISdl internalInterface = mock(ISdl.class);
-		when(internalInterface.getProtocolVersion()).thenReturn(new Version(5,1,0));
+		VideoStreamManager videoStreamManager = new VideoStreamManager(internalInterface);
+		List<MotionEvent> motionEventList;
+		long e1TS = 1558124390L, e2TS = 1558125390L, e3TS = 1558126390L;
+		int e1x = 50, e1y = 100, e2x = 150, e2y = 200, e3x = 250, e3y = 300;
+		int e1Id = 100, e2Id = 101, e3Id = 102;
+		int movingStep = 10;
+		OnTouchEvent testOnTouchEvent;
+		MotionEvent motionEvent;
+		TouchEvent touchEvent1 = new TouchEvent(e1Id, Collections.singletonList(e1TS), Collections.singletonList(new TouchCoord(e1x, e1y)));
+		TouchEvent touchEvent1AfterMove = new TouchEvent(e1Id, Collections.singletonList(e1TS), Collections.singletonList(new TouchCoord(e1x + movingStep, e1y + movingStep)));
+		TouchEvent touchEvent2 = new TouchEvent(e2Id, Collections.singletonList(e2TS), Collections.singletonList(new TouchCoord(e2x, e2y)));
+		TouchEvent touchEvent2AfterMove = new TouchEvent(e2Id, Collections.singletonList(e2TS), Collections.singletonList(new TouchCoord(e2x + movingStep, e2y + movingStep)));
+		TouchEvent touchEvent3 = new TouchEvent(e3Id, Collections.singletonList(e3TS), Collections.singletonList(new TouchCoord(e3x, e3y)));
+		TouchEvent touchEvent3AfterMove = new TouchEvent(e3Id, Collections.singletonList(e3TS), Collections.singletonList(new TouchCoord(e3x + movingStep, e3y + movingStep)));
 
-		final VideoStreamManager videoStreamManager = new VideoStreamManager(internalInterface);
-		videoStreamManager.start(new CompletionListener() {
-			@Override
-			public void onComplete(boolean success) {
-				assertTrue(success);
-				OnTouchEvent testOnTouchEvent = new OnTouchEvent();
-				TouchEvent touchEvent = Test.GENERAL_TOUCHEVENT;
-				testOnTouchEvent.setEvent(Collections.singletonList(touchEvent));
-				testOnTouchEvent.setType(Test.GENERAL_TOUCHTYPE);
-				MotionEvent motionEvent;
 
-				// Touch one pointer (100)
-				motionEvent = videoStreamManager.convertTouchEvent(testOnTouchEvent);
-				assertEquals(motionEvent.getAction(), MotionEvent.ACTION_DOWN);
 
-				// Touch another pointer (101) without release
-				touchEvent.setId(Test.GENERAL_INT + 1);
-				testOnTouchEvent.setEvent(Collections.singletonList(touchEvent));
-				motionEvent = videoStreamManager.convertTouchEvent(testOnTouchEvent);
-				assertEquals(motionEvent.getAction(), MotionEvent.ACTION_POINTER_DOWN);
+		/////////////////////////////////////////////////// First OnTouchEvent Notification ///////////////////////////////////////////////////
+		testOnTouchEvent = new OnTouchEvent(TouchType.BEGIN, Arrays.asList(touchEvent1, touchEvent2));
+		motionEventList = videoStreamManager.convertTouchEvent(testOnTouchEvent);
 
-				// Release one of the pointers (101)
-				testOnTouchEvent.setType(TouchType.END);
-				motionEvent = videoStreamManager.convertTouchEvent(testOnTouchEvent);
-				assertEquals(motionEvent.getAction(), MotionEvent.ACTION_POINTER_UP);
+		// First MotionEvent should be ACTION_DOWN and have 1 pointer
+		motionEvent = motionEventList.get(0);
+		assertEquals(1, motionEvent.getPointerCount());
+		assertEquals(e1x, Math.round(motionEvent.getX(0)));
+		assertEquals(e1y, Math.round(motionEvent.getY(0)));
+		assertEquals(MotionEvent.ACTION_DOWN, motionEvent.getAction());
 
-				// Release the other pointer (100)
-				touchEvent.setId(Test.GENERAL_INT);
-				testOnTouchEvent.setEvent(Collections.singletonList(touchEvent));
-				motionEvent = videoStreamManager.convertTouchEvent(testOnTouchEvent);
-				assertEquals(motionEvent.getAction(), MotionEvent.ACTION_UP);
-			}
-		});
+
+		// Second MotionEvent should be ACTION_POINTER_DOWN and have 2 pointers
+		motionEvent = motionEventList.get(1);
+		assertEquals(2, motionEvent.getPointerCount());
+		assertEquals(e1x, Math.round(motionEvent.getX(0)));
+		assertEquals(e1y, Math.round(motionEvent.getY(0)));
+		assertEquals(e2x, Math.round(motionEvent.getX(1)));
+		assertEquals(e2y, Math.round(motionEvent.getY(1)));
+		assertEquals(MotionEvent.ACTION_POINTER_DOWN, motionEvent.getActionMasked());
+		////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+
 	}
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/video/VideoStreamManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/video/VideoStreamManagerTests.java
@@ -249,7 +249,7 @@ public class VideoStreamManagerTests extends AndroidTestCase2 {
 
 	}
 
-	public void testConvertTouchEvent(){
+	public void testConvertTouchEvent() {
 		ISdl internalInterface = mock(ISdl.class);
 		VideoStreamManager videoStreamManager = new VideoStreamManager(internalInterface);
 		List<MotionEvent> motionEventList;
@@ -269,6 +269,7 @@ public class VideoStreamManagerTests extends AndroidTestCase2 {
 		/////////////////////////////////////////////////// First OnTouchEvent Notification ///////////////////////////////////////////////////
 		testOnTouchEvent = new OnTouchEvent(TouchType.BEGIN, Arrays.asList(touchEvent1, touchEvent2));
 		motionEventList = videoStreamManager.convertTouchEvent(testOnTouchEvent);
+
 
 		// First MotionEvent should be ACTION_DOWN and have 1 pointer
 		motionEvent = motionEventList.get(0);
@@ -328,39 +329,39 @@ public class VideoStreamManagerTests extends AndroidTestCase2 {
 
 
 
-        /////////////////////////////////////////////////// Fourth OnTouchEvent Notification ///////////////////////////////////////////////////
-        testOnTouchEvent = new OnTouchEvent(TouchType.END, Arrays.asList(touchEvent2AfterMovingPointer));
-        motionEventList = videoStreamManager.convertTouchEvent(testOnTouchEvent);
+		/////////////////////////////////////////////////// Fourth OnTouchEvent Notification ///////////////////////////////////////////////////
+		testOnTouchEvent = new OnTouchEvent(TouchType.END, Arrays.asList(touchEvent2AfterMovingPointer));
+		motionEventList = videoStreamManager.convertTouchEvent(testOnTouchEvent);
 
 
-        // First MotionEvent should be ACTION_POINTER_UP and have 3 pointers
-        motionEvent = motionEventList.get(0);
-        assertEquals(3, motionEvent.getPointerCount());
-        assertEquals(e1x, Math.round(motionEvent.getX(0)));
-        assertEquals(e1y, Math.round(motionEvent.getY(0)));
-        assertEquals(e2x + movingStep, Math.round(motionEvent.getX(1)));
-        assertEquals(e2y + movingStep, Math.round(motionEvent.getY(1)));
-        assertEquals(e3x, Math.round(motionEvent.getX(2)));
-        assertEquals(e3y, Math.round(motionEvent.getY(2)));
-        assertEquals(MotionEvent.ACTION_POINTER_UP, motionEvent.getActionMasked());
-        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+		// First MotionEvent should be ACTION_POINTER_UP and have 3 pointers
+		motionEvent = motionEventList.get(0);
+		assertEquals(3, motionEvent.getPointerCount());
+		assertEquals(e1x, Math.round(motionEvent.getX(0)));
+		assertEquals(e1y, Math.round(motionEvent.getY(0)));
+		assertEquals(e2x + movingStep, Math.round(motionEvent.getX(1)));
+		assertEquals(e2y + movingStep, Math.round(motionEvent.getY(1)));
+		assertEquals(e3x, Math.round(motionEvent.getX(2)));
+		assertEquals(e3y, Math.round(motionEvent.getY(2)));
+		assertEquals(MotionEvent.ACTION_POINTER_UP, motionEvent.getActionMasked());
+		////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 
 
-        /////////////////////////////////////////////////// Fifth OnTouchEvent Notification ///////////////////////////////////////////////////
-        testOnTouchEvent = new OnTouchEvent(TouchType.END, Arrays.asList(touchEvent3));
-        motionEventList = videoStreamManager.convertTouchEvent(testOnTouchEvent);
+		/////////////////////////////////////////////////// Fifth OnTouchEvent Notification ///////////////////////////////////////////////////
+		testOnTouchEvent = new OnTouchEvent(TouchType.END, Arrays.asList(touchEvent3));
+		motionEventList = videoStreamManager.convertTouchEvent(testOnTouchEvent);
 
 
-        // First MotionEvent should be ACTION_POINTER_UP and have 2 pointers
-        motionEvent = motionEventList.get(0);
-        assertEquals(2, motionEvent.getPointerCount());
-        assertEquals(e1x, Math.round(motionEvent.getX(0)));
-        assertEquals(e1y, Math.round(motionEvent.getY(0)));
-        assertEquals(e3x, Math.round(motionEvent.getX(1)));
-        assertEquals(e3y, Math.round(motionEvent.getY(1)));
-        assertEquals(MotionEvent.ACTION_POINTER_UP, motionEvent.getActionMasked());
-        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+		// First MotionEvent should be ACTION_POINTER_UP and have 2 pointers
+		motionEvent = motionEventList.get(0);
+		assertEquals(2, motionEvent.getPointerCount());
+		assertEquals(e1x, Math.round(motionEvent.getX(0)));
+		assertEquals(e1y, Math.round(motionEvent.getY(0)));
+		assertEquals(e3x, Math.round(motionEvent.getX(1)));
+		assertEquals(e3y, Math.round(motionEvent.getY(1)));
+		assertEquals(MotionEvent.ACTION_POINTER_UP, motionEvent.getActionMasked());
+		////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 
 
@@ -382,6 +383,7 @@ public class VideoStreamManagerTests extends AndroidTestCase2 {
 		/////////////////////////////////////////////////// Seventh OnTouchEvent Notification ///////////////////////////////////////////////////
 		testOnTouchEvent = new OnTouchEvent(TouchType.BEGIN, Arrays.asList(touchEvent1, touchEvent2));
 		motionEventList = videoStreamManager.convertTouchEvent(testOnTouchEvent);
+
 
 		// First MotionEvent should be ACTION_DOWN and have 1 pointer
 		motionEvent = motionEventList.get(0);
@@ -424,12 +426,28 @@ public class VideoStreamManagerTests extends AndroidTestCase2 {
 		testOnTouchEvent = new OnTouchEvent(TouchType.BEGIN, Arrays.asList(touchEvent1));
 		motionEventList = videoStreamManager.convertTouchEvent(testOnTouchEvent);
 
+
 		// First MotionEvent should be ACTION_DOWN and have 1 pointer
 		motionEvent = motionEventList.get(0);
 		assertEquals(1, motionEvent.getPointerCount());
 		assertEquals(e1x, Math.round(motionEvent.getX(0)));
 		assertEquals(e1y, Math.round(motionEvent.getY(0)));
 		assertEquals(MotionEvent.ACTION_DOWN, motionEvent.getActionMasked());
+		////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+
+		/////////////////////////////////////////////////// Tenth OnTouchEvent Notification ///////////////////////////////////////////////////
+		testOnTouchEvent = new OnTouchEvent(TouchType.END, Arrays.asList(touchEvent1));
+		motionEventList = videoStreamManager.convertTouchEvent(testOnTouchEvent);
+
+
+		// First MotionEvent should be ACTION_UP and have 1 pointer
+		motionEvent = motionEventList.get(0);
+		assertEquals(1, motionEvent.getPointerCount());
+		assertEquals(e1x, Math.round(motionEvent.getX(0)));
+		assertEquals(e1y, Math.round(motionEvent.getY(0)));
+		assertEquals(MotionEvent.ACTION_UP, motionEvent.getActionMasked());
 		////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	}
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/video/VideoStreamManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/video/VideoStreamManagerTests.java
@@ -275,7 +275,7 @@ public class VideoStreamManagerTests extends AndroidTestCase2 {
 		assertEquals(1, motionEvent.getPointerCount());
 		assertEquals(e1x, Math.round(motionEvent.getX(0)));
 		assertEquals(e1y, Math.round(motionEvent.getY(0)));
-		assertEquals(MotionEvent.ACTION_DOWN, motionEvent.getAction());
+		assertEquals(MotionEvent.ACTION_DOWN, motionEvent.getActionMasked());
 
 
 		// Second MotionEvent should be ACTION_POINTER_DOWN and have 2 pointers
@@ -388,7 +388,7 @@ public class VideoStreamManagerTests extends AndroidTestCase2 {
 		assertEquals(1, motionEvent.getPointerCount());
 		assertEquals(e1x, Math.round(motionEvent.getX(0)));
 		assertEquals(e1y, Math.round(motionEvent.getY(0)));
-		assertEquals(MotionEvent.ACTION_DOWN, motionEvent.getAction());
+		assertEquals(MotionEvent.ACTION_DOWN, motionEvent.getActionMasked());
 
 
 		// Second MotionEvent should be ACTION_POINTER_DOWN and have 2 pointers
@@ -429,7 +429,7 @@ public class VideoStreamManagerTests extends AndroidTestCase2 {
 		assertEquals(1, motionEvent.getPointerCount());
 		assertEquals(e1x, Math.round(motionEvent.getX(0)));
 		assertEquals(e1y, Math.round(motionEvent.getY(0)));
-		assertEquals(MotionEvent.ACTION_DOWN, motionEvent.getAction());
+		assertEquals(MotionEvent.ACTION_DOWN, motionEvent.getActionMasked());
 		////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	}
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/video/VideoStreamManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/video/VideoStreamManagerTests.java
@@ -260,11 +260,9 @@ public class VideoStreamManagerTests extends AndroidTestCase2 {
 		OnTouchEvent testOnTouchEvent;
 		MotionEvent motionEvent;
 		TouchEvent touchEvent1 = new TouchEvent(e1Id, Collections.singletonList(e1TS), Collections.singletonList(new TouchCoord(e1x, e1y)));
-		TouchEvent touchEvent1AfterMove = new TouchEvent(e1Id, Collections.singletonList(e1TS), Collections.singletonList(new TouchCoord(e1x + movingStep, e1y + movingStep)));
 		TouchEvent touchEvent2 = new TouchEvent(e2Id, Collections.singletonList(e2TS), Collections.singletonList(new TouchCoord(e2x, e2y)));
-		TouchEvent touchEvent2AfterMove = new TouchEvent(e2Id, Collections.singletonList(e2TS), Collections.singletonList(new TouchCoord(e2x + movingStep, e2y + movingStep)));
+		TouchEvent touchEvent2AfterMovingPointer = new TouchEvent(e2Id, Collections.singletonList(e2TS), Collections.singletonList(new TouchCoord(e2x + movingStep, e2y + movingStep)));
 		TouchEvent touchEvent3 = new TouchEvent(e3Id, Collections.singletonList(e3TS), Collections.singletonList(new TouchCoord(e3x, e3y)));
-		TouchEvent touchEvent3AfterMove = new TouchEvent(e3Id, Collections.singletonList(e3TS), Collections.singletonList(new TouchCoord(e3x + movingStep, e3y + movingStep)));
 
 
 
@@ -292,5 +290,146 @@ public class VideoStreamManagerTests extends AndroidTestCase2 {
 
 
 
+		/////////////////////////////////////////////////// Second OnTouchEvent Notification ///////////////////////////////////////////////////
+		testOnTouchEvent = new OnTouchEvent(TouchType.BEGIN, Arrays.asList(touchEvent3));
+		motionEventList = videoStreamManager.convertTouchEvent(testOnTouchEvent);
+
+
+		// First MotionEvent should be ACTION_POINTER_DOWN and have 3 pointers
+		motionEvent = motionEventList.get(0);
+		assertEquals(3, motionEvent.getPointerCount());
+		assertEquals(e1x, Math.round(motionEvent.getX(0)));
+		assertEquals(e1y, Math.round(motionEvent.getY(0)));
+		assertEquals(e2x, Math.round(motionEvent.getX(1)));
+		assertEquals(e2y, Math.round(motionEvent.getY(1)));
+		assertEquals(e3x, Math.round(motionEvent.getX(2)));
+		assertEquals(e3y, Math.round(motionEvent.getY(2)));
+		assertEquals(MotionEvent.ACTION_POINTER_DOWN, motionEvent.getActionMasked());
+		////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+
+		/////////////////////////////////////////////////// Third OnTouchEvent Notification ///////////////////////////////////////////////////
+		testOnTouchEvent = new OnTouchEvent(TouchType.MOVE, Arrays.asList(touchEvent2AfterMovingPointer));
+		motionEventList = videoStreamManager.convertTouchEvent(testOnTouchEvent);
+
+
+		// First MotionEvent should be ACTION_MOVE and have 3 pointers
+		motionEvent = motionEventList.get(0);
+		assertEquals(3, motionEvent.getPointerCount());
+		assertEquals(e1x, Math.round(motionEvent.getX(0)));
+		assertEquals(e1y, Math.round(motionEvent.getY(0)));
+		assertEquals(e2x + movingStep, Math.round(motionEvent.getX(1)));
+		assertEquals(e2y + movingStep, Math.round(motionEvent.getY(1)));
+		assertEquals(e3x, Math.round(motionEvent.getX(2)));
+		assertEquals(e3y, Math.round(motionEvent.getY(2)));
+		assertEquals(MotionEvent.ACTION_MOVE, motionEvent.getActionMasked());
+		////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+
+        /////////////////////////////////////////////////// Fourth OnTouchEvent Notification ///////////////////////////////////////////////////
+        testOnTouchEvent = new OnTouchEvent(TouchType.END, Arrays.asList(touchEvent2AfterMovingPointer));
+        motionEventList = videoStreamManager.convertTouchEvent(testOnTouchEvent);
+
+
+        // First MotionEvent should be ACTION_POINTER_UP and have 3 pointers
+        motionEvent = motionEventList.get(0);
+        assertEquals(3, motionEvent.getPointerCount());
+        assertEquals(e1x, Math.round(motionEvent.getX(0)));
+        assertEquals(e1y, Math.round(motionEvent.getY(0)));
+        assertEquals(e2x + movingStep, Math.round(motionEvent.getX(1)));
+        assertEquals(e2y + movingStep, Math.round(motionEvent.getY(1)));
+        assertEquals(e3x, Math.round(motionEvent.getX(2)));
+        assertEquals(e3y, Math.round(motionEvent.getY(2)));
+        assertEquals(MotionEvent.ACTION_POINTER_UP, motionEvent.getActionMasked());
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+
+        /////////////////////////////////////////////////// Fifth OnTouchEvent Notification ///////////////////////////////////////////////////
+        testOnTouchEvent = new OnTouchEvent(TouchType.END, Arrays.asList(touchEvent3));
+        motionEventList = videoStreamManager.convertTouchEvent(testOnTouchEvent);
+
+
+        // First MotionEvent should be ACTION_POINTER_UP and have 2 pointers
+        motionEvent = motionEventList.get(0);
+        assertEquals(2, motionEvent.getPointerCount());
+        assertEquals(e1x, Math.round(motionEvent.getX(0)));
+        assertEquals(e1y, Math.round(motionEvent.getY(0)));
+        assertEquals(e3x, Math.round(motionEvent.getX(1)));
+        assertEquals(e3y, Math.round(motionEvent.getY(1)));
+        assertEquals(MotionEvent.ACTION_POINTER_UP, motionEvent.getActionMasked());
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+
+		/////////////////////////////////////////////////// Sixth OnTouchEvent Notification ///////////////////////////////////////////////////
+		testOnTouchEvent = new OnTouchEvent(TouchType.END, Arrays.asList(touchEvent3));
+		motionEventList = videoStreamManager.convertTouchEvent(testOnTouchEvent);
+
+
+		// First MotionEvent should be ACTION_UP and have 1 pointer
+		motionEvent = motionEventList.get(0);
+		assertEquals(1, motionEvent.getPointerCount());
+		assertEquals(e1x, Math.round(motionEvent.getX(0)));
+		assertEquals(e1y, Math.round(motionEvent.getY(0)));
+		assertEquals(MotionEvent.ACTION_UP, motionEvent.getActionMasked());
+		////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+
+		/////////////////////////////////////////////////// Seventh OnTouchEvent Notification ///////////////////////////////////////////////////
+		testOnTouchEvent = new OnTouchEvent(TouchType.BEGIN, Arrays.asList(touchEvent1, touchEvent2));
+		motionEventList = videoStreamManager.convertTouchEvent(testOnTouchEvent);
+
+		// First MotionEvent should be ACTION_DOWN and have 1 pointer
+		motionEvent = motionEventList.get(0);
+		assertEquals(1, motionEvent.getPointerCount());
+		assertEquals(e1x, Math.round(motionEvent.getX(0)));
+		assertEquals(e1y, Math.round(motionEvent.getY(0)));
+		assertEquals(MotionEvent.ACTION_DOWN, motionEvent.getAction());
+
+
+		// Second MotionEvent should be ACTION_POINTER_DOWN and have 2 pointers
+		motionEvent = motionEventList.get(1);
+		assertEquals(2, motionEvent.getPointerCount());
+		assertEquals(e1x, Math.round(motionEvent.getX(0)));
+		assertEquals(e1y, Math.round(motionEvent.getY(0)));
+		assertEquals(e2x, Math.round(motionEvent.getX(1)));
+		assertEquals(e2y, Math.round(motionEvent.getY(1)));
+		assertEquals(MotionEvent.ACTION_POINTER_DOWN, motionEvent.getActionMasked());
+		////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+
+		/////////////////////////////////////////////////// Eighth OnTouchEvent Notification ///////////////////////////////////////////////////
+		testOnTouchEvent = new OnTouchEvent(TouchType.CANCEL, Arrays.asList(touchEvent3));
+		motionEventList = videoStreamManager.convertTouchEvent(testOnTouchEvent);
+
+
+		// First MotionEvent should be ACTION_CANCEL and have 2 pointers
+		motionEvent = motionEventList.get(0);
+		assertEquals(2, motionEvent.getPointerCount());
+		assertEquals(e1x, Math.round(motionEvent.getX(0)));
+		assertEquals(e1y, Math.round(motionEvent.getY(0)));
+		assertEquals(e2x, Math.round(motionEvent.getX(1)));
+		assertEquals(e2y, Math.round(motionEvent.getY(1)));
+		assertEquals(MotionEvent.ACTION_CANCEL, motionEvent.getActionMasked());
+		////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+
+		/////////////////////////////////////////////////// Ninth OnTouchEvent Notification ///////////////////////////////////////////////////
+		testOnTouchEvent = new OnTouchEvent(TouchType.BEGIN, Arrays.asList(touchEvent1));
+		motionEventList = videoStreamManager.convertTouchEvent(testOnTouchEvent);
+
+		// First MotionEvent should be ACTION_DOWN and have 1 pointer
+		motionEvent = motionEventList.get(0);
+		assertEquals(1, motionEvent.getPointerCount());
+		assertEquals(e1x, Math.round(motionEvent.getX(0)));
+		assertEquals(e1y, Math.round(motionEvent.getY(0)));
+		assertEquals(MotionEvent.ACTION_DOWN, motionEvent.getAction());
+		////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	}
 }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -544,6 +544,7 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 
 			if(motionEventAction == MotionEvent.ACTION_UP || motionEventAction == MotionEvent.ACTION_CANCEL){
 				//If the motion event should be finished we should clear our reference
+				sdlMotionEvent.pointers.clear();
 				sdlMotionEvent = null;
 				break;
 			} else if((motionEventAction & MotionEvent.ACTION_MASK) == MotionEvent.ACTION_POINTER_UP){

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -478,6 +478,26 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 		}
 	}
 
+	@Override
+	protected void onTransportUpdate(List<TransportRecord> connectedTransports, boolean audioStreamTransportAvail, boolean videoStreamTransportAvail){
+
+		isTransportAvailable = videoStreamTransportAvail;
+
+		if(internalInterface.getProtocolVersion().isNewerThan(new Version(5,1,0)) >= 0){
+			if(videoStreamTransportAvail){
+				checkState();
+			}
+		}else{
+			//The protocol version doesn't support simultaneous transports.
+			if(!videoStreamTransportAvail){
+				//If video streaming isn't available on primary transport then it is not possible to
+				//use the video streaming manager until a complete register on a transport that
+				//supports video
+				transitionToState(ERROR);
+			}
+		}
+	}
+
 	List<MotionEvent> convertTouchEvent(OnTouchEvent onTouchEvent){
 		List<MotionEvent> motionEventList = new ArrayList<MotionEvent>();
 
@@ -648,26 +668,6 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 
 		void removePointerById(int id){
 			pointers.remove(getPointerById(id));
-		}
-	}
-
-	@Override
-	protected void onTransportUpdate(List<TransportRecord> connectedTransports, boolean audioStreamTransportAvail, boolean videoStreamTransportAvail){
-
-		isTransportAvailable = videoStreamTransportAvail;
-
-		if(internalInterface.getProtocolVersion().isNewerThan(new Version(5,1,0)) >= 0){
-			if(videoStreamTransportAvail){
-				checkState();
-			}
-		}else{
-			//The protocol version doesn't support simultaneous transports.
-			if(!videoStreamTransportAvail){
-				//If video streaming isn't available on primary transport then it is not possible to
-				//use the video streaming manager until a complete register on a transport that
-				//supports video
-				transitionToState(ERROR);
-			}
 		}
 	}
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -152,8 +152,10 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 		public void onNotified(RPCNotification notification) {
 			if(notification != null && remoteDisplay != null){
 				List<MotionEvent> motionEventList = convertTouchEvent((OnTouchEvent)notification);
-				for (MotionEvent motionEvent : motionEventList) {
-					remoteDisplay.handleMotionEvent(motionEvent);
+				if (motionEventList != null && !motionEventList.isEmpty()) {
+					for (MotionEvent motionEvent : motionEventList) {
+						remoteDisplay.handleMotionEvent(motionEvent);
+					}
 				}
 			}
 		}
@@ -489,7 +491,7 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 			if (touchType == TouchType.BEGIN) {
 				sdlMotionEvent = new SdlMotionEvent();
 			} else{
-				return motionEventList;
+				return null;
 			}
 		}
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -73,6 +73,7 @@ import com.smartdevicelink.util.Version;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.FutureTask;
 
 @TargetApi(19)
@@ -594,7 +595,7 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 			}
 		}
 
-		private List<Pointer> pointers = new ArrayList<>();
+		private CopyOnWriteArrayList<Pointer> pointers = new CopyOnWriteArrayList<>();
 		private long downTime;
 		private long downTimeOnHMI;
 		private long eventTime;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -633,7 +633,7 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 					eventTime = downTime + touchEvent.getTimestamps().get(touchEvent.getTimestamps().size() - 1) - downTimeOnHMI;
 					break;
 				case END:
-					if(pointers.size() == 0){
+					if(pointers.size() <= 1){
 						//The motion event has just ended
 						motionEventAction = MotionEvent.ACTION_UP;
 					} else {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -37,7 +37,6 @@ import android.content.Context;
 import android.os.SystemClock;
 import android.util.DisplayMetrics;
 import android.util.Log;
-import android.util.SparseIntArray;
 import android.view.Display;
 import android.view.InputDevice;
 import android.view.MotionEvent;
@@ -72,6 +71,7 @@ import com.smartdevicelink.transport.utl.TransportRecord;
 import com.smartdevicelink.util.Version;
 
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.FutureTask;
 
@@ -151,9 +151,9 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 		@Override
 		public void onNotified(RPCNotification notification) {
 			if(notification != null && remoteDisplay != null){
-				MotionEvent event = convertTouchEvent((OnTouchEvent)notification);
-				if(event!=null){
-					remoteDisplay.handleMotionEvent(event);
+				List<MotionEvent> motionEventList = convertTouchEvent((OnTouchEvent)notification);
+				for (MotionEvent motionEvent : motionEventList) {
+					remoteDisplay.handleMotionEvent(motionEvent);
 				}
 			}
 		}
@@ -476,145 +476,175 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 		}
 	}
 
-	protected MotionEvent convertTouchEvent(OnTouchEvent touchEvent){
-		List<TouchEvent> eventList = touchEvent.getEvent();
-		if (eventList == null || eventList.size() == 0) return null;
+	List<MotionEvent> convertTouchEvent(OnTouchEvent onTouchEvent){
+		List<MotionEvent> motionEventList = new ArrayList<MotionEvent>();
 
-		TouchType touchType = touchEvent.getType();
-		if (touchType == null){ return null;}
+		List<TouchEvent> touchEventList = onTouchEvent.getEvent();
+		if (touchEventList == null || touchEventList.size() == 0) return null;
 
-		int eventListSize = eventList.size();
-
-		MotionEvent.PointerProperties[] pointerProperties = new MotionEvent.PointerProperties[eventListSize];
-		MotionEvent.PointerCoords[] pointerCoords = new MotionEvent.PointerCoords[eventListSize];
-
-		TouchEvent event;
-		MotionEvent.PointerProperties properties;
-		MotionEvent.PointerCoords coords;
-		TouchCoord touchCoord;
-
-		for(int i = 0; i < eventListSize; i++){
-			event = eventList.get(i);
-			if(event == null || event.getId() == null || event.getTouchCoordinates() == null){
-				continue;
-			}
-
-			properties = new MotionEvent.PointerProperties();
-			properties.id = event.getId();
-			properties.toolType = MotionEvent.TOOL_TYPE_FINGER;
-
-
-			List<TouchCoord> coordList = event.getTouchCoordinates();
-			if (coordList == null || coordList.size() == 0){ continue; }
-
-			touchCoord = coordList.get(coordList.size() -1);
-			if(touchCoord == null){ continue; }
-
-			coords = new MotionEvent.PointerCoords();
-			coords.x = touchCoord.getX() * touchScalar[0];
-			coords.y = touchCoord.getY() * touchScalar[1];
-			coords.orientation = 0;
-			coords.pressure = 1.0f;
-			coords.size = 1;
-
-			//Add the info to lists only after we are sure we have all available info
-			pointerProperties[i] = properties;
-			pointerCoords[i] = coords;
-
-		}
-
+		TouchType touchType = onTouchEvent.getType();
+		if (touchType == null) { return null; }
 
 		if(sdlMotionEvent == null) {
 			if (touchType == TouchType.BEGIN) {
 				sdlMotionEvent = new SdlMotionEvent();
-			}else{
-				return  null;
+			} else{
+				return motionEventList;
 			}
 		}
 
-		int eventAction = sdlMotionEvent.getMotionEvent(touchType, pointerProperties);
-		long startTime = sdlMotionEvent.startOfEvent;
+		SdlMotionEvent.Pointer pointer;
+		MotionEvent motionEvent;
 
-		//If the motion event should be finished we should clear our reference
-		if(eventAction == MotionEvent.ACTION_UP || eventAction == MotionEvent.ACTION_CANCEL){
-			sdlMotionEvent = null;
+		for (TouchEvent touchEvent : touchEventList) {
+			if (touchEvent == null || touchEvent.getId() == null) {
+				continue;
+			}
+
+			List<TouchCoord> touchCoordList = touchEvent.getTouchCoordinates();
+			if (touchCoordList == null || touchCoordList.size() == 0) {
+				continue;
+			}
+
+			TouchCoord touchCoord = touchCoordList.get(touchCoordList.size() - 1);
+			if (touchCoord == null) {
+				continue;
+			}
+
+			int motionEventAction = sdlMotionEvent.getMotionEventAction(touchType, touchEvent);
+			long downTime = sdlMotionEvent.downTime;
+			long eventTime = sdlMotionEvent.eventTime;
+			pointer = sdlMotionEvent.getPointerById(touchEvent.getId());
+			if (pointer != null) {
+				pointer.setCoords(touchCoord.getX() * touchScalar[0], touchCoord.getY() * touchScalar[1]);
+			}
+
+			MotionEvent.PointerProperties[] pointerProperties;
+			MotionEvent.PointerCoords[] pointerCoords;
+			pointerProperties = new MotionEvent.PointerProperties[sdlMotionEvent.pointers.size()];
+			pointerCoords = new MotionEvent.PointerCoords[sdlMotionEvent.pointers.size()];
+
+			for (int i = 0; i < sdlMotionEvent.pointers.size(); i++) {
+				pointerProperties[i] = new MotionEvent.PointerProperties();
+				pointerProperties[i].id = sdlMotionEvent.getPointerByIndex(i).id;
+				pointerProperties[i].toolType = MotionEvent.TOOL_TYPE_FINGER;
+
+				pointerCoords[i] = new MotionEvent.PointerCoords();
+				pointerCoords[i].x = sdlMotionEvent.getPointerByIndex(i).x;
+				pointerCoords[i].y = sdlMotionEvent.getPointerByIndex(i).y;
+				pointerCoords[i].orientation = 0;
+				pointerCoords[i].pressure = 1.0f;
+				pointerCoords[i].size = 1;
+			}
+
+			motionEvent = MotionEvent.obtain(downTime, eventTime, motionEventAction,
+					sdlMotionEvent.pointers.size(), pointerProperties, pointerCoords, 0, 0, 1,
+					1, 0, 0, InputDevice.SOURCE_TOUCHSCREEN, 0);
+			motionEventList.add(motionEvent);
+
+			if(motionEventAction == MotionEvent.ACTION_UP || motionEventAction == MotionEvent.ACTION_CANCEL){
+				//If the motion event should be finished we should clear our reference
+				sdlMotionEvent = null;
+				break;
+			} else if((motionEventAction & MotionEvent.ACTION_MASK) == MotionEvent.ACTION_POINTER_UP){
+				sdlMotionEvent.removePointerById(touchEvent.getId());
+			}
 		}
 
-		return MotionEvent.obtain(startTime, SystemClock.uptimeMillis(), eventAction, eventListSize, pointerProperties, pointerCoords, 0, 0,1,1,0,0, InputDevice.SOURCE_TOUCHSCREEN,0);
+		return motionEventList;
 	}
 
 	/**
 	 * Keeps track of the current motion event for VPM
 	 */
-	private static class SdlMotionEvent{
-		long startOfEvent;
-		SparseIntArray pointerStatuses = new SparseIntArray();
+	private static class SdlMotionEvent {
+		class Pointer {
+			int id;
+			float x;
+			float y;
+			Pointer (int id) {
+				this.id = id;
+				this.x = 0.0f;
+				this.y = 0.0f;
+			}
+			void setCoords(float x, float y) {
+				this.x = x;
+				this.y = y;
+			}
+		}
+
+		private List<Pointer> pointers = new ArrayList<>();
+		private long downTime;
+		private long downTimeOnHMI;
+		private long eventTime;
 
 		SdlMotionEvent(){
-			startOfEvent = SystemClock.uptimeMillis();
+			downTimeOnHMI = 0;
 		}
 
 		/**
-		 * Handles the SDL Touch Event to keep track of pointer status and returns the appropirate
+		 * Handles the SDL Touch Event to keep track of pointer status and returns the appropriate
 		 * Android MotionEvent according to this events status
 		 * @param touchType The SDL TouchType that was received from the module
-		 * @param pointerProperties the parsed pointer properties built from the OnTouchEvent RPC
-		 * @return the correct native Andorid MotionEvent action to dispatch
+		 * @param touchEvent The SDL TouchEvent that was received from the module
+		 * @return the correct native Android MotionEvent action to dispatch
 		 */
-		synchronized int  getMotionEvent(TouchType touchType, MotionEvent.PointerProperties[] pointerProperties){
-			int motionEvent = MotionEvent.ACTION_DOWN;
+		synchronized int getMotionEventAction(TouchType touchType, TouchEvent touchEvent){
+			eventTime = 0;
+			int motionEventAction = -1;
 			switch (touchType){
 				case BEGIN:
-					if(pointerStatuses.size() == 0){
+					if(pointers.size() == 0){
 						//The motion event has just begun
-						motionEvent = MotionEvent.ACTION_DOWN;
-					}else{
-						motionEvent = MotionEvent.ACTION_POINTER_DOWN;
+						motionEventAction = MotionEvent.ACTION_DOWN;
+						downTime = SystemClock.uptimeMillis();
+						downTimeOnHMI = touchEvent.getTimestamps().get(touchEvent.getTimestamps().size() - 1);
+						eventTime = downTime;
+					} else{
+						motionEventAction = MotionEvent.ACTION_POINTER_DOWN | pointers.size() << MotionEvent.ACTION_POINTER_INDEX_SHIFT;
+						eventTime = downTime + touchEvent.getTimestamps().get(touchEvent.getTimestamps().size() - 1) - downTimeOnHMI;
 					}
-					setPointerStatuses(motionEvent, pointerProperties);
+					pointers.add(new Pointer(touchEvent.getId()));
 					break;
 				case MOVE:
-					motionEvent = MotionEvent.ACTION_MOVE;
-					setPointerStatuses(motionEvent, pointerProperties);
-
+					motionEventAction = MotionEvent.ACTION_MOVE;
+					eventTime = downTime + touchEvent.getTimestamps().get(touchEvent.getTimestamps().size() - 1) - downTimeOnHMI;
 					break;
 				case END:
-					//Clears out pointers that have ended
-					setPointerStatuses(MotionEvent.ACTION_UP, pointerProperties);
-
-					if(pointerStatuses.size() == 0){
+					if(pointers.size() > 1){
+						motionEventAction = MotionEvent.ACTION_POINTER_UP | pointers.indexOf(getPointerById(touchEvent.getId())) << MotionEvent.ACTION_POINTER_INDEX_SHIFT;
+					} else{
 						//The motion event has just ended
-						motionEvent = MotionEvent.ACTION_UP;
-					}else{
-						motionEvent = MotionEvent.ACTION_POINTER_UP;
+						motionEventAction = MotionEvent.ACTION_UP;
 					}
+					eventTime = downTime + touchEvent.getTimestamps().get(touchEvent.getTimestamps().size() - 1) - downTimeOnHMI;
 					break;
 				case CANCEL:
 					//Assuming this cancels the entire event
-					motionEvent = MotionEvent.ACTION_CANCEL;
-					pointerStatuses.clear();
+					motionEventAction = MotionEvent.ACTION_CANCEL;
+					eventTime = downTime + touchEvent.getTimestamps().get(touchEvent.getTimestamps().size() - 1) - downTimeOnHMI;
 					break;
 				default:
 					break;
 			}
-			return motionEvent;
+			return motionEventAction;
 		}
 
-		private void setPointerStatuses(int motionEvent, MotionEvent.PointerProperties[] pointerProperties){
-
-			for(int i = 0; i < pointerProperties.length; i ++){
-				MotionEvent.PointerProperties properties = pointerProperties[i];
-				if(properties != null){
-					if(motionEvent == MotionEvent.ACTION_UP || motionEvent == MotionEvent.ACTION_POINTER_UP){
-						pointerStatuses.delete(properties.id);
-					}else if(motionEvent == MotionEvent.ACTION_DOWN && properties.id == 0){
-						pointerStatuses.put(properties.id, MotionEvent.ACTION_DOWN);
-					}else{
-						pointerStatuses.put(properties.id, motionEvent);
-					}
-
+		Pointer getPointerById(int id){
+			for (Pointer pointer : pointers){
+				if (pointer.id == id){
+					return pointer;
 				}
 			}
+			return null;
+		}
+
+		Pointer getPointerByIndex(int index){
+			return pointers.get(index);
+		}
+
+		void removePointerById(int id){
+			pointers.remove(getPointerById(id));
 		}
 	}
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -632,11 +632,16 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 					eventTime = downTime + touchEvent.getTimestamps().get(touchEvent.getTimestamps().size() - 1) - downTimeOnHMI;
 					break;
 				case END:
-					if(pointers.size() > 1){
-						motionEventAction = MotionEvent.ACTION_POINTER_UP | pointers.indexOf(getPointerById(touchEvent.getId())) << MotionEvent.ACTION_POINTER_INDEX_SHIFT;
-					} else{
+					if(pointers.size() == 0){
 						//The motion event has just ended
 						motionEventAction = MotionEvent.ACTION_UP;
+					} else {
+						int pointerIndex = pointers.indexOf(getPointerById(touchEvent.getId()));
+						if (pointerIndex != -1) {
+							motionEventAction = MotionEvent.ACTION_POINTER_UP | pointerIndex << MotionEvent.ACTION_POINTER_INDEX_SHIFT;
+						} else {
+							motionEventAction = MotionEvent.ACTION_UP;
+						}
 					}
 					eventTime = downTime + touchEvent.getTimestamps().get(touchEvent.getTimestamps().size() - 1) - downTimeOnHMI;
 					break;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -521,10 +521,8 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 				pointer.setCoords(touchCoord.getX() * touchScalar[0], touchCoord.getY() * touchScalar[1]);
 			}
 
-			MotionEvent.PointerProperties[] pointerProperties;
-			MotionEvent.PointerCoords[] pointerCoords;
-			pointerProperties = new MotionEvent.PointerProperties[sdlMotionEvent.pointers.size()];
-			pointerCoords = new MotionEvent.PointerCoords[sdlMotionEvent.pointers.size()];
+			MotionEvent.PointerProperties[] pointerProperties = new MotionEvent.PointerProperties[sdlMotionEvent.pointers.size()];
+			MotionEvent.PointerCoords[] pointerCoords = new MotionEvent.PointerCoords[sdlMotionEvent.pointers.size()];
 
 			for (int i = 0; i < sdlMotionEvent.pointers.size(); i++) {
 				pointerProperties[i] = new MotionEvent.PointerProperties();
@@ -634,9 +632,11 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 		}
 
 		Pointer getPointerById(int id){
-			for (Pointer pointer : pointers){
-				if (pointer.id == id){
-					return pointer;
+			if (pointers != null && !pointers.isEmpty()){
+				for (Pointer pointer : pointers){
+					if (pointer.id == id){
+						return pointer;
+					}
 				}
 			}
 			return null;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -45,7 +45,6 @@ import android.telephony.TelephonyManager;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.SparseArray;
-import android.util.SparseIntArray;
 import android.view.Display;
 import android.view.InputDevice;
 import android.view.MotionEvent;
@@ -8131,6 +8130,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 
 				if (motionEventAction == MotionEvent.ACTION_UP || motionEventAction == MotionEvent.ACTION_CANCEL) {
 					//If the motion event should be finished we should clear our reference
+					sdlMotionEvent.pointers.clear();
 					sdlMotionEvent = null;
 					break;
 				} else if ((motionEventAction & MotionEvent.ACTION_MASK) == MotionEvent.ACTION_POINTER_UP) {
@@ -8163,7 +8163,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			}
 		}
 
-		private List<Pointer> pointers = new ArrayList<>();
+		private CopyOnWriteArrayList<Pointer> pointers = new CopyOnWriteArrayList<>();
 		private long downTime;
 		private long downTimeOnHMI;
 		private long eventTime;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -8202,11 +8202,16 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					eventTime = downTime + touchEvent.getTimestamps().get(touchEvent.getTimestamps().size() - 1) - downTimeOnHMI;
 					break;
 				case END:
-					if (pointers.size() > 1) {
-						motionEventAction = MotionEvent.ACTION_POINTER_UP | pointers.indexOf(getPointerById(touchEvent.getId())) << MotionEvent.ACTION_POINTER_INDEX_SHIFT;
-					} else {
+					if(pointers.size() == 0){
 						//The motion event has just ended
 						motionEventAction = MotionEvent.ACTION_UP;
+					} else {
+						int pointerIndex = pointers.indexOf(getPointerById(touchEvent.getId()));
+						if (pointerIndex != -1) {
+							motionEventAction = MotionEvent.ACTION_POINTER_UP | pointerIndex << MotionEvent.ACTION_POINTER_INDEX_SHIFT;
+						} else {
+							motionEventAction = MotionEvent.ACTION_UP;
+						}
 					}
 					eventTime = downTime + touchEvent.getTimestamps().get(touchEvent.getTimestamps().size() - 1) - downTimeOnHMI;
 					break;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -8108,10 +8108,8 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					pointer.setCoords(touchCoord.getX() * touchScalar[0], touchCoord.getY() * touchScalar[1]);
 				}
 
-				MotionEvent.PointerProperties[] pointerProperties;
-				MotionEvent.PointerCoords[] pointerCoords;
-				pointerProperties = new MotionEvent.PointerProperties[sdlMotionEvent.pointers.size()];
-				pointerCoords = new MotionEvent.PointerCoords[sdlMotionEvent.pointers.size()];
+				MotionEvent.PointerProperties[] pointerProperties = new MotionEvent.PointerProperties[sdlMotionEvent.pointers.size()];
+				MotionEvent.PointerCoords[] pointerCoords = new MotionEvent.PointerCoords[sdlMotionEvent.pointers.size()];
 
 				for (int i = 0; i < sdlMotionEvent.pointers.size(); i++) {
 					pointerProperties[i] = new MotionEvent.PointerProperties();
@@ -8224,9 +8222,11 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		}
 
 		Pointer getPointerById(int id) {
-			for (Pointer pointer : pointers) {
-				if (pointer.id == id) {
-					return pointer;
+			if (pointers != null && !pointers.isEmpty()) {
+				for (Pointer pointer : pointers) {
+					if (pointer.id == id) {
+						return pointer;
+					}
 				}
 			}
 			return null;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -8202,7 +8202,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					eventTime = downTime + touchEvent.getTimestamps().get(touchEvent.getTimestamps().size() - 1) - downTimeOnHMI;
 					break;
 				case END:
-					if(pointers.size() == 0){
+					if(pointers.size() <= 1){
 						//The motion event has just ended
 						motionEventAction = MotionEvent.ACTION_UP;
 					} else {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -7893,8 +7893,10 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				public void onNotified(RPCNotification notification) {
 					if (notification != null && remoteDisplay != null) {
 						List<MotionEvent> events = convertTouchEvent((OnTouchEvent) notification);
-						for (MotionEvent ev : events) {
-							remoteDisplay.handleMotionEvent(ev);
+						if (events != null && !events.isEmpty()) {
+							for (MotionEvent ev : events) {
+								remoteDisplay.handleMotionEvent(ev);
+							}
 						}
 					}
 				}
@@ -8076,7 +8078,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				if (touchType == TouchType.BEGIN) {
 					sdlMotionEvent = new SdlMotionEvent();
 				} else {
-					return motionEventList;
+					return null;
 				}
 			}
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -7891,10 +7891,10 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			internalInterface.addOnRPCNotificationListener(FunctionID.ON_TOUCH_EVENT, new OnRPCNotificationListener() {
 				@Override
 				public void onNotified(RPCNotification notification) {
-					if(notification !=null && remoteDisplay != null){
-						MotionEvent event = convertTouchEvent((OnTouchEvent)notification);
-						if(event!=null){
-							remoteDisplay.handleMotionEvent(event);
+					if (notification != null && remoteDisplay != null) {
+						List<MotionEvent> events = convertTouchEvent((OnTouchEvent) notification);
+						for (MotionEvent ev : events) {
+							remoteDisplay.handleMotionEvent(ev);
 						}
 					}
 				}
@@ -8061,150 +8061,182 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 
 		}
 
-		private MotionEvent convertTouchEvent(OnTouchEvent touchEvent){
-			List<TouchEvent> eventList = touchEvent.getEvent();
-			if (eventList == null || eventList.size() == 0) return null;
+		private List<MotionEvent> convertTouchEvent(OnTouchEvent onTouchEvent) {
+			List<MotionEvent> motionEventList = new ArrayList<MotionEvent>();
 
-			TouchType touchType = touchEvent.getType();
-			if (touchType == null){ return null;}
+			List<TouchEvent> touchEventList = onTouchEvent.getEvent();
+			if (touchEventList == null || touchEventList.size() == 0) return null;
 
-			int eventListSize = eventList.size();
+			TouchType touchType = onTouchEvent.getType();
+			if (touchType == null) {
+				return null;
+			}
 
-			MotionEvent.PointerProperties[] pointerProperties = new MotionEvent.PointerProperties[eventListSize];
-			MotionEvent.PointerCoords[] pointerCoords = new MotionEvent.PointerCoords[eventListSize];
+			if (sdlMotionEvent == null) {
+				if (touchType == TouchType.BEGIN) {
+					sdlMotionEvent = new SdlMotionEvent();
+				} else {
+					return motionEventList;
+				}
+			}
 
-			TouchEvent event;
-			MotionEvent.PointerProperties properties;
-			MotionEvent.PointerCoords coords;
-			TouchCoord touchCoord;
+			SdlMotionEvent.Pointer pointer;
+			MotionEvent motionEvent;
 
-			for(int i = 0; i < eventListSize; i++){
-				event = eventList.get(i);
-				if(event == null || event.getId() == null || event.getTouchCoordinates() == null){
+			for (TouchEvent touchEvent : touchEventList) {
+				if (touchEvent == null || touchEvent.getId() == null) {
 					continue;
 				}
 
-				properties = new MotionEvent.PointerProperties();
-				properties.id = event.getId();
-				properties.toolType = MotionEvent.TOOL_TYPE_FINGER;
+				List<TouchCoord> touchCoordList = touchEvent.getTouchCoordinates();
+				if (touchCoordList == null || touchCoordList.size() == 0) {
+					continue;
+				}
 
+				TouchCoord touchCoord = touchCoordList.get(touchCoordList.size() - 1);
+				if (touchCoord == null) {
+					continue;
+				}
 
-				List<TouchCoord> coordList = event.getTouchCoordinates();
-				if (coordList == null || coordList.size() == 0){ continue; }
+				int motionEventAction = sdlMotionEvent.getMotionEventAction(touchType, touchEvent);
+				long downTime = sdlMotionEvent.downTime;
+				long eventTime = sdlMotionEvent.eventTime;
+				pointer = sdlMotionEvent.getPointerById(touchEvent.getId());
+				if (pointer != null) {
+					pointer.setCoords(touchCoord.getX() * touchScalar[0], touchCoord.getY() * touchScalar[1]);
+				}
 
-				touchCoord = coordList.get(coordList.size() -1);
-				if(touchCoord == null){ continue; }
+				MotionEvent.PointerProperties[] pointerProperties;
+				MotionEvent.PointerCoords[] pointerCoords;
+				pointerProperties = new MotionEvent.PointerProperties[sdlMotionEvent.pointers.size()];
+				pointerCoords = new MotionEvent.PointerCoords[sdlMotionEvent.pointers.size()];
 
-				coords = new MotionEvent.PointerCoords();
-				coords.x = touchCoord.getX() * touchScalar[0];
-				coords.y = touchCoord.getY() * touchScalar[1];
-				coords.orientation = 0;
-				coords.pressure = 1.0f;
-				coords.size = 1;
+				for (int i = 0; i < sdlMotionEvent.pointers.size(); i++) {
+					pointerProperties[i] = new MotionEvent.PointerProperties();
+					pointerProperties[i].id = sdlMotionEvent.getPointerByIndex(i).id;
+					pointerProperties[i].toolType = MotionEvent.TOOL_TYPE_FINGER;
 
-				//Add the info to lists only after we are sure we have all available info
-				pointerProperties[i] = properties;
-				pointerCoords[i] = coords;
+					pointerCoords[i] = new MotionEvent.PointerCoords();
+					pointerCoords[i].x = sdlMotionEvent.getPointerByIndex(i).x;
+					pointerCoords[i].y = sdlMotionEvent.getPointerByIndex(i).y;
+					pointerCoords[i].orientation = 0;
+					pointerCoords[i].pressure = 1.0f;
+					pointerCoords[i].size = 1;
+				}
 
-			}
+				motionEvent = MotionEvent.obtain(downTime, eventTime, motionEventAction,
+						sdlMotionEvent.pointers.size(), pointerProperties, pointerCoords, 0, 0, 1,
+						1, 0, 0, InputDevice.SOURCE_TOUCHSCREEN, 0);
+				motionEventList.add(motionEvent);
 
-
-			if(sdlMotionEvent == null) {
-				if (touchType == TouchType.BEGIN) {
-					sdlMotionEvent = new SdlMotionEvent();
-				}else{
-					return  null;
+				if (motionEventAction == MotionEvent.ACTION_UP || motionEventAction == MotionEvent.ACTION_CANCEL) {
+					//If the motion event should be finished we should clear our reference
+					sdlMotionEvent = null;
+					break;
+				} else if ((motionEventAction & MotionEvent.ACTION_MASK) == MotionEvent.ACTION_POINTER_UP) {
+					sdlMotionEvent.removePointerById(touchEvent.getId());
 				}
 			}
 
-			int eventAction = sdlMotionEvent.getMotionEvent(touchType, pointerProperties);
-			long startTime = sdlMotionEvent.startOfEvent;
-
-			//If the motion event should be finished we should clear our reference
-			if(eventAction == MotionEvent.ACTION_UP || eventAction == MotionEvent.ACTION_CANCEL){
-				sdlMotionEvent = null;
-			}
-
-			return MotionEvent.obtain(startTime, SystemClock.uptimeMillis(), eventAction, eventListSize, pointerProperties, pointerCoords, 0, 0,1,1,0,0, InputDevice.SOURCE_TOUCHSCREEN,0);
-
+			return motionEventList;
 		}
-
-
-
 	}
 
 	/**
 	 * Keeps track of the current motion event for VPM
 	 */
-	private static class SdlMotionEvent{
-		long startOfEvent;
-		SparseIntArray pointerStatuses = new SparseIntArray();
+	private static class SdlMotionEvent {
+		class Pointer {
+			int id;
+			float x;
+			float y;
 
-		SdlMotionEvent(){
-			startOfEvent = SystemClock.uptimeMillis();
+			Pointer(int id) {
+				this.id = id;
+				this.x = 0.0f;
+				this.y = 0.0f;
+			}
+
+			void setCoords(float x, float y) {
+				this.x = x;
+				this.y = y;
+			}
+		}
+
+		private List<Pointer> pointers = new ArrayList<>();
+		private long downTime;
+		private long downTimeOnHMI;
+		private long eventTime;
+
+		SdlMotionEvent() {
+			downTimeOnHMI = 0;
 		}
 
 		/**
-		 * Handles the SDL Touch Event to keep track of pointer status and returns the appropirate
+		 * Handles the SDL Touch Event to keep track of pointer status and returns the appropriate
 		 * Android MotionEvent according to this events status
-		 * @param touchType The SDL TouchType that was received from the module
-		 * @param pointerProperties the parsed pointer properties built from the OnTouchEvent RPC
-		 * @return the correct native Andorid MotionEvent action to dispatch
+		 *
+		 * @param touchType  The SDL TouchType that was received from the module
+		 * @param touchEvent The SDL TouchEvent that was received from the module
+		 * @return the correct native Android MotionEvent action to dispatch
 		 */
-		synchronized int  getMotionEvent(TouchType touchType, MotionEvent.PointerProperties[] pointerProperties){
-			int motionEvent = MotionEvent.ACTION_DOWN;
-			switch (touchType){
+		synchronized int getMotionEventAction(TouchType touchType, TouchEvent touchEvent) {
+			eventTime = 0;
+			int motionEventAction = -1;
+			switch (touchType) {
 				case BEGIN:
-					if(pointerStatuses.size() == 0){
+					if (pointers.size() == 0) {
 						//The motion event has just begun
-						motionEvent = MotionEvent.ACTION_DOWN;
-					}else{
-						motionEvent = MotionEvent.ACTION_POINTER_DOWN;
+						motionEventAction = MotionEvent.ACTION_DOWN;
+						downTime = SystemClock.uptimeMillis();
+						downTimeOnHMI = touchEvent.getTimestamps().get(touchEvent.getTimestamps().size() - 1);
+						eventTime = downTime;
+					} else {
+						motionEventAction = MotionEvent.ACTION_POINTER_DOWN | pointers.size() << MotionEvent.ACTION_POINTER_INDEX_SHIFT;
+						eventTime = downTime + touchEvent.getTimestamps().get(touchEvent.getTimestamps().size() - 1) - downTimeOnHMI;
 					}
-					setPointerStatuses(motionEvent, pointerProperties);
+					pointers.add(new Pointer(touchEvent.getId()));
 					break;
 				case MOVE:
-					motionEvent = MotionEvent.ACTION_MOVE;
-					setPointerStatuses(motionEvent, pointerProperties);
-
+					motionEventAction = MotionEvent.ACTION_MOVE;
+					eventTime = downTime + touchEvent.getTimestamps().get(touchEvent.getTimestamps().size() - 1) - downTimeOnHMI;
 					break;
 				case END:
-					//Clears out pointers that have ended
-					setPointerStatuses(MotionEvent.ACTION_UP, pointerProperties);
-
-					if(pointerStatuses.size() == 0){
+					if (pointers.size() > 1) {
+						motionEventAction = MotionEvent.ACTION_POINTER_UP | pointers.indexOf(getPointerById(touchEvent.getId())) << MotionEvent.ACTION_POINTER_INDEX_SHIFT;
+					} else {
 						//The motion event has just ended
-						motionEvent = MotionEvent.ACTION_UP;
-					}else{
-						motionEvent = MotionEvent.ACTION_POINTER_UP;
+						motionEventAction = MotionEvent.ACTION_UP;
 					}
+					eventTime = downTime + touchEvent.getTimestamps().get(touchEvent.getTimestamps().size() - 1) - downTimeOnHMI;
 					break;
 				case CANCEL:
 					//Assuming this cancels the entire event
-					motionEvent = MotionEvent.ACTION_CANCEL;
-					pointerStatuses.clear();
+					motionEventAction = MotionEvent.ACTION_CANCEL;
+					eventTime = downTime + touchEvent.getTimestamps().get(touchEvent.getTimestamps().size() - 1) - downTimeOnHMI;
 					break;
 				default:
 					break;
 			}
-			return motionEvent;
+			return motionEventAction;
 		}
 
-		private void setPointerStatuses(int motionEvent, MotionEvent.PointerProperties[] pointerProperties){
-
-					for(int i = 0; i < pointerProperties.length; i ++){
-						MotionEvent.PointerProperties properties = pointerProperties[i];
-						if(properties != null){
-							if(motionEvent == MotionEvent.ACTION_UP || motionEvent == MotionEvent.ACTION_POINTER_UP){
-								pointerStatuses.delete(properties.id);
-							}else if(motionEvent == MotionEvent.ACTION_DOWN && properties.id == 0){
-								pointerStatuses.put(properties.id, MotionEvent.ACTION_DOWN);
-							}else{
-								pointerStatuses.put(properties.id, motionEvent);
-							}
-
-					}
+		Pointer getPointerById(int id) {
+			for (Pointer pointer : pointers) {
+				if (pointer.id == id) {
+					return pointer;
+				}
 			}
+			return null;
+		}
+
+		Pointer getPointerByIndex(int index) {
+			return pointers.get(index);
+		}
+
+		void removePointerById(int id) {
+			pointers.remove(getPointerById(id));
 		}
 	}
+
 } // end-class


### PR DESCRIPTION
Fixes #972 and it is based on #973 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests will be added to test converting one `OnTouchEvent` that has multiple `TouchEvents` to multiple `MotionEvents`

### Summary
-  Update `VideoStreamManager` to be able to convert one Sdl `OnTouchEvent` to multiple Android `MotionEvents`
-  Update `SdlProxyBase` to be able to convert one Sdl `OnTouchEvent` to multiple Android `MotionEvents`
- Pass list of all active pointers to `MotionEvent` so the developer can later get the correct number of active pointers from the `MotionEvent` and the coordinates for each pointer
- Update the converted `MotionEvent` actions to exactly match the native Android ones. For example, if the user touches the screen using two fingers at the same time, the action will be `ACTION_POINTER_DOWN (1)` instead of just `ACTION_POINTER_DOWN` for the second touch 

 ### Tasks Remaining:
- [x] [Update `VideoStreamManager`]
- [x] [Update `SdlProxyBase`]
- [x] [Write new tests]

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
