### PR TITLE
Fixes #1101

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -3217,10 +3217,12 @@ public class SdlRouterService extends Service{
 					queues.put(transportType,queue);
 				}
 				queue.add(new PacketWriteTask(receivedBundle));
-				PacketWriteTaskMaster packetWriteTaskMaster = packetWriteTaskMasterMap.get(transportType);
-				if(packetWriteTaskMaster!=null){
-                    packetWriteTaskMaster.alert();
-                }
+				if(packetWriteTaskMasterMap != null) {
+					PacketWriteTaskMaster packetWriteTaskMaster = packetWriteTaskMasterMap.get(transportType);
+					if (packetWriteTaskMaster != null) {
+						packetWriteTaskMaster.alert();
+					}
+				} //If this is null, it is likely the service is closing
 			}
 			return true;
 		}


### PR DESCRIPTION
Fixes #1101 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.


### Summary

The map is set to null during the onDestroy method call. So there is a race condition to access the last messages to be processed and that map getting destroyed. Added a null check to prevent the NPE.

### Changelog


##### Bug Fixes
* Added a null check to prevent NPE when `packetWriteTaskMasterMap` is set to null during the service shutdown

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
