### PR TITLE
SoftButtonObject enhancements

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/ScreenManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/ScreenManagerTests.java
@@ -139,17 +139,19 @@ public class ScreenManagerTests extends AndroidTestCase2 {
 		SoftButtonState softButtonState1 = new SoftButtonState("object1-state1", "it is", testArtwork);
 		SoftButtonState softButtonState2 = new SoftButtonState("object1-state2", "Wed", testArtwork);
 		SoftButtonObject softButtonObject1 = new SoftButtonObject("object1", Arrays.asList(softButtonState1, softButtonState2), softButtonState1.getName(),null);
+		softButtonObject1.setButtonId(100);
 
 		// Create softButtonObject2
 		SoftButtonState softButtonState3 = new SoftButtonState("object2-state1", "my", testArtwork);
 		SoftButtonState softButtonState4 = new SoftButtonState("object2-state2", "dudes!", null);
 		SoftButtonObject softButtonObject2 = new SoftButtonObject("object2", Arrays.asList(softButtonState3, softButtonState4), softButtonState3.getName(), null);
+		softButtonObject2.setButtonId(200);
 
 		List<SoftButtonObject> softButtonObjects = Arrays.asList(softButtonObject1, softButtonObject2);
 		screenManager.setSoftButtonObjects(Arrays.asList(softButtonObject1, softButtonObject2));
 		assertEquals(screenManager.getSoftButtonObjects(), softButtonObjects);
 		assertEquals(screenManager.getSoftButtonObjectByName("object2"), softButtonObject2);
-		assertEquals(screenManager.getSoftButtonObjectById(100), softButtonObject2);
+		assertEquals(screenManager.getSoftButtonObjectById(200), softButtonObject2);
 	}
 
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -24,6 +24,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -242,5 +243,57 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
         success = softButtonObject1.transitionToStateByName("object1-state1");
         assertTrue(success);
         assertEquals(softButtonState1, softButtonObject1.getCurrentState());
+    }
+
+    public void testAssigningIdsToSoftButtonObjects(){
+        SoftButtonObject sbo1, sbo2, sbo3, sbo4, sbo5;
+
+        // Case 1 - don't set id for any button (Manager should set ids automatically starting from 1 and up)
+        sbo1 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        sbo2 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        sbo3 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        sbo4 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        sbo5 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        softButtonManager.checkAndAssignButtonIds(Arrays.asList(sbo1, sbo2, sbo3, sbo4, sbo5));
+        assertEquals("SoftButtonObject id doesn't match the expected value", 1, sbo1.getButtonId());
+        assertEquals("SoftButtonObject id doesn't match the expected value", 2, sbo2.getButtonId());
+        assertEquals("SoftButtonObject id doesn't match the expected value", 3, sbo3.getButtonId());
+        assertEquals("SoftButtonObject id doesn't match the expected value", 4, sbo4.getButtonId());
+        assertEquals("SoftButtonObject id doesn't match the expected value", 5, sbo5.getButtonId());
+
+
+        // Case 2 - Set ids for all buttons (Manager shouldn't alter the ids set by developer)
+        sbo1 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        sbo1.setButtonId(100);
+        sbo2 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        sbo2.setButtonId(200);
+        sbo3 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        sbo3.setButtonId(300);
+        sbo4 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        sbo4.setButtonId(400);
+        sbo5 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        sbo5.setButtonId(500);
+        softButtonManager.checkAndAssignButtonIds(Arrays.asList(sbo1, sbo2, sbo3, sbo4, sbo5));
+        assertEquals("SoftButtonObject id doesn't match the expected value", 100, sbo1.getButtonId());
+        assertEquals("SoftButtonObject id doesn't match the expected value", 200, sbo2.getButtonId());
+        assertEquals("SoftButtonObject id doesn't match the expected value", 300, sbo3.getButtonId());
+        assertEquals("SoftButtonObject id doesn't match the expected value", 400, sbo4.getButtonId());
+        assertEquals("SoftButtonObject id doesn't match the expected value", 500, sbo5.getButtonId());
+
+
+        // Case 23 - Set ids for some buttons (Manager shouldn't alter the ids set by developer. And it should assign ids for the ones that don't have id)
+        sbo1 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        sbo1.setButtonId(50);
+        sbo2 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        sbo3 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        sbo4 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        sbo4.setButtonId(100);
+        sbo5 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        softButtonManager.checkAndAssignButtonIds(Arrays.asList(sbo1, sbo2, sbo3, sbo4, sbo5));
+        assertEquals("SoftButtonObject id doesn't match the expected value", 50, sbo1.getButtonId());
+        assertEquals("SoftButtonObject id doesn't match the expected value", 101, sbo2.getButtonId());
+        assertEquals("SoftButtonObject id doesn't match the expected value", 102, sbo3.getButtonId());
+        assertEquals("SoftButtonObject id doesn't match the expected value", 100, sbo4.getButtonId());
+        assertEquals("SoftButtonObject id doesn't match the expected value", 103, sbo5.getButtonId());
     }
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -245,7 +245,7 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
         assertEquals(softButtonState1, softButtonObject1.getCurrentState());
     }
 
