### PR TITLE
Add Pushing Buffer Support to AudioStreamManager

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/audio/AudioStreamManagerTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/audio/AudioStreamManagerTest.java
@@ -231,11 +231,16 @@ public class AudioStreamManagerTest extends TestCase {
             @Override
             public void sendAudio(byte[] data, int offset, int length, long presentationTimeUs) throws ArrayIndexOutOfBoundsException {
                 ByteBuffer buffer = ByteBuffer.wrap(data, offset, length);
-                this.sendAudio(buffer, presentationTimeUs);
+                this.sendAudio(buffer, presentationTimeUs, null);
             }
 
             @Override
             public void sendAudio(ByteBuffer data, long presentationTimeUs) {
+                sendAudio(data, presentationTimeUs, null);
+            }
+
+            @Override
+            public void sendAudio(ByteBuffer data, long presentationTimeUs, CompletionListener listener) {
                 SampleBuffer samples = SampleBuffer.wrap(data, sampleType, presentationTimeUs);
                 double timeUs = presentationTimeUs;
                 double sampleDurationUs = 1000000.0 / sampleRate;
@@ -473,11 +478,16 @@ public class AudioStreamManagerTest extends TestCase {
             @Override
             public void sendAudio(byte[] data, int offset, int length, long presentationTimeUs) throws ArrayIndexOutOfBoundsException {
                 ByteBuffer buffer = ByteBuffer.wrap(data, offset, length);
-                this.sendAudio(buffer, presentationTimeUs);
+                this.sendAudio(buffer, presentationTimeUs, null);
             }
 
             @Override
             public void sendAudio(ByteBuffer data, long presentationTimeUs) {
+                sendAudio(data, presentationTimeUs, null);
+            }
+
+            @Override
+            public void sendAudio(ByteBuffer data, long presentationTimeUs, CompletionListener listener) {
                 try {
                     long length = data.limit();
                     byte[] d = data.array();

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/audio/AudioStreamManagerTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/audio/AudioStreamManagerTest.java
@@ -20,7 +20,6 @@ import com.smartdevicelink.proxy.rpc.enums.AudioType;
 import com.smartdevicelink.proxy.rpc.enums.BitsPerSample;
 import com.smartdevicelink.proxy.rpc.enums.SamplingRate;
 import com.smartdevicelink.proxy.rpc.enums.SystemCapabilityType;
-import com.smartdevicelink.streaming.StreamPacketizer;
 
 import junit.framework.TestCase;
 
@@ -38,7 +37,6 @@ import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
-import static junit.framework.TestCase.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/audio/AudioStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/audio/AudioStreamManager.java
@@ -64,6 +64,7 @@ import com.smartdevicelink.util.Version;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.ref.WeakReference;
+import java.nio.ByteBuffer;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
@@ -428,6 +429,24 @@ public class AudioStreamManager extends BaseAudioStreamManager {
         }
     }
 
+    /**
+     * Pushes raw audio data to SDL Core.
+     * The audio file will be played immediately. If another audio file is currently playing,
+     * the specified file will stay queued and automatically played when ready.
+     * @param data Audio raw dara to send.
+     * @param completionListener A completion listener that informs when the audio file is played.
+     */
+    public void pushBuffer(ByteBuffer data, CompletionListener completionListener) {
+        // streaming state must be STARTED (starting the service is ready. starting stream is started)
+        if (streamingStateMachine.getState() != StreamingStateMachine.STARTED) {
+            Log.w(TAG, "AudioStreamManager is not ready!");
+            return;
+        }
+
+        if (sdlAudioStream != null) {
+            sdlAudioStream.sendAudio(data, -1);
+        }
+    }
 
     @Override
     protected void onTransportUpdate(List<TransportRecord> connectedTransports, boolean audioStreamTransportAvail, boolean videoStreamTransportAvail){

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/audio/AudioStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/audio/AudioStreamManager.java
@@ -444,7 +444,7 @@ public class AudioStreamManager extends BaseAudioStreamManager {
         }
 
         if (sdlAudioStream != null) {
-            sdlAudioStream.sendAudio(data, -1);
+            sdlAudioStream.sendAudio(data, -1, completionListener);
         }
     }
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/audio/AudioStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/audio/AudioStreamManager.java
@@ -385,7 +385,7 @@ public class AudioStreamManager extends BaseAudioStreamManager {
             @Override
             public void onAudioDataAvailable(SampleBuffer buffer) {
                 if (sdlAudioStream != null) {
-                    sdlAudioStream.sendAudio(buffer.getByteBuffer(), buffer.getPresentationTimeUs());
+                    sdlAudioStream.sendAudio(buffer.getByteBuffer(), buffer.getPresentationTimeUs(), null);
                 }
             }
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/audio/AudioStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/audio/AudioStreamManager.java
@@ -433,7 +433,7 @@ public class AudioStreamManager extends BaseAudioStreamManager {
      * Pushes raw audio data to SDL Core.
      * The audio file will be played immediately. If another audio file is currently playing,
      * the specified file will stay queued and automatically played when ready.
-     * @param data Audio raw dara to send.
+     * @param data Audio raw data to send.
      * @param completionListener A completion listener that informs when the audio file is played.
      */
     public void pushBuffer(ByteBuffer data, CompletionListener completionListener) {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/streaming/StreamPacketizer.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/streaming/StreamPacketizer.java
@@ -244,6 +244,7 @@ public class StreamPacketizer extends AbstractPacketizer implements IVideoStream
 	 *
 	 * @see IAudioStreamListener#sendAudio(ByteBuffer, long)
 	 */
+	@Deprecated
 	@Override
 	public void sendAudio(ByteBuffer data, long presentationTimeUs) {
 		sendByteBufferData(data, null);

--- a/android/sdl_android/src/main/java/com/smartdevicelink/streaming/StreamPacketizer.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/streaming/StreamPacketizer.java
@@ -210,7 +210,7 @@ public class StreamPacketizer extends AbstractPacketizer implements IVideoStream
 	/**
 	 * Called by the app.
 	 *
-	 * @see com.smartdevicelink.proxy.interfaces.IVideoStreamListener#sendFrame(byte[], int, int, long)
+	 * @see IVideoStreamListener#sendFrame(byte[], int, int, long)
 	 */
 	@Override
 	public void sendFrame(byte[] data, int offset, int length, long presentationTimeUs)
@@ -221,7 +221,7 @@ public class StreamPacketizer extends AbstractPacketizer implements IVideoStream
 	/**
 	 * Called by the app.
 	 *
-	 * @see com.smartdevicelink.proxy.interfaces.IVideoStreamListener#sendFrame(ByteBuffer, long)
+	 * @see IVideoStreamListener#sendFrame(ByteBuffer, long)
 	 */
 	@Override
 	public void sendFrame(ByteBuffer data, long presentationTimeUs) {
@@ -231,7 +231,7 @@ public class StreamPacketizer extends AbstractPacketizer implements IVideoStream
 	/**
 	 * Called by the app.
 	 *
-	 * @see com.smartdevicelink.proxy.interfaces.IAudioStreamListener#sendAudio(byte[], int, int, long)
+	 * @see IAudioStreamListener#sendAudio(byte[], int, int, long)
 	 */
 	@Override
 	public void sendAudio(byte[] data, int offset, int length, long presentationTimeUs)
@@ -242,13 +242,18 @@ public class StreamPacketizer extends AbstractPacketizer implements IVideoStream
 	/**
 	 * Called by the app.
 	 *
-	 * @see com.smartdevicelink.proxy.interfaces.IAudioStreamListener#sendAudio(ByteBuffer, long)
+	 * @see IAudioStreamListener#sendAudio(ByteBuffer, long)
 	 */
 	@Override
 	public void sendAudio(ByteBuffer data, long presentationTimeUs) {
 		sendByteBufferData(data, null);
 	}
 
+	/**
+	 * Called by the app.
+	 *
+	 * @see IAudioStreamListener#sendAudio(ByteBuffer, long, CompletionListener)
+	 */
 	@Override
 	public void sendAudio(ByteBuffer data, long presentationTimeUs, CompletionListener completionListener) {
 		sendByteBufferData(data, completionListener);

--- a/base/src/main/java/com/smartdevicelink/proxy/interfaces/IAudioStreamListener.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/interfaces/IAudioStreamListener.java
@@ -30,6 +30,8 @@
 
 package com.smartdevicelink.proxy.interfaces;
 
+import com.smartdevicelink.managers.CompletionListener;
+
 import java.nio.ByteBuffer;
 
 /**
@@ -68,4 +70,18 @@ public interface IAudioStreamListener {
 	 *                           Specify -1 if unknown.
 	 */
 	void sendAudio(ByteBuffer data, long presentationTimeUs);
+
+	/**
+	 * Sends a chunk of audio data to SDL Core.
+	 * <p>
+	 * Note: this method must not be called after SdlProxyBase.endAudioStream() is called.
+	 *
+	 * @param data               Data chunk to send. Its position will be updated upon return.
+	 * @param presentationTimeUs (Reserved for future use) Presentation timestamp (PTS) of the
+	 *                           last audio sample data included in this chunk, in microseconds.
+	 *                           It must be greater than the previous timestamp.
+	 *                           Specify -1 if unknown.
+	 * @param completionListener A completion listener that informs when the audio file is played
+	 */
+	void sendAudio(ByteBuffer data, long presentationTimeUs, CompletionListener completionListener);
 }

--- a/base/src/main/java/com/smartdevicelink/proxy/interfaces/IAudioStreamListener.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/interfaces/IAudioStreamListener.java
@@ -69,6 +69,7 @@ public interface IAudioStreamListener {
 	 *                           It must be greater than the previous timestamp.
 	 *                           Specify -1 if unknown.
 	 */
+	@Deprecated
 	void sendAudio(ByteBuffer data, long presentationTimeUs);
 
 	/**

--- a/hello_sdl_java/src/main/java/com/smartdevicelink/java/SdlService.java
+++ b/hello_sdl_java/src/main/java/com/smartdevicelink/java/SdlService.java
@@ -55,8 +55,6 @@ import com.smartdevicelink.util.DebugTool;
 
 import java.util.*;
 
-import static javafx.scene.input.KeyCode.R;
-
 public class SdlService {
 
 


### PR DESCRIPTION
Fixes #1075 #1042 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests are updated. Also, smoke tests can be run to confirm that the new  `pushBuffer()` API works:
- Prepare raw audio `ByteBuffer`. For example, you can load a .raw audio file and convert its content to `ByteBuffer`
- Pass the `ByteBuffer` to `AudioStreamManager.pushBuffer()` and confirm that audio plays on HU and that `completetionListener` is called 

### Summary
This PR adds a new public API to play audio from a raw buffer as described in the proposal

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
