### PR TITLE
Make TCP use new transport layers

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/SdlConnection/SdlSession2.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/SdlConnection/SdlSession2.java
@@ -45,6 +45,7 @@ import com.smartdevicelink.protocol.heartbeat.IHeartbeatMonitor;
 import com.smartdevicelink.proxy.interfaces.ISdlServiceListener;
 import com.smartdevicelink.transport.BaseTransportConfig;
 import com.smartdevicelink.transport.MultiplexTransportConfig;
+import com.smartdevicelink.transport.TCPTransportConfig;
 import com.smartdevicelink.transport.enums.TransportType;
 import com.smartdevicelink.util.MediaStreamingStatus;
 import com.smartdevicelink.util.Version;
@@ -82,8 +83,14 @@ public class SdlSession2 extends SdlSession implements ISdlProtocol{
 
     }
 
+    public SdlSession2(ISdlConnectionListener listener, TCPTransportConfig config){ //TODO is it better to have two constructors or make it take BaseTransportConfig?
+        this.transportConfig = config;
+        this.sessionListener = listener;
+        this.sdlProtocol = new SdlProtocol(this,config);
+    }
+
     boolean isAudioRequirementMet(){
-        if(mediaStreamingStatus == null){
+        if(mediaStreamingStatus == null && contextWeakReference!= null && contextWeakReference.get() != null){
             mediaStreamingStatus = new MediaStreamingStatus(contextWeakReference.get(), new MediaStreamingStatus.Callback() {
                 @Override
                 public void onAudioNoLongerAvailable() {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlProtocol.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlProtocol.java
@@ -32,11 +32,27 @@
 
 package com.smartdevicelink.protocol;
 
+import android.os.Handler;
+import android.os.Message;
 import android.support.annotation.NonNull;
+import android.util.Log;
 
 import com.smartdevicelink.protocol.enums.SessionType;
+import com.smartdevicelink.transport.BaseTransportConfig;
+import com.smartdevicelink.transport.MultiplexBaseTransport;
+import com.smartdevicelink.transport.MultiplexTcpTransport;
 import com.smartdevicelink.transport.MultiplexTransportConfig;
+import com.smartdevicelink.transport.SdlRouterService;
+import com.smartdevicelink.transport.TCPTransport;
+import com.smartdevicelink.transport.TCPTransportConfig;
+import com.smartdevicelink.transport.TCPTransportManager;
 import com.smartdevicelink.transport.TransportManager;
+import com.smartdevicelink.transport.TransportManagerBase;
+import com.smartdevicelink.transport.enums.TransportType;
+import com.smartdevicelink.transport.utl.TransportRecord;
+
+import java.lang.ref.WeakReference;
+import java.util.Collections;
 
 
 @SuppressWarnings("WeakerAccess")
@@ -54,17 +70,27 @@ public class SdlProtocol extends SdlProtocolBase {
     }
 
 
+    public SdlProtocol(@NonNull ISdlProtocol iSdlProtocol, @NonNull TCPTransportConfig config) {
+        super(iSdlProtocol,config);
+        this.requestedPrimaryTransports = Collections.singletonList(TransportType.TCP);
+        this.requestedSecondaryTransports = null;
+        this.requiresHighBandwidth =false;
+        this.setTransportManager(new TCPTransportManager(config,transportEventListener));
+        this.requestedPrimaryTransports = Collections.singletonList(TransportType.TCP);
+    }
+
     /**
      * If there was a TransportListener attached to the supplied multiplex config, this method will
      * call the onTransportEvent method.
      */
     @Override
     void notifyDevTransportListener (){
-        MultiplexTransportConfig transportConfig = (MultiplexTransportConfig)this.transportConfig;
-        if(transportConfig.getTransportListener() != null && transportManager != null) {
-            transportConfig.getTransportListener().onTransportEvent(transportManager.getConnectedTransports(), isTransportForServiceAvailable(SessionType.PCM),isTransportForServiceAvailable(SessionType.NAV));
+        if(TransportType.MULTIPLEX.equals(transportConfig.getTransportType() )) {
+            MultiplexTransportConfig transportConfig = (MultiplexTransportConfig) this.transportConfig;
+            if (transportConfig.getTransportListener() != null && transportManager != null) {
+                transportConfig.getTransportListener().onTransportEvent(transportManager.getConnectedTransports(), isTransportForServiceAvailable(SessionType.PCM), isTransportForServiceAvailable(SessionType.NAV));
+            }
         }
     }
-
 
 }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -123,6 +123,8 @@ import com.smartdevicelink.trace.enums.InterfaceActivityDirection;
 import com.smartdevicelink.transport.BaseTransportConfig;
 import com.smartdevicelink.transport.MultiplexTransportConfig;
 import com.smartdevicelink.transport.SiphonServer;
+import com.smartdevicelink.transport.TCPTransport;
+import com.smartdevicelink.transport.TCPTransportConfig;
 import com.smartdevicelink.transport.USBTransportConfig;
 import com.smartdevicelink.transport.enums.TransportType;
 import com.smartdevicelink.util.CorrelationIdGenerator;
@@ -1563,14 +1565,14 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		synchronized(CONNECTION_REFERENCE_LOCK) {
 
 			//Handle legacy USB connections
-			if(_transportConfig != null
-					&& TransportType.USB.equals(_transportConfig.getTransportType())){
+			if (_transportConfig != null
+					&& TransportType.USB.equals(_transportConfig.getTransportType())) {
 				//A USB transport config was provided
-				USBTransportConfig usbTransportConfig = (USBTransportConfig)_transportConfig;
-				if(usbTransportConfig.getUsbAccessory() == null){
+				USBTransportConfig usbTransportConfig = (USBTransportConfig) _transportConfig;
+				if (usbTransportConfig.getUsbAccessory() == null) {
 					DebugTool.logInfo("Legacy USB transport config was used, but received null for accessory. Attempting to connect with router service");
 					//The accessory was null which means it came from a router service
-					MultiplexTransportConfig multiplexTransportConfig = new MultiplexTransportConfig(usbTransportConfig.getUSBContext(),_appID);
+					MultiplexTransportConfig multiplexTransportConfig = new MultiplexTransportConfig(usbTransportConfig.getUSBContext(), _appID);
 					multiplexTransportConfig.setRequiresHighBandwidth(true);
 					multiplexTransportConfig.setSecurityLevel(MultiplexTransportConfig.FLAG_MULTI_SECURITY_OFF);
 					multiplexTransportConfig.setPrimaryTransports(Collections.singletonList(TransportType.USB));
@@ -1579,9 +1581,11 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				}
 			}
 
-			if(_transportConfig.getTransportType().equals(TransportType.MULTIPLEX)){
-				this.sdlSession = new SdlSession2(_interfaceBroker,(MultiplexTransportConfig)_transportConfig);
-			}else{
+			if (_transportConfig.getTransportType().equals(TransportType.MULTIPLEX)) {
+				this.sdlSession = new SdlSession2(_interfaceBroker, (MultiplexTransportConfig) _transportConfig);
+			}else if(_transportConfig.getTransportType().equals(TransportType.TCP)){
+				this.sdlSession = new SdlSession2(_interfaceBroker, (TCPTransportConfig) _transportConfig);
+			}else {
 				this.sdlSession = SdlSession.createSession((byte)getProtocolVersion().getMajor(),_interfaceBroker, _transportConfig);
 			}
 		}

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexTcpTransport.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexTcpTransport.java
@@ -47,6 +47,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import static com.smartdevicelink.util.DebugTool.logError;
 import static com.smartdevicelink.util.NativeLogTool.logInfo;
@@ -354,8 +356,46 @@ public class MultiplexTcpTransport extends MultiplexBaseTransport {
 	}
 
 	private class WriterThread extends Thread {
-		private boolean mCancelled = false;
+		private boolean isHalted = false;
 		private boolean mVerbose = false;
+		final BlockingQueue<OutPacket> packetQueue = new LinkedBlockingQueue<>();
+
+		@Override
+		public void run() {
+			while(!isHalted){
+				try{
+					OutPacket packet = packetQueue.take();
+					if(packet == null){
+						continue;
+					}
+
+					OutputStream out;
+					synchronized (MultiplexTcpTransport.this) {
+						out = mOutputStream;
+					}
+
+					if ((out != null) && (!isHalted)) {
+						try {
+							out.write(packet.bytes, packet.offset, packet.count);
+							if (mVerbose) {
+								logInfo("TCPTransport.sendBytesOverTransport: successfully sent data");
+							}
+						} catch (IOException e) {
+							logError("TCPTransport.sendBytesOverTransport: error during sending data: " + e.getMessage());
+						}
+					} else {
+						if (isHalted) {
+							logError("TCPTransport: sendBytesOverTransport request accepted, thread is cancelled");
+						} else {
+							logError("TCPTransport: sendBytesOverTransport request accepted, but output stream is null");
+						}
+					}
+
+				}catch(InterruptedException e){
+					break;
+				}
+			}
+		}
 
 		public void write(byte[] msgBytes, int offset, int count) {
 			if ((msgBytes == null) || (msgBytes.length == 0)) {
@@ -366,32 +406,12 @@ public class MultiplexTcpTransport extends MultiplexBaseTransport {
 			if (offset + count > msgBytes.length) {
 				count = msgBytes.length - offset;
 			}
+			packetQueue.add(new OutPacket(msgBytes, offset, count));
 
-			OutputStream out;
-			synchronized (MultiplexTcpTransport.this) {
-				out = mOutputStream;
-			}
-
-			if ((out != null) && (!mCancelled)) {
-				try {
-					out.write(msgBytes, offset, count);
-					if (mVerbose) {
-						logInfo("TCPTransport.sendBytesOverTransport: successfully sent data");
-					}
-				} catch (IOException e) {
-					logError("TCPTransport.sendBytesOverTransport: error during sending data: " + e.getMessage());
-				}
-			} else {
-				if (mCancelled) {
-					logError("TCPTransport: sendBytesOverTransport request accepted, thread is cancelled");
-				} else {
-					logError("TCPTransport: sendBytesOverTransport request accepted, but output stream is null");
-				}
-			}
 		}
 
 		public synchronized void cancel() {
-			mCancelled = true;
+			isHalted = true;
 			if (mOutputStream != null) {
 				synchronized (MultiplexTcpTransport.this) {
 					try {
@@ -410,4 +430,17 @@ public class MultiplexTcpTransport extends MultiplexBaseTransport {
 			}
 		}
 	}
+
+	private final class OutPacket{
+		byte[] bytes;
+		int count;
+		int offset;
+		public OutPacket(byte[] bytes, int offset, int count){
+			this.bytes = bytes;
+			this.offset = offset;
+			this.count = count;
+		}
+	}
+
+
 }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/TCPTransportManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/TCPTransportManager.java
@@ -1,0 +1,136 @@
+package com.smartdevicelink.transport;
+
+import android.os.Handler;
+import android.os.Message;
+import android.util.Log;
+
+import com.smartdevicelink.protocol.SdlPacket;
+import com.smartdevicelink.protocol.SdlProtocol;
+import com.smartdevicelink.transport.enums.TransportType;
+import com.smartdevicelink.transport.utl.TransportRecord;
+import com.smartdevicelink.util.DebugTool;
+
+import java.lang.ref.WeakReference;
+
+public class TCPTransportManager extends TransportManagerBase{
+
+    private static final String TAG = "TCPTransportManager";
+
+    TCPHandler tcpHandler;
+    private MultiplexTcpTransport transport;
+    private TCPTransportConfig config;
+
+    public TCPTransportManager(TCPTransportConfig config, TransportEventListener transportEventListener){
+        super(config,transportEventListener);
+        Log.d(TAG, "USING THE TCP TRANSPORT MANAGER");
+        this.config = config;
+        tcpHandler = new TCPHandler(this);
+        transport = new MultiplexTcpTransport(config.getPort(), config.getIPAddress(),config.getAutoReconnect(),tcpHandler, null);
+    }
+
+    @Override
+    public void start() {
+        transport.start();
+
+    }
+
+    @Override
+    public void close(long sessionId) {
+        transport.stop();
+    }
+
+    @Override
+    public void resetSession() {
+        if(transport != null){
+            transport.stop();
+        }
+        //TODO make sure this makes sense
+        transport = new MultiplexTcpTransport(config.getPort(), config.getIPAddress(),config.getAutoReconnect(),null, null);
+
+    }
+
+    @Override
+    public boolean isConnected(TransportType transportType, String address) {
+        return (transportType == null || TransportType.TCP.equals(transportType)) && transport.isConnected();
+    }
+
+    @Override
+    public TransportRecord getTransportRecord(TransportType transportType, String address) {
+        if(transport != null){
+            return transport.getTransportRecord();
+        }else{
+            return null;
+        }
+    }
+
+    @Override
+    public void sendPacket(SdlPacket packet) {
+        if(packet != null){
+            byte[] rawBytes = packet.constructPacket();
+            if(rawBytes != null && rawBytes.length >0){
+                transport.write(rawBytes, 0, rawBytes.length);
+            }
+        }
+
+    }
+
+
+    protected static class TCPHandler extends Handler {
+
+        final WeakReference<TCPTransportManager> provider;
+
+        public TCPHandler(TCPTransportManager provider){
+            this.provider = new WeakReference<>(provider);
+        }
+        @Override
+        public void handleMessage(Message msg) {
+            if(this.provider.get() == null){
+                return;
+            }
+            TCPTransportManager service = this.provider.get();
+            if(service.transportListener == null){
+                return;
+            }
+            switch (msg.what) {
+                case SdlRouterService.MESSAGE_STATE_CHANGE:
+                    switch (msg.arg1) {
+                        case MultiplexBaseTransport.STATE_CONNECTED:
+                            synchronized (service.TRANSPORT_STATUS_LOCK){
+                                service.transportStatus.clear();
+                                service.transportStatus.add(service.transport.getTransportRecord());
+                            }
+                            DebugTool.logInfo("TCP transport has connected");
+                            service.transportListener.onTransportConnected(service.transportStatus);
+                            break;
+                        case MultiplexBaseTransport.STATE_CONNECTING:
+                            // Currently attempting to connect - update UI?
+                            break;
+                        case MultiplexBaseTransport.STATE_LISTEN:
+                            if(service.transport != null){
+                                service.transport.stop();
+                                service.transport = null;
+                            }
+                            break;
+                        case MultiplexBaseTransport.STATE_NONE:
+                            // We've just lost the connection
+                            if(service.transport != null){
+                                service.transportListener.onTransportDisconnected("TCP transport disconnected", service.transport.transportRecord, null);
+                            }else{
+                                service.transportListener.onTransportDisconnected("TCP transport disconnected", null, null);
+
+                            }
+                            break;
+                        case MultiplexBaseTransport.STATE_ERROR:
+                            Log.d(TAG, "TCP transport encountered an error");
+                            service.transportListener.onError("TCP transport encountered an error" );
+                            break;
+                    }
+                    break;
+
+                case SdlRouterService.MESSAGE_READ:
+                    service.transportListener.onPacketReceived((SdlPacket) msg.obj);
+                    break;
+            }
+        }
+    }
+}

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/utl/WiFiSocketFactory.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/utl/WiFiSocketFactory.java
@@ -72,6 +72,10 @@ public class WiFiSocketFactory {
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private static Socket createWiFiSocket(Context context) {
+        if(context == null){
+            logInfo("Context supplied was null");
+            return null;
+        }
         PackageManager pm = context.getPackageManager();
         if (pm == null) {
             logInfo("PackageManager isn't available.");


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- Connect with Manticore and observe code path through SdlSession2 logic.
- Test multiple transports to ensure TCP transport modifications work in router service

### Summary
- Added a new TCPTransportManager
- SdlProtocol can now be created with multiplexing or TCP transport config and will use the correct transport manager.
- Modified TCPTransport to actually use a different thread to write on

### Changelog


##### Enhancements
* TCP now follows the newer stack

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