-    public void testAssigningIdsToSoftButtonObjects(){
+    public void testAssigningIdsToSoftButtonObjects() {
         SoftButtonObject sbo1, sbo2, sbo3, sbo4, sbo5;
 
         // Case 1 - don't set id for any button (Manager should set ids automatically starting from 1 and up)
@@ -281,7 +281,7 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
         assertEquals("SoftButtonObject id doesn't match the expected value", 500, sbo5.getButtonId());
 
 
-        // Case 23 - Set ids for some buttons (Manager shouldn't alter the ids set by developer. And it should assign ids for the ones that don't have id)
+        // Case 3 - Set ids for some buttons (Manager shouldn't alter the ids set by developer. And it should assign ids for the ones that don't have id)
         sbo1 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
         sbo1.setButtonId(50);
         sbo2 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -39,8 +39,9 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
 
     private SoftButtonManager softButtonManager;
     private boolean fileManagerUploadArtworksGotCalled;
-    private boolean internalInterfaceSendRPCRequestGotCalled;
+    private boolean internalInterfaceSendRPCGotCalled;
     private boolean softButtonMangerUpdateCompleted;
+    private int softButtonObject1Id = 1000, softButtonObject2Id = 2000;
     private SoftButtonObject softButtonObject1, softButtonObject2;
     private SoftButtonState softButtonState1, softButtonState2, softButtonState3, softButtonState4;
 
@@ -86,13 +87,13 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
         softButtonManager = new SoftButtonManager(internalInterface, fileManager);
 
 
-        // When internalInterface.sendRPCRequest() is called inside SoftButtonManager:
+        // When internalInterface.sendRPC() is called inside SoftButtonManager:
         // 1) respond with a fake onResponse() callback to let the SoftButtonManager continue working
         // 2) assert that the Show RPC values (ie: MainField1 & SoftButtons) that are created by the SoftButtonManager, match the ones that are provided by the developer
         Answer<Void> onSendShowRPCAnswer = new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock invocation) {
-                internalInterfaceSendRPCRequestGotCalled = true;
+                internalInterfaceSendRPCGotCalled = true;
                 Object[] args = invocation.getArguments();
                 Show show = (Show) args[0];
 
@@ -104,16 +105,18 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
                 return null;
             }
         };
-        doAnswer(onSendShowRPCAnswer).when(internalInterface).sendRPCRequest(any(Show.class));
+        doAnswer(onSendShowRPCAnswer).when(internalInterface).sendRPC(any(Show.class));
 
 
         // Create soft button objects
         softButtonState1 = new SoftButtonState("object1-state1", "o1s1", new SdlArtwork("image1", FileType.GRAPHIC_PNG, 1, true));
         softButtonState2 = new SoftButtonState("object1-state2", "o1s2", new SdlArtwork(StaticIconName.ALBUM));
         softButtonObject1 = new SoftButtonObject("object1", Arrays.asList(softButtonState1, softButtonState2), softButtonState1.getName(), null);
+        softButtonObject1.setButtonId(softButtonObject1Id);
         softButtonState3 = new SoftButtonState("object2-state1", "o2s1", null);
         softButtonState4 = new SoftButtonState("object2-state2", "o2s2", new SdlArtwork("image3", FileType.GRAPHIC_PNG, 3, true));
         softButtonObject2 = new SoftButtonObject("object2", Arrays.asList(softButtonState3, softButtonState4), softButtonState3.getName(), null);
+        softButtonObject2.setButtonId(softButtonObject2Id);
     }
 
     @Override
