### PR TITLE
Add prerecorded speech to SystemCapabilityManager

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/Validator.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/Validator.java
@@ -102,6 +102,7 @@ import com.smartdevicelink.proxy.rpc.enums.DefrostZone;
 import com.smartdevicelink.proxy.rpc.enums.FileType;
 import com.smartdevicelink.proxy.rpc.enums.HMILevel;
 import com.smartdevicelink.proxy.rpc.enums.HmiZoneCapabilities;
+import com.smartdevicelink.proxy.rpc.enums.PrerecordedSpeech;
 import com.smartdevicelink.proxy.rpc.enums.SpeechCapabilities;
 import com.smartdevicelink.proxy.rpc.enums.VentilationMode;
 
@@ -3548,6 +3549,15 @@ public class Validator{
 	}
 
 	public static boolean validateSpeechCapabilities(List<SpeechCapabilities> spA, List<SpeechCapabilities> spB){
+		for(int i = 0; i < spA.size(); i++){
+			if(!spA.get(i).equals(spB.get(i))){
+				return false;
+			}
+		}
+		return true;
+	}
+
+	public static boolean validatePreRecordedSpeechCapabilities(List<PrerecordedSpeech> spA, List<PrerecordedSpeech> spB){
 		for(int i = 0; i < spA.size(); i++){
 			if(!spA.get(i).equals(spB.get(i))){
 				return false;

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SystemCapabilityManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SystemCapabilityManagerTests.java
@@ -30,6 +30,7 @@ import com.smartdevicelink.proxy.rpc.SystemCapability;
 import com.smartdevicelink.proxy.rpc.VideoStreamingCapability;
 import com.smartdevicelink.proxy.rpc.enums.AppServiceType;
 import com.smartdevicelink.proxy.rpc.enums.HmiZoneCapabilities;
+import com.smartdevicelink.proxy.rpc.enums.PrerecordedSpeech;
 import com.smartdevicelink.proxy.rpc.enums.ServiceUpdateReason;
 import com.smartdevicelink.proxy.rpc.enums.SpeechCapabilities;
 import com.smartdevicelink.proxy.rpc.enums.SystemCapabilityType;
@@ -81,6 +82,7 @@ public class SystemCapabilityManagerTests extends AndroidTestCase2 {
 		raiResponse.setPresetBankCapabilities(Test.GENERAL_PRESETBANKCAPABILITIES);
 		raiResponse.setSoftButtonCapabilities(Test.GENERAL_SOFTBUTTONCAPABILITIES_LIST);
 		raiResponse.setSpeechCapabilities(Test.GENERAL_SPEECHCAPABILITIES_LIST);
+		raiResponse.setPrerecordedSpeech(Test.GENERAL_PRERECORDEDSPEECH_LIST);
 		raiResponse.setSuccess(true);
 
 		systemCapabilityManager.parseRAIResponse(raiResponse);
@@ -106,6 +108,9 @@ public class SystemCapabilityManagerTests extends AndroidTestCase2 {
 				Validator.validateSoftButtonCapabilities(Test.GENERAL_SOFTBUTTONCAPABILITIES_LIST, (List<SoftButtonCapabilities>) systemCapabilityManager.getCapability(SystemCapabilityType.SOFTBUTTON)));
 		assertTrue(Test.TRUE,
 				Validator.validateSpeechCapabilities(Test.GENERAL_SPEECHCAPABILITIES_LIST, (List<SpeechCapabilities>) systemCapabilityManager.getCapability(SystemCapabilityType.SPEECH)));
+		assertTrue(Test.TRUE,
+				Validator.validatePreRecordedSpeechCapabilities(Test.GENERAL_PRERECORDEDSPEECH_LIST, (List<PrerecordedSpeech>) systemCapabilityManager.getCapability(SystemCapabilityType.PRERECORDED_SPEECH)));
+
 	}
 
 	public void testGetVSCapability(){

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/SystemCapabilityTypeTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/SystemCapabilityTypeTests.java
@@ -48,6 +48,8 @@ public class SystemCapabilityTypeTests extends TestCase {
 		SystemCapabilityType enumPCM = SystemCapabilityType.valueForString(example);
 		example = "APP_SERVICES";
 		SystemCapabilityType enumAppServices = SystemCapabilityType.valueForString(example);
+		example = "PRERECORDED_SPEECH";
+		SystemCapabilityType enumPrerecordedSpeech = SystemCapabilityType.valueForString(example);
 
 		assertNotNull("NAVIGATION returned null", enumNavigation);
 		assertNotNull("PHONE_CALL returned null", enumPhoneCall);
@@ -64,6 +66,7 @@ public class SystemCapabilityTypeTests extends TestCase {
 		assertNotNull("VOICE_RECOGNITION returned null", enumVoiceRecognition);
 		assertNotNull("PCM_STREAMING", enumPCM);
 		assertNotNull("APP_SERVICES", enumAppServices);
+		assertNotNull("PRERECORDED_SPEECH", enumPrerecordedSpeech);
 	}
 
 	/**
@@ -116,6 +119,7 @@ public class SystemCapabilityTypeTests extends TestCase {
 		enumTestList.add(SystemCapabilityType.VOICE_RECOGNITION);
 		enumTestList.add(SystemCapabilityType.PCM_STREAMING);
 		enumTestList.add(SystemCapabilityType.APP_SERVICES);
+		enumTestList.add(SystemCapabilityType.PRERECORDED_SPEECH);
 
 		assertTrue("Enum value list does not match enum class list", 
 				enumValueList.containsAll(enumTestList) && enumTestList.containsAll(enumValueList));

--- a/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
@@ -83,6 +83,7 @@ public class SystemCapabilityManager {
 			setCapability(SystemCapabilityType.SOFTBUTTON, response.getSoftButtonCapabilities());
 			setCapability(SystemCapabilityType.SPEECH, response.getSpeechCapabilities());
 			setCapability(SystemCapabilityType.VOICE_RECOGNITION, response.getVrCapabilities());
+			setCapability(SystemCapabilityType.PRERECORDED_SPEECH, response.getPrerecordedSpeech());
 		}
 	}
 

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/SystemCapabilityType.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/SystemCapabilityType.java
@@ -281,7 +281,29 @@ public enum SystemCapabilityType {
 	 * 		</tr>
 	 * 	</table>
 	 */
-    DISPLAY (false),
+	DISPLAY (false),
+
+	/**
+	 * Available Synchronously after Register App Interface response <br>
+	 * Returns: List<PrerecordedSpeech>
+	 * <table border="1" rules="all">
+	 * 		<tr>
+	 * 			<th>Enum Name</th>
+	 * 			<th>Return Type</th>
+	 * 			<th>Description</th>
+	 * 			<th>Requires Async?</th>
+	 * 			<th>Notes</th>
+	 * 		</tr>
+	 * 		<tr>
+	 * 			<td>DISPLAY</td>
+	 * 			<td>prerecordedSpeechCapabilities</td>
+	 * 			<td>Returns List<PrerecordedSpeech></td>
+	 * 			<td align=center>N</td>
+	 * 			<td>Available Synchronously <strong>after</strong> Register App Interface response received</td>
+	 * 		</tr>
+	 * 	</table>
+	 */
+	PRERECORDED_SPEECH (false),
 
 	/**
 	 * Available Synchronously after Register App Interface response <br>

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/SystemCapabilityType.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/SystemCapabilityType.java
@@ -295,7 +295,7 @@ public enum SystemCapabilityType {
 	 * 			<th>Notes</th>
 	 * 		</tr>
 	 * 		<tr>
-	 * 			<td>DISPLAY</td>
+	 * 			<td>PRERECORDED_SPEECH</td>
 	 * 			<td>prerecordedSpeechCapabilities</td>
 	 * 			<td>Returns List<PrerecordedSpeech></td>
 	 * 			<td align=center>N</td>


### PR DESCRIPTION
Fixes #1123 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests and smoke tests

```java
sdlManager.getSystemCapabilityManager().getCapability(SystemCapabilityType.PRERECORDED_SPEECH, new OnSystemCapabilityListener() {
    @Override
    public void onCapabilityRetrieved(Object capability) {
        List<PrerecordedSpeech> prerecordedSpeeches = SystemCapabilityManager.convertToList(capability, PrerecordedSpeech.class);

        for (PrerecordedSpeech speech : prerecordedSpeeches){
            Log.i(TAG, "SPEECH CAP: "+ speech.toString());
        }
    }

    @Override
    public void onError(String info) {

    }
});
```

### Summary
Add new capability type

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)