### PR TITLE
Bug fix for #1102: Resuming video stream

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -194,6 +194,7 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 				&& hmiLevel != null
 				&& hmiLevel.equals(HMILevel.HMI_FULL)
 				&& parameters != null){
+			stateMachine.transitionToState(StreamingStateMachine.READY);
 			transitionToState(READY);
 		}
 	}

--- a/android/sdl_android/src/main/java/com/smartdevicelink/streaming/video/SdlRemoteDisplay.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/streaming/video/SdlRemoteDisplay.java
@@ -173,7 +173,7 @@ public abstract class SdlRemoteDisplay extends Presentation {
                 public void run() {
                     // Want to create presentation on UI thread so it finds the right Looper
                     // when setting up the Dialog.
-                    if ((remoteDisplay == null) && (mDisplay != null))
+                    if((mDisplay!=null) && (remoteDisplay == null || remoteDisplay.getDisplay() != mDisplay))
                     {
                         try {
                             Constructor constructor = remoteDisplayClass.getConstructor(Context.class, Display.class);


### PR DESCRIPTION
Fixes #1102 (Similar to PR #1116)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Tested on own version of app + custom web-based HMI

### Summary
Added a state transition to Video Stream Manager so that the state machine works, and added an alternative condition to show a SdlRemoteDisplay (which is when there already was a previous but different Display)

### Changelog
##### Breaking Changes
* NA

##### Enhancements
* NA

##### Bug Fixes
* Added state transition to VideoStreamManager
* Altered if condition in SdlRemoteDisplay

### Tasks Remaining:
- NA

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