@@ -124,7 +127,7 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
     public void testSoftButtonManagerUpdate() {
         // Reset the boolean variables
         fileManagerUploadArtworksGotCalled = false;
-        internalInterfaceSendRPCRequestGotCalled = false;
+        internalInterfaceSendRPCGotCalled = false;
         softButtonMangerUpdateCompleted = false;
 
 
@@ -148,7 +151,7 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
 
         // Check that everything got called as expected
         assertTrue("FileManager.uploadArtworks() did not get called", fileManagerUploadArtworksGotCalled);
-        assertTrue("InternalInterface.sendRPCRequest() did not get called", internalInterfaceSendRPCRequestGotCalled);
+        assertTrue("InternalInterface.sendRPC() did not get called", internalInterfaceSendRPCGotCalled);
         assertTrue("SoftButtonManger update onComplete() did not get called", softButtonMangerUpdateCompleted);
 
 
@@ -169,11 +172,11 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
 
 
         // Test get by valid id
-        assertEquals("Returned SoftButtonObject doesn't match the expected value", softButtonObject2, softButtonManager.getSoftButtonObjectById(100));
+        assertEquals("Returned SoftButtonObject doesn't match the expected value", softButtonObject2, softButtonManager.getSoftButtonObjectById(softButtonObject2Id));
 
 
         // Test get by invalid id
-        assertNull("Returned SoftButtonObject doesn't match the expected value", softButtonManager.getSoftButtonObjectById(500));
+        assertNull("Returned SoftButtonObject doesn't match the expected value", softButtonManager.getSoftButtonObjectById(5555));
     }
 
     public void testSoftButtonState(){
@@ -190,9 +193,10 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
 
 
         // Test SoftButtonState.getSoftButton()
-        SoftButton softButtonExpectedValue = new SoftButton(SoftButtonType.SBT_BOTH, 0);
+        SoftButton softButtonExpectedValue = new SoftButton(SoftButtonType.SBT_BOTH, SoftButtonObject.SOFT_BUTTON_ID_NOT_SET_VALUE);
         softButtonExpectedValue.setText("o1s1");
         softButtonExpectedValue.setImage(new Image(artworkExpectedValue.getName(), ImageType.DYNAMIC));
+        SoftButton actual = softButtonState1.getSoftButton();
         assertTrue("Returned SoftButton doesn't match the expected value", Validator.validateSoftButton(softButtonExpectedValue, softButtonState1.getSoftButton()));
     }
 
@@ -210,11 +214,11 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
 
 
         // Test SoftButtonObject.getButtonId()
-        assertEquals("Returned button Id doesn't match the expected value", 0, softButtonObject1.getButtonId());
+        assertEquals("Returned button Id doesn't match the expected value", softButtonObject1Id, softButtonObject1.getButtonId());
 
 
         // Test SoftButtonObject.getCurrentStateSoftButton()
-        SoftButton softButtonExpectedValue = new SoftButton(SoftButtonType.SBT_TEXT, 0);
+        SoftButton softButtonExpectedValue = new SoftButton(SoftButtonType.SBT_TEXT, softButtonObject2Id);
         softButtonExpectedValue.setText("o2s1");
         assertTrue("Returned current state SoftButton doesn't match the expected value", Validator.validateSoftButton(softButtonExpectedValue, softButtonObject2.getCurrentStateSoftButton()));
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/Validator.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/Validator.java
@@ -367,7 +367,7 @@ public class Validator{
         return validateImage(button1.getImage(), button2.getImage())
                 && validateText(button1.getText(), button2.getText())
                 && button1.getIsHighlighted() == button2.getIsHighlighted()
-                && button1.getSoftButtonID() == button2.getSoftButtonID()
+                && ( (button1 .getSoftButtonID() == null && button2.getSoftButtonID() == null) || button1.getSoftButtonID().equals(button2.getSoftButtonID()))
                 && button1.getSystemAction() == button2.getSystemAction()
                 && button1.getType() == button2.getType();
     }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
