### PR TITLE
Implement Issue 1125 Show OEM Logo Lockscreen

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenConfig.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenConfig.java
@@ -45,6 +45,8 @@ package com.smartdevicelink.managers.lockscreen;
  * <li> appIcon - if using the default lockscreen, you can set your own app icon</li>
  *
  * <li> customView - If you would like to provide your own view, you can pass it in here.</li>
+ *
+ * <li> deviceLogo - On by default. If available, will show the device or OEMs logo on the lockscreen</li>
  */
 public class LockScreenConfig {
 
@@ -54,7 +56,7 @@ public class LockScreenConfig {
 	public LockScreenConfig(){
 		// set default values
 		this.enable = true;
-		this.deviceLogo = false;
+		this.deviceLogo = true;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1125 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Smoke testing was performed against the develop branch of core on an ubuntu VM

### Summary
Change the default value of showDeviceLogo in the LockscreenConfig from false to true to match iOS

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
