### PR TITLE
[SDL 0179]Pixel density and Scale

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/ImageResolutionTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/ImageResolutionTests.java
@@ -67,4 +67,26 @@ public class ImageResolutionTests extends TestCase{
         	fail(Test.JSON_FAIL);
         }
     }
+
+    public void testSetResolutionWidth_Odd() {
+        msg.setResolutionWidth(175);
+        assertEquals(176, (int)msg.getResolutionWidth());
+    }
+
+    public void testSetResolutionHeight_Odd() {
+        msg.setResolutionHeight(175);
+        assertEquals(176, (int)msg.getResolutionHeight());
+    }
+
+    public void testSetResolutionWidth_Pair() {
+        msg.setResolutionWidth(176);
+        assertEquals(176, (int)msg.getResolutionWidth());
+
+    }
+
+    public void testSetResolutionHeight_Pair() {
+        msg.setResolutionHeight(176);
+        assertEquals(176, (int)msg.getResolutionHeight());
+
+    }
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/VideoStreamingCapabilityTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/VideoStreamingCapabilityTests.java
@@ -14,11 +14,9 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 
 public class VideoStreamingCapabilityTests extends TestCase {

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/VideoStreamingCapabilityTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/VideoStreamingCapabilityTests.java
@@ -14,9 +14,11 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 
 public class VideoStreamingCapabilityTests extends TestCase {
@@ -30,6 +32,9 @@ public class VideoStreamingCapabilityTests extends TestCase {
 		msg.setPreferredResolution(Test.GENERAL_IMAGERESOLUTION);
 		msg.setMaxBitrate(Test.GENERAL_INT);
 		msg.setIsHapticSpatialDataSupported(Test.GENERAL_BOOLEAN);
+		msg.setDiagonalScreenSize(Test.GENERAL_DOUBLE);
+		msg.setPixelPerInch(Test.GENERAL_DOUBLE);
+		msg.setScale(Test.GENERAL_DOUBLE);
 	}
 
 	/**
@@ -41,12 +46,18 @@ public class VideoStreamingCapabilityTests extends TestCase {
 		ImageResolution res = msg.getPreferredResolution();
 		Integer maxBitrate = msg.getMaxBitrate();
 		Boolean isHapticSpatialDataSupported = msg.getIsHapticSpatialDataSupported();
+		Double diagonalScreenSize = msg.getDiagonalScreenSize();
+		Double pixelPerInch = msg.getPixelPerInch();
+		Double scale = msg.getScale();
 
 		// Valid Tests
 		assertEquals(Test.MATCH, (List<VideoStreamingFormat>) Test.GENERAL_VIDEOSTREAMINGFORMAT_LIST, format);
 		assertEquals(Test.MATCH, (ImageResolution) Test.GENERAL_IMAGERESOLUTION, res);
 		assertEquals(Test.MATCH, (Integer) Test.GENERAL_INT, maxBitrate);
 		assertEquals(Test.MATCH, (Boolean) Test.GENERAL_BOOLEAN, isHapticSpatialDataSupported);
+		assertEquals(Test.MATCH, Test.GENERAL_DOUBLE, diagonalScreenSize);
+		assertEquals(Test.MATCH, Test.GENERAL_DOUBLE, pixelPerInch);
+		assertEquals(Test.MATCH, Test.GENERAL_DOUBLE, scale);
 
 		// Invalid/Null Tests
 		VideoStreamingCapability msg = new VideoStreamingCapability();
@@ -56,6 +67,9 @@ public class VideoStreamingCapabilityTests extends TestCase {
 		assertNull(Test.NULL, msg.getPreferredResolution());
 		assertNull(Test.NULL, msg.getSupportedFormats());
 		assertNull(Test.NULL, msg.getIsHapticSpatialDataSupported());
+		assertNull(Test.NULL, msg.getDiagonalScreenSize());
+		assertNull(Test.NULL, msg.getPixelPerInch());
+		assertNull(Test.NULL, msg.getScale());
 	}
 
 	public void testJson() {
@@ -66,6 +80,9 @@ public class VideoStreamingCapabilityTests extends TestCase {
 			reference.put(VideoStreamingCapability.KEY_PREFERRED_RESOLUTION, Test.GENERAL_IMAGERESOLUTION);
 			reference.put(VideoStreamingCapability.KEY_SUPPORTED_FORMATS, Test.GENERAL_VIDEOSTREAMINGFORMAT_LIST);
 			reference.put(VideoStreamingCapability.KEY_HAPTIC_SPATIAL_DATA_SUPPORTED, Test.GENERAL_BOOLEAN);
+			reference.put(VideoStreamingCapability.KEY_DIAGONAL_SCREEN_SIZE, Test.GENERAL_DOUBLE);
+			reference.put(VideoStreamingCapability.KEY_PIXEL_PER_INCH, Test.GENERAL_DOUBLE);
+			reference.put(VideoStreamingCapability.KEY_SCALE, Test.GENERAL_DOUBLE);
 
 			JSONObject underTest = msg.serializeJSON();
 			assertEquals(Test.MATCH, reference.length(), underTest.length());
@@ -87,6 +104,9 @@ public class VideoStreamingCapabilityTests extends TestCase {
 					for(VideoStreamingFormat vsf : vsfReference){
 						assertTrue(Validator.validateSupportedFormats(vsf, new VideoStreamingFormat(JsonRPCMarshaller.deserializeJSONObject(vsfArray.getJSONObject(i++)))));
 					}
+				} else if (key.equals(VideoStreamingCapability.KEY_DIAGONAL_SCREEN_SIZE) || key.equals(VideoStreamingCapability.KEY_PIXEL_PER_INCH) ||
+						key.equals(VideoStreamingCapability.KEY_SCALE)) {
+					assertEquals(JsonUtils.readDoubleFromJsonObject(reference, key), JsonUtils.readDoubleFromJsonObject(underTest, key), 0.0005);
 				}
 			}
 		} catch (JSONException e) {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
@@ -107,8 +107,8 @@ public class VirtualDisplayEncoder {
     }
 
     @SuppressWarnings("unused")
-    public void setStreamingParams(int displayDensity, ImageResolution resolution, int frameRate, int bitrate, int interval, VideoStreamingFormat format) {
-        this.streamingParams = new VideoStreamingParameters(displayDensity, frameRate, bitrate, interval, resolution, format);
+    public void setStreamingParams(int displayDensity, ImageResolution resolution, int frameRate, int bitrate, int interval, double scale, VideoStreamingFormat format) {
+        this.streamingParams = new VideoStreamingParameters(displayDensity, frameRate, bitrate, interval, scale, resolution, format);
     }
 
     @SuppressWarnings("unused")

--- a/android/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
@@ -107,14 +107,8 @@ public class VirtualDisplayEncoder {
     }
 
     @SuppressWarnings("unused")
-    @Deprecated
     public void setStreamingParams(int displayDensity, ImageResolution resolution, int frameRate, int bitrate, int interval, VideoStreamingFormat format) {
         this.streamingParams = new VideoStreamingParameters(displayDensity, frameRate, bitrate, interval, resolution, format);
-    }
-
-    @SuppressWarnings("unused")
-    public void setStreamingParams(int displayDensity, ImageResolution resolution, int frameRate, int bitrate, int interval, double scale, VideoStreamingFormat format) {
-        this.streamingParams = new VideoStreamingParameters(displayDensity, frameRate, bitrate, interval, scale, resolution, format);
     }
 
     @SuppressWarnings("unused")

--- a/android/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
@@ -107,6 +107,12 @@ public class VirtualDisplayEncoder {
     }
 
     @SuppressWarnings("unused")
+    @Deprecated
+    public void setStreamingParams(int displayDensity, ImageResolution resolution, int frameRate, int bitrate, int interval, VideoStreamingFormat format) {
+        this.streamingParams = new VideoStreamingParameters(displayDensity, frameRate, bitrate, interval, resolution, format);
+    }
+
+    @SuppressWarnings("unused")
     public void setStreamingParams(int displayDensity, ImageResolution resolution, int frameRate, int bitrate, int interval, double scale, VideoStreamingFormat format) {
         this.streamingParams = new VideoStreamingParameters(displayDensity, frameRate, bitrate, interval, scale, resolution, format);
     }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/haptic/HapticInterfaceManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/haptic/HapticInterfaceManager.java
@@ -86,7 +86,7 @@ public class HapticInterfaceManager {
                 SendHapticData msg = new SendHapticData();
                 msg.setHapticRectData(hapticRects);
 
-                proxy.sendRPCRequest(msg);
+                proxy.sendRPC(msg);
             }
         }
     }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/haptic/HapticInterfaceManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/haptic/HapticInterfaceManager.java
@@ -28,6 +28,8 @@ import com.smartdevicelink.proxy.interfaces.ISdl;
 import com.smartdevicelink.proxy.rpc.HapticRect;
 import com.smartdevicelink.proxy.rpc.Rectangle;
 import com.smartdevicelink.proxy.rpc.SendHapticData;
+import com.smartdevicelink.proxy.rpc.VideoStreamingCapability;
+import com.smartdevicelink.proxy.rpc.enums.SystemCapabilityType;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -91,6 +93,15 @@ public class HapticInterfaceManager {
         List<View> focusables = new ArrayList<>();
         getFocusableViews(root, focusables);
 
+        double scale = 1.0;
+        ISdl proxy = proxyHolder.get();
+
+        VideoStreamingCapability videoStreamingCapability = (VideoStreamingCapability)
+                proxy.getCapability(SystemCapabilityType.VIDEO_STREAMING);
+        if (videoStreamingCapability != null && videoStreamingCapability.getScale() != null) {
+            scale = videoStreamingCapability.getScale();
+        }
+
         int [] loc = new int[2];
         int id = 0;
         for (View view : focusables) {
@@ -99,10 +110,10 @@ public class HapticInterfaceManager {
             view.getLocationOnScreen(loc);
 
             Rectangle rect = new Rectangle();
-            rect.setWidth((float) w);
-            rect.setHeight((float) h);
-            rect.setX((float) loc[0]);
-            rect.setY((float) loc[1]);
+            rect.setWidth((float) (w * scale));
+            rect.setHeight((float) (h * scale));
+            rect.setX((float) (loc[0] * scale));
+            rect.setY((float) (loc[1] * scale));
 
             HapticRect hapticRect = new HapticRect();
             hapticRect.setId(id++);

--- a/android/sdl_android/src/main/java/com/smartdevicelink/haptic/HapticInterfaceManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/haptic/HapticInterfaceManager.java
@@ -96,10 +96,12 @@ public class HapticInterfaceManager {
         double scale = 1.0;
         ISdl proxy = proxyHolder.get();
 
-        VideoStreamingCapability videoStreamingCapability = (VideoStreamingCapability)
-                proxy.getCapability(SystemCapabilityType.VIDEO_STREAMING);
-        if (videoStreamingCapability != null && videoStreamingCapability.getScale() != null) {
-            scale = videoStreamingCapability.getScale();
+        if (proxy != null) {
+            VideoStreamingCapability videoStreamingCapability = (VideoStreamingCapability)
+                    proxy.getCapability(SystemCapabilityType.VIDEO_STREAMING);
+            if (videoStreamingCapability != null && videoStreamingCapability.getScale() != null) {
+                scale = videoStreamingCapability.getScale();
+            }
         }
 
         int [] loc = new int[2];

--- a/android/sdl_android/src/main/java/com/smartdevicelink/haptic/HapticInterfaceManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/haptic/HapticInterfaceManager.java
@@ -61,8 +61,8 @@ public class HapticInterfaceManager {
      */
     public void setHapticData(List<HapticRect> hapticData) {
         userHapticData = hapticData;
-        ISdl proxy = proxyHolder.get();
-        if (proxy != null) {
+        if(proxyHolder.get() != null) {
+            ISdl proxy = proxyHolder.get();
             SendHapticData msg = new SendHapticData();
             msg.setHapticRectData(userHapticData);
             proxy.sendRPCRequest(msg);
@@ -77,15 +77,17 @@ public class HapticInterfaceManager {
      *          the root or parent View
      */
     public void refreshHapticData(View root) {
-        ISdl proxy = proxyHolder.get();
-        if ((userHapticData == null) && (proxy != null)) {
-            List<HapticRect> hapticRects = new ArrayList<>();
-            findHapticRects(root, hapticRects);
+        if(proxyHolder.get() != null) {
+            ISdl proxy = proxyHolder.get();
+            if (userHapticData == null) {
+                List<HapticRect> hapticRects = new ArrayList<>();
+                findHapticRects(root, hapticRects);
 
-            SendHapticData msg = new SendHapticData();
-            msg.setHapticRectData(hapticRects);
+                SendHapticData msg = new SendHapticData();
+                msg.setHapticRectData(hapticRects);
 
-            proxy.sendRPCRequest(msg);
+                proxy.sendRPCRequest(msg);
+            }
         }
     }
 
@@ -94,9 +96,9 @@ public class HapticInterfaceManager {
         getFocusableViews(root, focusables);
 
         double scale = 1.0;
-        ISdl proxy = proxyHolder.get();
 
-        if (proxy != null) {
+        if (proxyHolder.get() != null) {
+            ISdl proxy = proxyHolder.get();
             VideoStreamingCapability videoStreamingCapability = (VideoStreamingCapability)
                     proxy.getCapability(SystemCapabilityType.VIDEO_STREAMING);
             if (videoStreamingCapability != null && videoStreamingCapability.getScale() != null) {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -453,7 +453,7 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 						disp.getMetrics(displayMetrics);
 						touchScalar[0] = ((float)displayMetrics.widthPixels) / resolution.getResolutionWidth();
 						touchScalar[1] = ((float)displayMetrics.heightPixels) / resolution.getResolutionHeight();
-					}
+                    }
 
 				}
 
@@ -498,6 +498,11 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 			}
 		}
 	}
+
+    void createTouchScalar(ImageResolution resolution, DisplayMetrics displayMetrics) {
+        touchScalar[0] = ((float)displayMetrics.widthPixels) / resolution.getResolutionWidth();
+        touchScalar[1] = ((float)displayMetrics.heightPixels) / resolution.getResolutionHeight();
+    }
 
 	List<MotionEvent> convertTouchEvent(OnTouchEvent onTouchEvent){
 		List<MotionEvent> motionEventList = new ArrayList<MotionEvent>();

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -451,8 +451,7 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 					if(resolution != null){
 						DisplayMetrics displayMetrics = new DisplayMetrics();
 						disp.getMetrics(displayMetrics);
-						touchScalar[0] = ((float)displayMetrics.widthPixels) / resolution.getResolutionWidth();
-						touchScalar[1] = ((float)displayMetrics.heightPixels) / resolution.getResolutionHeight();
+						createTouchScalar(resolution, displayMetrics);
                     }
 
 				}

--- a/android/sdl_android/src/test/java/com/smartdevicelink/haptic/HapticInterfaceManagerTest.java
+++ b/android/sdl_android/src/test/java/com/smartdevicelink/haptic/HapticInterfaceManagerTest.java
@@ -96,7 +96,7 @@ public class HapticInterfaceManagerTest extends TestCase {
     public void testRefreshHapticData() throws Exception {
         View root = createViews();
         hapticMgr.refreshHapticData(root);
-        verify(mockProxy).sendRPCRequest(captor.capture());
+        verify(mockProxy).sendRPC(captor.capture());
         SendHapticData data = captor.getValue();
         assertNotNull("SendHapticData RPC", data);
         List<HapticRect> list = data.getHapticRectData();
@@ -107,7 +107,7 @@ public class HapticInterfaceManagerTest extends TestCase {
     @Test
     public void testRefreshHapticDataNull() throws Exception {
         hapticMgr.refreshHapticData(null);
-        verify(mockProxy).sendRPCRequest(captor.capture());
+        verify(mockProxy).sendRPC(captor.capture());
         SendHapticData data = captor.getValue();
         assertNotNull("SendHapticData RPC", data);
         List<HapticRect> list = data.getHapticRectData();
@@ -280,7 +280,7 @@ public class HapticInterfaceManagerTest extends TestCase {
 
 
         hapticMgr.refreshHapticData(button);
-        verify(mockProxy).sendRPCRequest(captor.capture());
+        verify(mockProxy).sendRPC(captor.capture());
 
         SendHapticData data = captor.getValue();
         List<HapticRect> list = data.getHapticRectData();

--- a/android/sdl_android/src/test/java/com/smartdevicelink/haptic/HapticInterfaceManagerTest.java
+++ b/android/sdl_android/src/test/java/com/smartdevicelink/haptic/HapticInterfaceManagerTest.java
@@ -28,6 +28,8 @@ import com.smartdevicelink.proxy.interfaces.ISdl;
 import com.smartdevicelink.proxy.rpc.HapticRect;
 import com.smartdevicelink.proxy.rpc.Rectangle;
 import com.smartdevicelink.proxy.rpc.SendHapticData;
+import com.smartdevicelink.proxy.rpc.VideoStreamingCapability;
+import com.smartdevicelink.proxy.rpc.enums.SystemCapabilityType;
 
 import junit.framework.TestCase;
 
@@ -46,6 +48,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -112,6 +115,86 @@ public class HapticInterfaceManagerTest extends TestCase {
     }
 
     @Test
+    public void testRefreshHapticData_Scale_2_0() {
+        double scale = 2.0;
+
+        final int buttonX = 60;
+        final int buttonY = 60;
+        final int buttonWidth = 150;
+        final int buttonHeight = 70;
+
+        Rectangle expected = new Rectangle();
+        expected.setX(120.0f);
+        expected.setY(120.0f);
+        expected.setWidth(300.0f);
+        expected.setHeight(140.0f);
+
+        VideoStreamingCapability capability = new VideoStreamingCapability();
+        capability.setScale(scale);
+
+        assertViewWithCapability(buttonX, buttonY, buttonWidth, buttonHeight, expected, capability);
+    }
+
+
+    @Test
+    public void testRefreshHapticData_Scale_0_5() {
+        double scale = 0.5;
+
+        final int buttonX = 60;
+        final int buttonY = 60;
+        final int buttonWidth = 150;
+        final int buttonHeight = 70;
+
+        Rectangle expected = new Rectangle();
+        expected.setX(30.0f);
+        expected.setY(30.0f);
+        expected.setWidth(75.0f);
+        expected.setHeight(35.0f);
+
+        VideoStreamingCapability capability = new VideoStreamingCapability();
+        capability.setScale(scale);
+
+        assertViewWithCapability(buttonX, buttonY, buttonWidth, buttonHeight, expected, capability);
+    }
+
+
+
+    @Test
+    public void testRefreshHapticData_NullCapability() {
+        final int buttonX = 60;
+        final int buttonY = 60;
+        final int buttonWidth = 150;
+        final int buttonHeight = 70;
+
+        Rectangle expected = new Rectangle();
+        expected.setX(60.0f);
+        expected.setY(60.0f);
+        expected.setWidth(150.0f);
+        expected.setHeight(70.0f);
+
+        assertViewWithCapability(buttonX, buttonY, buttonWidth, buttonHeight, expected, null);
+    }
+
+    @Test
+    public void testRefreshHapticData_NullScale() {
+        final int buttonX = 60;
+        final int buttonY = 60;
+        final int buttonWidth = 150;
+        final int buttonHeight = 70;
+
+        Rectangle expected = new Rectangle();
+        expected.setX(60.0f);
+        expected.setY(60.0f);
+        expected.setWidth(150.0f);
+        expected.setHeight(70.0f);
+
+        VideoStreamingCapability capability = new VideoStreamingCapability();
+        capability.setScale(null);
+
+        assertViewWithCapability(buttonX, buttonY, buttonWidth, buttonHeight, expected, capability);
+    }
+
+    @Test
     public void testRefreshWithUserData() throws Exception {
         List<HapticRect> rects = new ArrayList<>();
         Rectangle rect = new Rectangle();
@@ -169,5 +252,44 @@ public class HapticInterfaceManagerTest extends TestCase {
         });
 
         return parent1;
+    }
+
+
+    private View createView(final int x, final int y, int w, int h) {
+        View button = mock(View.class);
+        when(button.isFocusable()).thenReturn(true);
+        doAnswer(new Answer() {
+            @Override
+            public int[] answer(InvocationOnMock invocation) throws Throwable {
+                int[] args = (int[])(invocation.getArguments()[0]);
+                args[0] = x;
+                args[1] = y;
+                return args;
+            }
+        }).when(button).getLocationOnScreen(any(int[].class));
+
+        when(button.getWidth()).thenReturn(w);
+        when(button.getHeight()).thenReturn(h);
+        return button;
+    }
+
+    private void assertViewWithCapability(int x, int y, int w, int h, Rectangle expected, VideoStreamingCapability capability) {
+        when(mockProxy.getCapability(SystemCapabilityType.VIDEO_STREAMING)).thenReturn(capability);
+
+        View button = createView(x, y, w, h);
+
+
+        hapticMgr.refreshHapticData(button);
+        verify(mockProxy).sendRPCRequest(captor.capture());
+
+        SendHapticData data = captor.getValue();
+        List<HapticRect> list = data.getHapticRectData();
+        assertEquals(1, list.size());
+        Rectangle current = list.get(0).getRect();
+
+        assertEquals(expected.getX(), current.getX(), 0.0005);
+        assertEquals(expected.getY(), current.getY(), 0.0005);
+        assertEquals(expected.getWidth(), current.getWidth(), 0.0005);
+        assertEquals(expected.getHeight(), current.getHeight(), 0.0005);
     }
 }

--- a/android/sdl_android/src/test/java/com/smartdevicelink/streaming/video/VideoStreamingParametersTest.java
+++ b/android/sdl_android/src/test/java/com/smartdevicelink/streaming/video/VideoStreamingParametersTest.java
@@ -41,7 +41,6 @@ import static org.junit.Assert.*;
 
 public class VideoStreamingParametersTest {
     private VideoStreamingParameters params;
-    private VideoStreamingParameters otherParameters;
     private VideoStreamingCapability capability;
     private ImageResolution preferredResolution;
 
@@ -49,34 +48,22 @@ public class VideoStreamingParametersTest {
     public void setUp() {
         params = new VideoStreamingParameters();
         capability = new VideoStreamingCapability();
-        otherParameters = new VideoStreamingParameters();
     }
 
     @Test
-    public void defaultValue_Scale() {
-        assertEquals(1.0, params.getScale(), 0.005);
-    }
+    public void update_NullScale() {
+        preferredResolution = new ImageResolution(800, 354);
 
-    @Test
-    public void update_Scale() {
-        double expectedValue = 3.0;
-        otherParameters.setScale(expectedValue);
-        params = new VideoStreamingParameters(otherParameters);
-        assertEquals(expectedValue, params.getScale(), 0.005);
-    }
+        capability.setScale(null);
+        capability.setPreferredResolution(preferredResolution);
 
-    @Test
-    public void test_toString() {
-        StringBuilder builder = new StringBuilder();
-        builder.append("VideoStreamingParams - format: {codec=H264, protocol=RAW}, ");
-        builder.append("resolution: {576, 1024}, ");
-        builder.append("frame rate: {30}, ");
-        builder.append("displayDensity: {240}, ");
-        builder.append("bitrate: {512000}, ");
-        builder.append("IFrame interval: {5}, ");
-        builder.append("scale: {1.0}");
+        params.update(capability);
 
-        assertEquals(builder.toString(), params.toString());
+        int width = params.getResolution().getResolutionWidth();
+        int height = params.getResolution().getResolutionHeight();
+
+        assertEquals(800, width);
+        assertEquals(354, height);
     }
 
     @Test
@@ -108,7 +95,7 @@ public class VideoStreamingParametersTest {
         int height = params.getResolution().getResolutionHeight();
 
         assertEquals(1024, width);
-        assertEquals(455, height);
+        assertEquals(456, height);
     }
 
     @Test
@@ -123,7 +110,7 @@ public class VideoStreamingParametersTest {
         int width = params.getResolution().getResolutionWidth();
         int height = params.getResolution().getResolutionHeight();
 
-        assertEquals(853, width);
-        assertEquals(379, height);
+        assertEquals(854, width);
+        assertEquals(380, height);
     }
 }

--- a/android/sdl_android/src/test/java/com/smartdevicelink/streaming/video/VideoStreamingParametersTest.java
+++ b/android/sdl_android/src/test/java/com/smartdevicelink/streaming/video/VideoStreamingParametersTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2017 - 2019, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium, Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.smartdevicelink.streaming.video;
+
+import com.smartdevicelink.proxy.rpc.ImageResolution;
+import com.smartdevicelink.proxy.rpc.VideoStreamingCapability;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class VideoStreamingParametersTest {
+    private VideoStreamingParameters params;
+    private VideoStreamingParameters otherParameters;
+    private VideoStreamingCapability capability;
+    private ImageResolution preferredResolution;
+
+    @Before
+    public void setUp() {
+        params = new VideoStreamingParameters();
+        capability = new VideoStreamingCapability();
+        otherParameters = new VideoStreamingParameters();
+    }
+
+    @Test
+    public void defaultValue_Scale() {
+        assertEquals(1.0, params.getScale(), 0.005);
+    }
+
+    @Test
+    public void update_Scale() {
+        double expectedValue = 3.0;
+        otherParameters.setScale(expectedValue);
+        params = new VideoStreamingParameters(otherParameters);
+        assertEquals(expectedValue, params.getScale(), 0.005);
+    }
+
+    @Test
+    public void test_toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("VideoStreamingParams - format: {codec=H264, protocol=RAW}, ");
+        builder.append("resolution: {576, 1024}, ");
+        builder.append("frame rate: {30}, ");
+        builder.append("displayDensity: {240}, ");
+        builder.append("bitrate: {512000}, ");
+        builder.append("IFrame interval: {5}, ");
+        builder.append("scale: {1.0}");
+
+        assertEquals(builder.toString(), params.toString());
+    }
+
+    @Test
+    public void update_Scale_1_Resolution_800_354() {
+        preferredResolution = new ImageResolution(800, 354);
+
+        capability.setScale(1.0);
+        capability.setPreferredResolution(preferredResolution);
+
+        params.update(capability);
+
+        int width = params.getResolution().getResolutionWidth();
+        int height = params.getResolution().getResolutionHeight();
+
+        assertEquals(800, width);
+        assertEquals(354, height);
+    }
+
+    @Test
+    public void update_Scale_1_25_Resolution_1280_569() {
+        preferredResolution = new ImageResolution(1280, 569);
+
+        capability.setScale(1.25);
+        capability.setPreferredResolution(preferredResolution);
+
+        params.update(capability);
+
+        int width = params.getResolution().getResolutionWidth();
+        int height = params.getResolution().getResolutionHeight();
+
+        assertEquals(1024, width);
+        assertEquals(455, height);
+    }
+
+    @Test
+    public void update_Scale_1_5_Resolution_1280_569() {
+        preferredResolution = new ImageResolution(1280, 569);
+
+        capability.setScale(1.5);
+        capability.setPreferredResolution(preferredResolution);
+
+        params.update(capability);
+
+        int width = params.getResolution().getResolutionWidth();
+        int height = params.getResolution().getResolutionHeight();
+
+        assertEquals(853, width);
+        assertEquals(379, height);
+    }
+}

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/ImageResolution.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/ImageResolution.java
@@ -97,6 +97,9 @@ public class ImageResolution extends RPCStruct {
     }
     
     public void setResolutionWidth(@NonNull Integer resolutionWidth) {
+        if(resolutionWidth != null && resolutionWidth % 2 != 0) {
+            resolutionWidth++;
+        }
         setValue(KEY_RESOLUTION_WIDTH, resolutionWidth);
     }
     
@@ -105,6 +108,9 @@ public class ImageResolution extends RPCStruct {
     }
     
     public void setResolutionHeight(@NonNull Integer resolutionHeight) {
+        if(resolutionHeight != null && resolutionHeight % 2 != 0) {
+            resolutionHeight++;
+        }
         setValue(KEY_RESOLUTION_HEIGHT, resolutionHeight);
     }
     

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/ImageResolution.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/ImageResolution.java
@@ -95,7 +95,12 @@ public class ImageResolution extends RPCStruct {
         setResolutionWidth(resolutionWidth);
         setResolutionHeight(resolutionHeight);
     }
-    
+
+    /**
+     * @param resolutionWidth the desired resolution width. Odds values cause problems in
+     *                        the Android H264 decoder, as a workaround the odd value is
+     *                        converted to a pair value.
+     */
     public void setResolutionWidth(@NonNull Integer resolutionWidth) {
         if(resolutionWidth != null && resolutionWidth % 2 != 0) {
             resolutionWidth++;
@@ -106,7 +111,12 @@ public class ImageResolution extends RPCStruct {
     public Integer getResolutionWidth() {
         return getInteger(KEY_RESOLUTION_WIDTH);
     }
-    
+
+    /**
+     * @param resolutionHeight the desired resolution height. Odds values cause problems in
+     *                        the Android H264 decoder, as a workaround the odd value is
+     *                        converted to a pair value.
+     */
     public void setResolutionHeight(@NonNull Integer resolutionHeight) {
         if(resolutionHeight != null && resolutionHeight % 2 != 0) {
             resolutionHeight++;

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/VideoStreamingCapability.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/VideoStreamingCapability.java
@@ -32,6 +32,7 @@
 package com.smartdevicelink.proxy.rpc;
 
 import com.smartdevicelink.proxy.RPCStruct;
+import com.smartdevicelink.util.SdlDataTypeConverter;
 
 import java.util.Hashtable;
 import java.util.List;
@@ -45,6 +46,9 @@ public class VideoStreamingCapability extends RPCStruct {
 	public static final String KEY_MAX_BITRATE = "maxBitrate";
 	public static final String KEY_SUPPORTED_FORMATS = "supportedFormats";
 	public static final String KEY_HAPTIC_SPATIAL_DATA_SUPPORTED = "hapticSpatialDataSupported";
+	public static final String KEY_DIAGONAL_SCREEN_SIZE = "diagonalScreenSize";
+	public static final String KEY_PIXEL_PER_INCH = "pixelPerInch";
+	public static final String KEY_SCALE = "scale";
 
 	public VideoStreamingCapability(){}
 	public VideoStreamingCapability(Hashtable<String, Object> hash){super(hash);}
@@ -91,5 +95,32 @@ public class VideoStreamingCapability extends RPCStruct {
 
 	public void setIsHapticSpatialDataSupported(Boolean hapticSpatialDataSupported) {
 		setValue(KEY_HAPTIC_SPATIAL_DATA_SUPPORTED, hapticSpatialDataSupported);
+	}
+
+	public Double getDiagonalScreenSize() {
+	    Object object = getValue(KEY_DIAGONAL_SCREEN_SIZE);
+		return SdlDataTypeConverter.objectToDouble(object);
+	}
+
+	public void setDiagonalScreenSize(Double diagonalScreenSize) {
+		setValue(KEY_DIAGONAL_SCREEN_SIZE, diagonalScreenSize);
+	}
+
+	public Double getPixelPerInch() {
+	    Object object = getValue(KEY_PIXEL_PER_INCH);
+	    return SdlDataTypeConverter.objectToDouble(object);
+	}
+
+	public void setPixelPerInch(Double pixelPerInch) {
+		setValue(KEY_PIXEL_PER_INCH, pixelPerInch);
+	}
+
+	public Double getScale() {
+	    Object object = getValue(KEY_SCALE);
+	    return SdlDataTypeConverter.objectToDouble(object);
+	}
+
+	public void setScale(Double scale) {
+		setValue(KEY_SCALE, scale);
 	}
 }

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/VideoStreamingCapability.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/VideoStreamingCapability.java
@@ -97,29 +97,47 @@ public class VideoStreamingCapability extends RPCStruct {
 		setValue(KEY_HAPTIC_SPATIAL_DATA_SUPPORTED, hapticSpatialDataSupported);
 	}
 
+	/**
+	 * @return the diagonal screen size in inches.
+	 */
 	public Double getDiagonalScreenSize() {
 	    Object object = getValue(KEY_DIAGONAL_SCREEN_SIZE);
 		return SdlDataTypeConverter.objectToDouble(object);
 	}
 
+	/**
+	 * @param diagonalScreenSize the diagonal screen size in inches.
+	 */
 	public void setDiagonalScreenSize(Double diagonalScreenSize) {
 		setValue(KEY_DIAGONAL_SCREEN_SIZE, diagonalScreenSize);
 	}
 
+	/**
+	 * @return the diagonal resolution in pixels divided by the diagonal screen size in inches.
+	 */
 	public Double getPixelPerInch() {
 	    Object object = getValue(KEY_PIXEL_PER_INCH);
 	    return SdlDataTypeConverter.objectToDouble(object);
 	}
 
+	/**
+	 * @param pixelPerInch the diagonal resolution in pixels divided by the diagonal screen size in inches.
+	 */
 	public void setPixelPerInch(Double pixelPerInch) {
 		setValue(KEY_PIXEL_PER_INCH, pixelPerInch);
 	}
 
+	/**
+	 * @return the scaling factor the app should use to change the size of the projecting view.
+	 */
 	public Double getScale() {
 	    Object object = getValue(KEY_SCALE);
 	    return SdlDataTypeConverter.objectToDouble(object);
 	}
 
+	/**
+	 * @param scale the scaling factor the app should use to change the size of the projecting view.
+	 */
 	public void setScale(Double scale) {
 		setValue(KEY_SCALE, scale);
 	}

--- a/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
+++ b/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
@@ -57,7 +57,6 @@ public class VideoStreamingParameters {
 	private int frameRate;
 	private int bitrate;
 	private int interval;
-	private double scale;
 	private ImageResolution resolution;
 	private VideoStreamingFormat format;
 
@@ -66,7 +65,6 @@ public class VideoStreamingParameters {
 	    frameRate = DEFAULT_FRAMERATE;
 	    bitrate = DEFAULT_BITRATE;
 	    interval = DEFAULT_INTERVAL;
-	    scale = DEFAULT_SCALE;
 	    resolution = new ImageResolution();
 	    resolution.setResolutionWidth(DEFAULT_WIDTH);
 	    resolution.setResolutionHeight(DEFAULT_HEIGHT);
@@ -75,26 +73,15 @@ public class VideoStreamingParameters {
 	    format.setCodec(DEFAULT_CODEC);
     }
 
-
-    @Deprecated
     public VideoStreamingParameters(int displayDensity, int frameRate, int bitrate, int interval,
                                     ImageResolution resolution, VideoStreamingFormat format){
-        this(displayDensity, frameRate, bitrate, interval, DEFAULT_SCALE, resolution, format);
-    }
-
-    public VideoStreamingParameters(int displayDensity, int frameRate, int bitrate, int interval,
-                                    double scale, ImageResolution resolution,
-                                    VideoStreamingFormat format){
 	    this.displayDensity = displayDensity;
 	    this.frameRate = frameRate;
 	    this.bitrate = bitrate;
 	    this.interval = interval;
-	    this.scale = scale;
 	    this.resolution = resolution;
 	    this.format = format;
     }
-
-
 
     /**
      * Will only copy values that are not null or are greater than 0
@@ -102,7 +89,6 @@ public class VideoStreamingParameters {
      */
     @SuppressWarnings("unused")
     public VideoStreamingParameters(VideoStreamingParameters params){
-        resolution = new ImageResolution();
         update(params);
     }
 
@@ -123,9 +109,6 @@ public class VideoStreamingParameters {
             }
             if (params.interval > 0) {
                 this.interval = params.interval;
-            }
-            if(params.scale > 0.0) {
-                this.scale = params.scale;
             }
             if (params.resolution != null) {
                 if (params.resolution.getResolutionHeight() != null && params.resolution.getResolutionHeight() > 0) {
@@ -150,6 +133,7 @@ public class VideoStreamingParameters {
      */
     public void update(VideoStreamingCapability capability){
         if(capability.getMaxBitrate()!=null){ this.bitrate = capability.getMaxBitrate() * 1000; } // NOTE: the unit of maxBitrate in getSystemCapability is kbps.
+        double scale = DEFAULT_SCALE;
         if(capability.getScale() != null) { scale = capability.getScale(); }
         ImageResolution resolution = capability.getPreferredResolution();
         if(resolution!=null){
@@ -197,14 +181,6 @@ public class VideoStreamingParameters {
         return interval;
     }
 
-    public void setScale(double scale) {
-        this.scale = scale;
-    }
-
-    public double getScale() {
-        return scale;
-    }
-
     public void setFormat(VideoStreamingFormat format){
 	    this.format = format;
     }
@@ -228,18 +204,16 @@ public class VideoStreamingParameters {
         builder.append(format.toString());
         builder.append("}, resolution: {");
         builder.append(resolution.getResolutionHeight());
-        builder.append(", ");
+        builder.append(" , ");
         builder.append(resolution.getResolutionWidth());
-        builder.append("}, frame rate: {");
+        builder.append("}, frame rate {");
         builder.append(frameRate);
-        builder.append("}, displayDensity: {");
+        builder.append("}, displayDensity{ ");
         builder.append(displayDensity);
-        builder.append("}, bitrate: {");
+        builder.append("}, bitrate");
         builder.append(bitrate);
-        builder.append("}, IFrame interval: {");
+        builder.append("}, IFrame interval{ ");
         builder.append(interval);
-        builder.append("}, scale: {");
-        builder.append(scale);
         builder.append("}");
         return builder.toString();
     }

--- a/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
+++ b/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
@@ -50,12 +50,14 @@ public class VideoStreamingParameters {
 	private final int DEFAULT_FRAMERATE = 30;
 	private final int DEFAULT_BITRATE = 512000;
 	private final int DEFAULT_INTERVAL = 5;
+	private final double DEFAULT_SCALE = 1.0;
 
 
 	private int displayDensity;
 	private int frameRate;
 	private int bitrate;
 	private int interval;
+	private double scale;
 	private ImageResolution resolution;
 	private VideoStreamingFormat format;
 
@@ -64,6 +66,7 @@ public class VideoStreamingParameters {
 	    frameRate = DEFAULT_FRAMERATE;
 	    bitrate = DEFAULT_BITRATE;
 	    interval = DEFAULT_INTERVAL;
+	    scale = DEFAULT_SCALE;
 	    resolution = new ImageResolution();
 	    resolution.setResolutionWidth(DEFAULT_WIDTH);
 	    resolution.setResolutionHeight(DEFAULT_HEIGHT);
@@ -73,11 +76,13 @@ public class VideoStreamingParameters {
     }
 
     public VideoStreamingParameters(int displayDensity, int frameRate, int bitrate, int interval,
-                                    ImageResolution resolution, VideoStreamingFormat format){
+                                    double scale, ImageResolution resolution,
+                                    VideoStreamingFormat format){
 	    this.displayDensity = displayDensity;
 	    this.frameRate = frameRate;
 	    this.bitrate = bitrate;
 	    this.interval = interval;
+	    this.scale = scale;
 	    this.resolution = resolution;
 	    this.format = format;
     }
@@ -88,6 +93,7 @@ public class VideoStreamingParameters {
      */
     @SuppressWarnings("unused")
     public VideoStreamingParameters(VideoStreamingParameters params){
+        resolution = new ImageResolution();
         update(params);
     }
 
@@ -108,6 +114,9 @@ public class VideoStreamingParameters {
             }
             if (params.interval > 0) {
                 this.interval = params.interval;
+            }
+            if(params.scale > 0.0) {
+                this.scale = params.scale;
             }
             if (params.resolution != null) {
                 if (params.resolution.getResolutionHeight() != null && params.resolution.getResolutionHeight() > 0) {
@@ -132,10 +141,12 @@ public class VideoStreamingParameters {
      */
     public void update(VideoStreamingCapability capability){
         if(capability.getMaxBitrate()!=null){ this.bitrate = capability.getMaxBitrate() * 1000; } // NOTE: the unit of maxBitrate in getSystemCapability is kbps.
+        if(capability.getScale() != null) { scale = capability.getScale(); }
         ImageResolution resolution = capability.getPreferredResolution();
         if(resolution!=null){
-            if(resolution.getResolutionHeight()!=null && resolution.getResolutionHeight() > 0){ this.resolution.setResolutionHeight(resolution.getResolutionHeight()); }
-            if(resolution.getResolutionWidth()!=null && resolution.getResolutionWidth() > 0){ this.resolution.setResolutionWidth(resolution.getResolutionWidth()); }
+
+            if(resolution.getResolutionHeight()!=null && resolution.getResolutionHeight() > 0){ this.resolution.setResolutionHeight((int)(resolution.getResolutionHeight() / scale)); }
+            if(resolution.getResolutionWidth()!=null && resolution.getResolutionWidth() > 0){ this.resolution.setResolutionWidth((int)(resolution.getResolutionWidth() / scale)); }
         }
         List<VideoStreamingFormat> formats = capability.getSupportedFormats();
         if(formats != null && formats.size()>0){
@@ -177,6 +188,14 @@ public class VideoStreamingParameters {
         return interval;
     }
 
+    public void setScale(double scale) {
+        this.scale = scale;
+    }
+
+    public double getScale() {
+        return scale;
+    }
+
     public void setFormat(VideoStreamingFormat format){
 	    this.format = format;
     }
@@ -200,16 +219,18 @@ public class VideoStreamingParameters {
         builder.append(format.toString());
         builder.append("}, resolution: {");
         builder.append(resolution.getResolutionHeight());
-        builder.append(" , ");
+        builder.append(", ");
         builder.append(resolution.getResolutionWidth());
-        builder.append("}, frame rate {");
+        builder.append("}, frame rate: {");
         builder.append(frameRate);
-        builder.append("}, displayDensity{ ");
+        builder.append("}, displayDensity: {");
         builder.append(displayDensity);
-        builder.append("}, bitrate");
+        builder.append("}, bitrate: {");
         builder.append(bitrate);
-        builder.append("}, IFrame interval{ ");
+        builder.append("}, IFrame interval: {");
         builder.append(interval);
+        builder.append("}, scale: {");
+        builder.append(scale);
         builder.append("}");
         return builder.toString();
     }

--- a/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
+++ b/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
@@ -50,7 +50,7 @@ public class VideoStreamingParameters {
 	private final int DEFAULT_FRAMERATE = 30;
 	private final int DEFAULT_BITRATE = 512000;
 	private final int DEFAULT_INTERVAL = 5;
-	private final double DEFAULT_SCALE = 1.0;
+	private final static double DEFAULT_SCALE = 1.0;
 
 
 	private int displayDensity;
@@ -75,6 +75,13 @@ public class VideoStreamingParameters {
 	    format.setCodec(DEFAULT_CODEC);
     }
 
+
+    @Deprecated
+    public VideoStreamingParameters(int displayDensity, int frameRate, int bitrate, int interval,
+                                    ImageResolution resolution, VideoStreamingFormat format){
+        this(displayDensity, frameRate, bitrate, interval, DEFAULT_SCALE, resolution, format);
+    }
+
     public VideoStreamingParameters(int displayDensity, int frameRate, int bitrate, int interval,
                                     double scale, ImageResolution resolution,
                                     VideoStreamingFormat format){
@@ -86,6 +93,8 @@ public class VideoStreamingParameters {
 	    this.resolution = resolution;
 	    this.format = format;
     }
+
+
 
     /**
      * Will only copy values that are not null or are greater than 0


### PR DESCRIPTION
Fixes #804 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests added for:
- VideoStreamManager
- VideoStreamingCapability
- VideoStreamingParameters
- HapticManagerTest

Functional testing can be done by editing the preferred resolution,
and scale in HMI and testing that the captured view has the proper size and touches are reported
correctly and with the correct coordinates while clicking on the HMI interface.
Also the Automatic Haptic Rect sent to HMI should have the propper size according to the scale value set. 


### Summary
The main change is related to changing the size of the view captured.
This is done by adding a new scale parameter in the video
streaming capability and by dividing the preferred resolution from the
HMI and the scale.

Changes in the calculation of the touch coordinates are not needed due
to the array VideoStreamManager.touchScalar, this array is already
handling the differences in the size between the preferred resolution
and the captured view.
The touch coordinates are correctly being divided by the scale value.

Automatic haptic rects are resized according to the scale value.
### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