@@ -296,7 +296,7 @@ abstract class BaseSoftButtonManager extends BaseSubManager {
 
 
         // Set ids and updateListeners for soft button objects
-        int generatedSoftButtonId = buttonIdsSetByDevHashSet.isEmpty() ? SoftButtonObject.SOFT_BUTTON_ID_MIN_VALUE : Collections.max(buttonIdsSetByDevHashSet);;
+        int generatedSoftButtonId = buttonIdsSetByDevHashSet.isEmpty() ? SoftButtonObject.SOFT_BUTTON_ID_MIN_VALUE : Collections.max(buttonIdsSetByDevHashSet);
         for (SoftButtonObject softButtonObject : softButtonObjects) {
             softButtonObject.setUpdateListener(updateListener);
 

--- a/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
@@ -279,7 +279,7 @@ abstract class BaseSoftButtonManager extends BaseSubManager {
         }
 
 
-        // Check if two soft button objects have the same id
+        // Check if multiple soft button objects have the same id
         HashSet<Integer> buttonIdsSetByDevHashSet = new HashSet<>();
         int currentSoftButtonId, numberOfButtonIdsSetByDev = 0;
         for (SoftButtonObject softButtonObject : softButtonObjects) {
@@ -296,14 +296,20 @@ abstract class BaseSoftButtonManager extends BaseSubManager {
 
 
         // Set ids and updateListeners for soft button objects
-        int generatedSoftButtonId = buttonIdsSetByDevHashSet.isEmpty() ? 0 : Collections.max(buttonIdsSetByDevHashSet);
+        int generatedSoftButtonId = buttonIdsSetByDevHashSet.isEmpty() ? SoftButtonObject.SOFT_BUTTON_ID_MIN_VALUE : Collections.max(buttonIdsSetByDevHashSet);;
         for (SoftButtonObject softButtonObject : softButtonObjects) {
             softButtonObject.setUpdateListener(updateListener);
 
             // If the dev did not set the buttonId, the manager should set an id on the dev's behalf
             currentSoftButtonId = softButtonObject.getButtonId();
             if (currentSoftButtonId == SoftButtonObject.SOFT_BUTTON_ID_NOT_SET_VALUE){
-                softButtonObject.setButtonId(++generatedSoftButtonId);
+                do {
+                    if (generatedSoftButtonId >= SoftButtonObject.SOFT_BUTTON_ID_MAX_VALUE){
+                        generatedSoftButtonId = SoftButtonObject.SOFT_BUTTON_ID_MIN_VALUE;
+                    }
+                    generatedSoftButtonId++;
+                } while (buttonIdsSetByDevHashSet.contains(generatedSoftButtonId));
+                softButtonObject.setButtonId(generatedSoftButtonId);
             }
         }
         this.softButtonObjects = softButtonObjects;

--- a/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
@@ -444,9 +444,8 @@ abstract class BaseSoftButtonManager extends BaseSubManager {
             public void onError(int correlationId, Result resultCode, String info) {
                 super.onError(correlationId, resultCode, info);
 
-                Log.e(TAG, "Soft button update error");
+                Log.e(TAG, "Soft button update error. resultCode: " + resultCode + ". info: " + info);
                 handleResponse(false);
-
             }
 
             private void handleResponse(boolean success){

--- a/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
@@ -386,11 +386,14 @@ abstract class BaseSoftButtonManager extends BaseSubManager {
     boolean checkAndAssignButtonIds(List<SoftButtonObject> softButtonObjects) {
         // Check if multiple soft button objects have the same id
         HashSet<Integer> buttonIdsSetByDevHashSet = new HashSet<>();
-        int currentSoftButtonId, numberOfButtonIdsSetByDev = 0;
+        int currentSoftButtonId, numberOfButtonIdsSetByDev = 0, maxButtonIdsSetByDev = SoftButtonObject.SOFT_BUTTON_ID_MIN_VALUE;
         for (SoftButtonObject softButtonObject : softButtonObjects) {
             currentSoftButtonId = softButtonObject.getButtonId();
             if (currentSoftButtonId != SoftButtonObject.SOFT_BUTTON_ID_NOT_SET_VALUE) {
                 numberOfButtonIdsSetByDev++;
+                if (currentSoftButtonId > maxButtonIdsSetByDev){
+                    maxButtonIdsSetByDev = currentSoftButtonId;
+                }
                 buttonIdsSetByDevHashSet.add(softButtonObject.getButtonId());
             }
         }
@@ -400,7 +403,7 @@ abstract class BaseSoftButtonManager extends BaseSubManager {
 
 
         // Set ids for soft button objects
-        int generatedSoftButtonId = buttonIdsSetByDevHashSet.isEmpty() ? SoftButtonObject.SOFT_BUTTON_ID_MIN_VALUE : Collections.max(buttonIdsSetByDevHashSet);
+        int generatedSoftButtonId = maxButtonIdsSetByDev;
         for (SoftButtonObject softButtonObject : softButtonObjects) {
             // If the dev did not set the buttonId, the manager should set an id on the dev's behalf
             currentSoftButtonId = softButtonObject.getButtonId();

--- a/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
@@ -62,7 +62,6 @@ import com.smartdevicelink.util.DebugTool;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -52,6 +52,7 @@ import java.util.List;
 public class SoftButtonObject {
 
     private static final String TAG = "SoftButtonObject";
+    static int SOFT_BUTTON_ID_NOT_SET_VALUE = -1;
     private String name;
     private List<SoftButtonState> states;
     private String currentStateName;
@@ -78,7 +79,7 @@ public class SoftButtonObject {
         this.name = name;
         this.states = states;
         currentStateName = initialStateName;
-        this.buttonId = 0;
+        this.buttonId = SOFT_BUTTON_ID_NOT_SET_VALUE;
         this.onEventListener = onEventListener;
     }
 
@@ -268,6 +269,10 @@ public class SoftButtonObject {
      * @param buttonId an int value that represents the id of the SoftButtonObject
      */
     public void setButtonId(int buttonId) {
+        if (buttonId < 0){
+            Log.e(TAG, "buttonId has to be more than 0");
+            return;
+        }
         this.buttonId = buttonId;
     }
 

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -53,6 +53,8 @@ public class SoftButtonObject {
 
     private static final String TAG = "SoftButtonObject";
     static int SOFT_BUTTON_ID_NOT_SET_VALUE = -1;
+    static int SOFT_BUTTON_ID_MIN_VALUE = 0;
+    static int SOFT_BUTTON_ID_MAX_VALUE = 65535;
     private String name;
     private List<SoftButtonState> states;
     private String currentStateName;
@@ -269,8 +271,8 @@ public class SoftButtonObject {
      * @param buttonId an int value that represents the id of the SoftButtonObject
      */
     public void setButtonId(int buttonId) {
-        if (buttonId < 0){
-            Log.e(TAG, "buttonId has to be more than 0");
+        if (buttonId < SOFT_BUTTON_ID_MIN_VALUE){
+            Log.e(TAG, "buttonId has to be equal or more than " + SOFT_BUTTON_ID_MIN_VALUE);
             return;
         }
         this.buttonId = buttonId;

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -267,7 +267,8 @@ public class SoftButtonObject {
 
     /**
      * Sets the id of the SoftButtonObject <br>
-     * <strong>Note: This may be overridden by the Screen Manager</strong>
+     * <strong>Note: If the developer did not set buttonId, the manager will automatically assign an id before the SoftButtons are sent to the head unit.
+     * Please note that the manager may reuse ids from previous batch of SoftButtons that were already sent to the head unit</strong>
      * @param buttonId an int value that represents the id of the SoftButtonObject
      */
     public void setButtonId(int buttonId) {

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
@@ -37,6 +37,9 @@ import android.util.Log;
 import com.smartdevicelink.managers.file.filetypes.SdlArtwork;
 import com.smartdevicelink.proxy.rpc.SoftButton;
 import com.smartdevicelink.proxy.rpc.enums.SoftButtonType;
+import com.smartdevicelink.proxy.rpc.enums.SystemAction;
+
+import java.util.List;
 
 /**
  * <strong>SoftButtonState</strong> <br>
@@ -106,6 +109,40 @@ public class SoftButtonState {
      */
     public void setName(@NonNull String name) {
         this.name = name;
+    }
+
+    /**
+     * Get whether or not the button should be highlighted on the UI
+     * @return boolean representing whether or not the button should be highlighted
+     */
+    public boolean getHighlighted(){
+        return this.getSoftButton().getIsHighlighted();
+    }
+
+    /**
+     * Set whether or not the button should be highlighted on the UI
+     * @param highlighted boolean representing whether or not the button should be highlighted
+     */
+    public void setHighlighted(boolean highlighted){
+        this.getSoftButton().setIsHighlighted(highlighted);
+    }
+
+    /**
+     * Get whether selecting a SoftButton shall call a specific system action
+     * See {@link SystemAction}
+     * @return SystemAction value representing whether selecting a SoftButton shall call a specific action
+     */
+    public SystemAction getSystemAction(){
+        return this.getSoftButton().getSystemAction();
+    }
+
+    /**
+     * Set whether selecting a SoftButton shall call a specific system action
+     * See {@link SystemAction}
+     * @param systemAction SystemAction value representing whether selecting a SoftButton shall call a specific action
+     */
+    public void setSystemAction(SystemAction systemAction){
+        this.getSoftButton().setSystemAction(systemAction);
     }
 
     /**

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
@@ -81,7 +81,7 @@ public class SoftButtonState {
         } else {
             type = SoftButtonType.SBT_TEXT;
         }
-        this.softButton = new SoftButton(type, 0);
+        this.softButton = new SoftButton(type, SoftButtonObject.SOFT_BUTTON_ID_NOT_SET_VALUE);
 
 
         // Set the SoftButton's image


### PR DESCRIPTION
Fixes #1126 & #1127 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests have been updated.

### Summary
- Add `isHighlighted` & `systemAction` setters to `SoftbuttonState`
- Improve `buttonId` setting logic in `SoftButtonManager`. The manager now allows devs to set their own ids and will not alter them. However, if the dev did not set `buttonId`, the manager will still automatically set one on the dev's behalf

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
