### PR TITLE
Update LeftRearInflatableBelted key to match RPC Specs 

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/BeltStatusTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/BeltStatusTests.java
@@ -107,7 +107,7 @@ public class BeltStatusTests extends TestCase{
 
         try{
             reference.put(BeltStatus.KEY_PASSENGER_CHILD_DETECTED, Test.GENERAL_VEHCILEDATAEVENTSTATUS);
-            reference.put(BeltStatus.KEY_REAR_INFLATABLE_BELTED, Test.GENERAL_VEHCILEDATAEVENTSTATUS);
+            reference.put(BeltStatus.KEY_LEFT_REAR_INFLATABLE_BELTED, Test.GENERAL_VEHCILEDATAEVENTSTATUS);
             reference.put(BeltStatus.KEY_RIGHT_REAR_INFLATABLE_BELTED, Test.GENERAL_VEHCILEDATAEVENTSTATUS);            
             reference.put(BeltStatus.KEY_DRIVER_BELT_DEPLOYED, Test.GENERAL_VEHCILEDATAEVENTSTATUS);
             reference.put(BeltStatus.KEY_DRIVER_BUCKLE_BELTED, Test.GENERAL_VEHCILEDATAEVENTSTATUS);

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/notifications/OnVehicleDataTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/notifications/OnVehicleDataTests.java
@@ -275,7 +275,7 @@ public class OnVehicleDataTests extends BaseRpcTests{
 			beltStatusObj.put(BeltStatus.KEY_MIDDLE_ROW_3_BUCKLE_BELTED, VehicleDataHelper.BELT_STATUS_MIDDLE_ROW_3_BELTED);
 			beltStatusObj.put(BeltStatus.KEY_LEFT_ROW_3_BUCKLE_BELTED, VehicleDataHelper.BELT_STATUS_LEFT_ROW_3_BELTED);
 			beltStatusObj.put(BeltStatus.KEY_RIGHT_ROW_3_BUCKLE_BELTED, VehicleDataHelper.BELT_STATUS_RIGHT_ROW_3_BELTED);
-			beltStatusObj.put(BeltStatus.KEY_REAR_INFLATABLE_BELTED, VehicleDataHelper.BELT_STATUS_LEFT_REAR_INFLATABLE_BELTED);
+			beltStatusObj.put(BeltStatus.KEY_LEFT_REAR_INFLATABLE_BELTED, VehicleDataHelper.BELT_STATUS_LEFT_REAR_INFLATABLE_BELTED);
 			beltStatusObj.put(BeltStatus.KEY_RIGHT_REAR_INFLATABLE_BELTED, VehicleDataHelper.BELT_STATUS_RIGHT_REAR_INFLATABLE_BELTED);
 			beltStatusObj.put(BeltStatus.KEY_MIDDLE_ROW_1_BELT_DEPLOYED, VehicleDataHelper.BELT_STATUS_MIDDLE_ROW_1_DEPLOYED);
 			beltStatusObj.put(BeltStatus.KEY_MIDDLE_ROW_1_BUCKLE_BELTED, VehicleDataHelper.BELT_STATUS_MIDDLE_ROW_1_BELTED);

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/responses/GetVehicleDataResponseTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/responses/GetVehicleDataResponseTests.java
@@ -170,7 +170,7 @@ public class GetVehicleDataResponseTests extends BaseRpcTests{
 			beltStatusObj.put(BeltStatus.KEY_MIDDLE_ROW_3_BUCKLE_BELTED, VehicleDataHelper.BELT_STATUS_MIDDLE_ROW_3_BELTED);
 			beltStatusObj.put(BeltStatus.KEY_LEFT_ROW_3_BUCKLE_BELTED, VehicleDataHelper.BELT_STATUS_LEFT_ROW_3_BELTED);
 			beltStatusObj.put(BeltStatus.KEY_RIGHT_ROW_3_BUCKLE_BELTED, VehicleDataHelper.BELT_STATUS_RIGHT_ROW_3_BELTED);
-			beltStatusObj.put(BeltStatus.KEY_REAR_INFLATABLE_BELTED, VehicleDataHelper.BELT_STATUS_LEFT_REAR_INFLATABLE_BELTED);
+			beltStatusObj.put(BeltStatus.KEY_LEFT_REAR_INFLATABLE_BELTED, VehicleDataHelper.BELT_STATUS_LEFT_REAR_INFLATABLE_BELTED);
 			beltStatusObj.put(BeltStatus.KEY_RIGHT_REAR_INFLATABLE_BELTED, VehicleDataHelper.BELT_STATUS_RIGHT_REAR_INFLATABLE_BELTED);
 			beltStatusObj.put(BeltStatus.KEY_MIDDLE_ROW_1_BELT_DEPLOYED, VehicleDataHelper.BELT_STATUS_MIDDLE_ROW_1_DEPLOYED);
 			beltStatusObj.put(BeltStatus.KEY_MIDDLE_ROW_1_BUCKLE_BELTED, VehicleDataHelper.BELT_STATUS_MIDDLE_ROW_1_BELTED);

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/BeltStatus.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/BeltStatus.java
@@ -160,7 +160,7 @@ public class BeltStatus extends RPCStruct {
     public static final String KEY_LEFT_ROW_3_BUCKLE_BELTED = "leftRow3BuckleBelted";
 
     public static final String KEY_RIGHT_ROW_3_BUCKLE_BELTED = "rightRow3BuckleBelted";
-    public static final String KEY_REAR_INFLATABLE_BELTED = "rearInflatableBelted";
+    public static final String KEY_LEFT_REAR_INFLATABLE_BELTED = "leftRearInflatableBelted";
     public static final String KEY_RIGHT_REAR_INFLATABLE_BELTED = "rightRearInflatableBelted";
     public static final String KEY_MIDDLE_ROW_1_BELT_DEPLOYED = "middleRow1BeltDeployed";
     public static final String KEY_MIDDLE_ROW_1_BUCKLE_BELTED = "middleRow1BuckleBelted";
@@ -267,10 +267,10 @@ public class BeltStatus extends RPCStruct {
         return (VehicleDataEventStatus) getObject(VehicleDataEventStatus.class, KEY_RIGHT_ROW_3_BUCKLE_BELTED);
     }
     public void setLeftRearInflatableBelted(@NonNull VehicleDataEventStatus rearInflatableBelted) {
-        setValue(KEY_REAR_INFLATABLE_BELTED, rearInflatableBelted);
+        setValue(KEY_LEFT_REAR_INFLATABLE_BELTED, rearInflatableBelted);
     }
     public VehicleDataEventStatus getLeftRearInflatableBelted() {
-        return (VehicleDataEventStatus) getObject(VehicleDataEventStatus.class, KEY_REAR_INFLATABLE_BELTED);
+        return (VehicleDataEventStatus) getObject(VehicleDataEventStatus.class, KEY_LEFT_REAR_INFLATABLE_BELTED);
     }
     public void setRightRearInflatableBelted(@NonNull VehicleDataEventStatus rightRearInflatableBelted) {
         setValue(KEY_RIGHT_REAR_INFLATABLE_BELTED, rightRearInflatableBelted);

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/BeltStatus.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/BeltStatus.java
@@ -160,6 +160,7 @@ public class BeltStatus extends RPCStruct {
     public static final String KEY_LEFT_ROW_3_BUCKLE_BELTED = "leftRow3BuckleBelted";
 
     public static final String KEY_RIGHT_ROW_3_BUCKLE_BELTED = "rightRow3BuckleBelted";
+    @Deprecated public static final String KEY_REAR_INFLATABLE_BELTED = "rearInflatableBelted";
     public static final String KEY_LEFT_REAR_INFLATABLE_BELTED = "leftRearInflatableBelted";
     public static final String KEY_RIGHT_REAR_INFLATABLE_BELTED = "rightRearInflatableBelted";
     public static final String KEY_MIDDLE_ROW_1_BELT_DEPLOYED = "middleRow1BeltDeployed";


### PR DESCRIPTION
Fixes #1078 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- Send `GetVehicleData` request and set `getVehicleData.setBeltStatus(true)`
- Check the `LeftRearInflatableBelted` in the reponse and make sure the value is correct and it is not `null`

### Summary
This PR updates the `LeftRearInflatableBelted` key value in `BetlStatus` to match RPC Specs. Also, unit tests are updated accordingly.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
