### PR TITLE
New RPC CloseApplication

### DIFF
--- a/android/sdl_android/src/androidTest/assets/json/CloseApplication.json
+++ b/android/sdl_android/src/androidTest/assets/json/CloseApplication.json
@@ -1,0 +1,11 @@
+{
+  "request":{
+    "name":"CloseApplication",
+    "correlationID":131
+  },
+  "response":{
+    "name":"CloseApplicationResponse",
+    "correlationID":131,
+    "parameters":{}
+  }
+}

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/requests/CloseApplicationTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/requests/CloseApplicationTests.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c)  2019 Livio, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Livio Inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Created by Nicole Yarroch on 7/11/19 10:06 AM
+ */
+
+package com.smartdevicelink.test.rpc.requests;
+
+import com.smartdevicelink.marshal.JsonRPCMarshaller;
+import com.smartdevicelink.protocol.enums.FunctionID;
+import com.smartdevicelink.proxy.RPCMessage;
+import com.smartdevicelink.proxy.rpc.CloseApplication;
+import com.smartdevicelink.test.BaseRpcTests;
+import com.smartdevicelink.test.JsonUtils;
+import com.smartdevicelink.test.Test;
+import com.smartdevicelink.test.json.rpc.JsonFileReader;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Hashtable;
+
+/**
+ * This is a unit test class for the SmartDeviceLink library project class :
+ * {@link com.smartdevicelink.proxy.rpc.CloseApplication}
+ */
+public class CloseApplicationTests extends BaseRpcTests {
+
+    @Override
+    protected RPCMessage createMessage(){
+        return new CloseApplication();
+    }
+
+    @Override
+    protected String getMessageType(){
+        return RPCMessage.KEY_REQUEST;
+    }
+
+    @Override
+    protected String getCommandType(){
+        return FunctionID.CLOSE_APPLICATION.toString();
+    }
+
+    @Override
+    protected JSONObject getExpectedParameters(int sdlVersion){
+        return new JSONObject();
+    }
+
+    /**
+     * Tests the expected values of the RPC message.
+     */
+    public void testRpcValues () {
+        // Invalid/Null Tests
+        CloseApplication msg = new CloseApplication();
+        assertNotNull(Test.NOT_NULL, msg);
+        testNullBase(msg);
+    }
+
+    /**
+     * Tests a valid JSON construction of this RPC message.
+     */
+    public void testJsonConstructor () {
+        JSONObject commandJson = JsonFileReader.readId(this.mContext, getCommandType(), getMessageType());
+        assertNotNull(Test.NOT_NULL, commandJson);
+
+        try {
+            Hashtable<String, Object> hash = JsonRPCMarshaller.deserializeJSONObject(commandJson);
+            CloseApplication cmd = new CloseApplication(hash);
+
+            JSONObject body = JsonUtils.readJsonObjectFromJsonObject(commandJson, getMessageType());
+            assertNotNull(Test.NOT_NULL, body);
+
+            // Test everything in the json body.
+            assertEquals(Test.MATCH, JsonUtils.readStringFromJsonObject(body, RPCMessage.KEY_FUNCTION_NAME), cmd.getFunctionName());
+            assertEquals(Test.MATCH, JsonUtils.readIntegerFromJsonObject(body, RPCMessage.KEY_CORRELATION_ID), cmd.getCorrelationID());
+        }
+        catch (JSONException e) {
+            fail(Test.JSON_FAIL);
+        }
+    }
+}

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/responses/CloseApplicationResponseTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/responses/CloseApplicationResponseTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c)  2019 Livio, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Livio Inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Created by Nicole Yarroch on 7/11/19 10:47 AM
+ */
+
+package com.smartdevicelink.test.rpc.responses;
+
+import com.smartdevicelink.marshal.JsonRPCMarshaller;
+import com.smartdevicelink.protocol.enums.FunctionID;
+import com.smartdevicelink.proxy.RPCMessage;
+import com.smartdevicelink.proxy.rpc.CloseApplicationResponse;
+import com.smartdevicelink.proxy.rpc.UnregisterAppInterfaceResponse;
+import com.smartdevicelink.test.BaseRpcTests;
+import com.smartdevicelink.test.JsonUtils;
+import com.smartdevicelink.test.Test;
+import com.smartdevicelink.test.json.rpc.JsonFileReader;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Hashtable;
+
+/**
+ * This is a unit test class for the SmartDeviceLink library project class :
+ * {@link com.smartdevicelink.proxy.rpc.CloseApplicationResponse}
+ */
+public class CloseApplicationResponseTests extends BaseRpcTests {
+
+    @Override
+    protected RPCMessage createMessage(){
+        return new CloseApplicationResponse();
+    }
+
+    @Override
+    protected String getMessageType(){
+        return RPCMessage.KEY_RESPONSE;
+    }
+
+    @Override
+    protected String getCommandType(){
+        return FunctionID.CLOSE_APPLICATION.toString();
+    }
+
+    @Override
+    protected JSONObject getExpectedParameters(int sdlVersion){
+        return new JSONObject();
+    }
+
+    /**
+     * Tests the expected values of the RPC message.
+     */
+    public void testRpcValues () {
+        // Invalid/Null Tests
+        CloseApplicationResponse msg = new CloseApplicationResponse();
+        assertNotNull(Test.NOT_NULL, msg);
+        testNullBase(msg);
+    }
+
+    /**
+     * Tests a valid JSON construction of this RPC message.
+     */
+    public void testJsonConstructor () {
+        JSONObject commandJson = JsonFileReader.readId(this.mContext, getCommandType(), getMessageType());
+        assertNotNull(Test.NOT_NULL, commandJson);
+
+        try {
+            Hashtable<String, Object> hash = JsonRPCMarshaller.deserializeJSONObject(commandJson);
+            CloseApplicationResponse cmd = new CloseApplicationResponse(hash);
+
+            JSONObject body = JsonUtils.readJsonObjectFromJsonObject(commandJson, getMessageType());
+            assertNotNull(Test.NOT_NULL, body);
+
+            // Test everything in the json body.
+            assertEquals(Test.MATCH, JsonUtils.readStringFromJsonObject(body, RPCMessage.KEY_FUNCTION_NAME), cmd.getFunctionName());
+            assertEquals(Test.MATCH, JsonUtils.readIntegerFromJsonObject(body, RPCMessage.KEY_CORRELATION_ID), cmd.getCorrelationID());
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/ProxyBridge.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/ProxyBridge.java
@@ -45,6 +45,7 @@ import com.smartdevicelink.proxy.rpc.AlertManeuverResponse;
 import com.smartdevicelink.proxy.rpc.AlertResponse;
 import com.smartdevicelink.proxy.rpc.ButtonPressResponse;
 import com.smartdevicelink.proxy.rpc.ChangeRegistrationResponse;
+import com.smartdevicelink.proxy.rpc.CloseApplicationResponse;
 import com.smartdevicelink.proxy.rpc.CreateInteractionChoiceSetResponse;
 import com.smartdevicelink.proxy.rpc.DeleteCommandResponse;
 import com.smartdevicelink.proxy.rpc.DeleteFileResponse;
@@ -635,5 +636,10 @@ public class ProxyBridge implements IProxyListener{
 	@Override
 	public void onOnSystemCapabilityUpdated(OnSystemCapabilityUpdated notification){
 		onRPCReceived(notification);
+	}
+
+	@Override
+	public void onCloseApplication(CloseApplicationResponse response) {
+		onRPCReceived(response);
 	}
 }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/ProxyBridge.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/ProxyBridge.java
@@ -639,7 +639,7 @@ public class ProxyBridge implements IProxyListener{
 	}
 
 	@Override
-	public void onCloseApplication(CloseApplicationResponse response) {
+	public void onCloseApplicationResponse(CloseApplicationResponse response) {
 		onRPCReceived(response);
 	}
 }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -3694,6 +3694,22 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					_proxyListener.onPerformAppServiceInteractionResponse( msg);
 					onRPCResponseReceived(msg);
 				}
+			} else if (functionName.equals(FunctionID.CLOSE_APPLICATION.toString())) {
+				final CloseApplicationResponse msg = new CloseApplicationResponse(hash);
+				msg.format(rpcSpecVersion, true);
+				if (_callbackToUIThread) {
+					// Run in UI thread
+					_mainUIHandler.post(new Runnable() {
+						@Override
+						public void run() {
+							_proxyListener.onCloseApplicationResponse( msg);
+							onRPCResponseReceived(msg);
+						}
+					});
+				} else {
+					_proxyListener.onCloseApplicationResponse( msg);
+					onRPCResponseReceived(msg);
+				}
 			} else {
 				if (_sdlMsgVersion != null) {
 					DebugTool.logError("Unrecognized response Message: " + functionName +

--- a/base/src/main/java/com/smartdevicelink/protocol/enums/FunctionID.java
+++ b/base/src/main/java/com/smartdevicelink/protocol/enums/FunctionID.java
@@ -100,6 +100,7 @@ public enum FunctionID{
     GET_APP_SERVICE_DATA(53, "GetAppServiceData"),
     GET_FILE(54, "GetFile"),
     PERFORM_APP_SERVICES_INTERACTION(55, "PerformAppServiceInteraction"),
+    CLOSE_APPLICATION(58, "CloseApplication"),
 
     // NOTIFICATIONS
     ON_HMI_STATUS(32768, "OnHMIStatus"),

--- a/base/src/main/java/com/smartdevicelink/proxy/interfaces/IProxyListenerBase.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/interfaces/IProxyListenerBase.java
@@ -39,6 +39,7 @@ import com.smartdevicelink.proxy.rpc.AlertManeuverResponse;
 import com.smartdevicelink.proxy.rpc.AlertResponse;
 import com.smartdevicelink.proxy.rpc.ButtonPressResponse;
 import com.smartdevicelink.proxy.rpc.ChangeRegistrationResponse;
+import com.smartdevicelink.proxy.rpc.CloseApplicationResponse;
 import com.smartdevicelink.proxy.rpc.CreateInteractionChoiceSetResponse;
 import com.smartdevicelink.proxy.rpc.DeleteCommandResponse;
 import com.smartdevicelink.proxy.rpc.DeleteFileResponse;
@@ -414,4 +415,11 @@ public interface IProxyListenerBase {
 
 	public void onOnSystemCapabilityUpdated(OnSystemCapabilityUpdated notification);
 
+	/**
+	 * onCloseApplication being called indicates that SDL has
+	 * responded to a request to close the application on the module.
+	 *
+	 * @param response - Contains information about the response sent from SDL.
+	 */
+	public void onCloseApplication(CloseApplicationResponse response);
 }

--- a/base/src/main/java/com/smartdevicelink/proxy/interfaces/IProxyListenerBase.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/interfaces/IProxyListenerBase.java
@@ -416,10 +416,10 @@ public interface IProxyListenerBase {
 	public void onOnSystemCapabilityUpdated(OnSystemCapabilityUpdated notification);
 
 	/**
-	 * onCloseApplication being called indicates that SDL has
+	 * onCloseApplicationResponse being called indicates that SDL has
 	 * responded to a request to close the application on the module.
 	 *
 	 * @param response - Contains information about the response sent from SDL.
 	 */
-	public void onCloseApplication(CloseApplicationResponse response);
+	public void onCloseApplicationResponse(CloseApplicationResponse response);
 }

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/CloseApplication.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/CloseApplication.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c)  2019 Livio, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Livio Inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Created by Nicole Yarroch on 7/10/19 3:55 PM
+ */
+
+package com.smartdevicelink.proxy.rpc;
+
+import com.smartdevicelink.protocol.enums.FunctionID;
+import com.smartdevicelink.proxy.RPCRequest;
+
+import java.util.Hashtable;
+
+/**
+ * Used by an app to set itself to a `HMILevel` of `NONE`. The app will close but will still be registered. If the app is a navigation app it will no longer be used as the preferred mobile-navigation application by the module.
+ */
+public class CloseApplication extends RPCRequest {
+    /**
+     * Constructs a new CloseApplication object
+     */
+    public CloseApplication() {
+        super(FunctionID.CLOSE_APPLICATION.toString());
+    }
+
+    /**
+     * Constructs a new CloseApplication object indicated by the Hashtable parameter
+     *
+     * @param hash The Hashtable to use
+     */
+    public CloseApplication(Hashtable<String, Object> hash) {
+        super(hash);
+    }
+}

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/CloseApplicationResponse.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/CloseApplicationResponse.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c)  2019 Livio, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Livio Inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Created by Nicole Yarroch on 7/10/19 3:55 PM
+ */
+
+package com.smartdevicelink.proxy.rpc;
+
+import com.smartdevicelink.protocol.enums.FunctionID;
+import com.smartdevicelink.proxy.RPCResponse;
+
+import java.util.Hashtable;
+
+/**
+ * Response to the request to close this app on the module.
+ */
+public class CloseApplicationResponse extends RPCResponse {
+    /**
+     * Constructs a new CloseApplicationResponse object
+     */
+    public CloseApplicationResponse() {
+        super(FunctionID.CLOSE_APPLICATION.toString());
+    }
+
+    /**
+     * Constructs a new CloseApplicationResponse object indicated by the Hashtable parameter
+     *
+     * @param hash The Hashtable to use
+     */
+    public CloseApplicationResponse(Hashtable<String, Object> hash) {
+        super(hash);
+    }
+}


### PR DESCRIPTION
Fixes #658 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Smoke tests added for the `CloseApplication` response and request classes.

### Summary
Added `CloseApplication` request and response classes to the library.

### Changelog
##### Enhancements
* Added new RPC `CloseApplication` to the library.

### Tasks Remaining:
- [x] Test against sdl_core v.6.0
- [x] Set the finalized `functionID` for `CloseApplication`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)