### PR TITLE
Add getBytesAvailable() to FileManager

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
@@ -39,7 +39,6 @@ import static org.mockito.Mockito.mock;
  */
 public class FileManagerTests extends AndroidTestCase2 {
 	public static final String TAG = "FileManagerTests";
-	private FileManager fileManager;
 	private Context mTestContext;
 	private SdlFile validFile;
 
@@ -101,6 +100,7 @@ public class FileManagerTests extends AndroidTestCase2 {
 				int correlationId = message.getCorrelationID();
 				PutFileResponse putFileResponse = new PutFileResponse();
 				putFileResponse.setSuccess(true);
+				putFileResponse.setSpaceAvailable(Test.GENERAL_INT);
 				message.getOnRPCResponseListener().onResponse(correlationId, putFileResponse);
 			}
 			return null;
@@ -153,8 +153,9 @@ public class FileManagerTests extends AndroidTestCase2 {
 			@Override
 			public void onComplete(boolean success) {
 				assertTrue(success);
-				Assert.assertEquals(fileManager.getState(), BaseSubManager.READY);
+				assertEquals(fileManager.getState(), BaseSubManager.READY);
 				assertEquals(fileManager.getRemoteFileNames(), Test.GENERAL_STRING_LIST);
+				assertEquals(Test.GENERAL_INT, fileManager.getBytesAvailable());
 			}
 		});
 	}
@@ -170,6 +171,7 @@ public class FileManagerTests extends AndroidTestCase2 {
 			public void onComplete(boolean success) {
 				assertFalse(success);
 				assertEquals(fileManager.getState(), BaseSubManager.ERROR);
+				assertEquals(BaseFileManager.SPACE_AVAILABLE_MAX_VALUE, fileManager.getBytesAvailable());
 			}
 		});
 	}
@@ -191,6 +193,7 @@ public class FileManagerTests extends AndroidTestCase2 {
 						assertTrue(success);
 						assertTrue(fileManager.getRemoteFileNames().contains(validFile.getName()));
 						assertTrue(fileManager.hasUploadedFile(validFile));
+						assertEquals(Test.GENERAL_INT, fileManager.getBytesAvailable());
 					}
 				});
 			}

--- a/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
@@ -79,7 +79,7 @@ import java.util.Map;
 abstract class BaseFileManager extends BaseSubManager {
 
 	final static String TAG = "FileManager";
-	private final static int SPACE_AVAILABLE_MAX_VALUE = 2000000000;
+	final static int SPACE_AVAILABLE_MAX_VALUE = 2000000000;
 	private List<String> remoteFiles, uploadedEphemeralFileNames;
 	private int bytesAvailable = SPACE_AVAILABLE_MAX_VALUE;
 

--- a/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
@@ -44,9 +44,11 @@ import com.smartdevicelink.proxy.RPCRequest;
 import com.smartdevicelink.proxy.RPCResponse;
 import com.smartdevicelink.proxy.interfaces.ISdl;
 import com.smartdevicelink.proxy.rpc.DeleteFile;
+import com.smartdevicelink.proxy.rpc.DeleteFileResponse;
 import com.smartdevicelink.proxy.rpc.ListFiles;
 import com.smartdevicelink.proxy.rpc.ListFilesResponse;
 import com.smartdevicelink.proxy.rpc.PutFile;
+import com.smartdevicelink.proxy.rpc.PutFileResponse;
 import com.smartdevicelink.proxy.rpc.enums.Result;
 import com.smartdevicelink.proxy.rpc.listeners.OnMultipleRequestListener;
 import com.smartdevicelink.proxy.rpc.listeners.OnRPCResponseListener;
@@ -77,7 +79,9 @@ import java.util.Map;
 abstract class BaseFileManager extends BaseSubManager {
 
 	final static String TAG = "FileManager";
+	private final static int SPACE_AVAILABLE_MAX_VALUE = 2000000000;
 	private List<String> remoteFiles, uploadedEphemeralFileNames;
+	private int bytesAvailable = SPACE_AVAILABLE_MAX_VALUE;
 
 	BaseFileManager(ISdl internalInterface) {
 
@@ -108,6 +112,14 @@ abstract class BaseFileManager extends BaseSubManager {
 		return remoteFiles;
 	}
 
+	/**
+	 * Get the number of bytes still available for files for this app.
+	 * @return int value representing The number of bytes still available
+	 */
+	public int getBytesAvailable(){
+		return bytesAvailable;
+	}
+
 	private void retrieveRemoteFiles(){
 		remoteFiles = new ArrayList<>();
 		// hold list in remoteFiles class var
@@ -115,9 +127,12 @@ abstract class BaseFileManager extends BaseSubManager {
 		listFiles.setOnRPCResponseListener(new OnRPCResponseListener() {
 			@Override
 			public void onResponse(int correlationId, RPCResponse response) {
-				if(response.getSuccess()){
-					if(((ListFilesResponse) response).getFilenames() != null){
-						remoteFiles.addAll(((ListFilesResponse) response).getFilenames());
+				ListFilesResponse listFilesResponse = (ListFilesResponse) response;
+				if(listFilesResponse.getSuccess()){
+					bytesAvailable = listFilesResponse.getSpaceAvailable() != null ? listFilesResponse.getSpaceAvailable() : SPACE_AVAILABLE_MAX_VALUE;
+
+					if(listFilesResponse.getFilenames() != null){
+						remoteFiles.addAll(listFilesResponse.getFilenames());
 					}
 					// on callback set manager to ready state
 					transitionToState(BaseSubManager.READY);
@@ -146,12 +161,15 @@ abstract class BaseFileManager extends BaseSubManager {
 		deleteFile.setOnRPCResponseListener(new OnRPCResponseListener() {
 			@Override
 			public void onResponse(int correlationId, RPCResponse response) {
-				if(response.getSuccess()){
+				DeleteFileResponse deleteFileResponse = (DeleteFileResponse) response;
+				if(deleteFileResponse.getSuccess()){
+					bytesAvailable = deleteFileResponse.getSpaceAvailable() != null ? deleteFileResponse.getSpaceAvailable() : SPACE_AVAILABLE_MAX_VALUE;
+
 					remoteFiles.remove(fileName);
 					uploadedEphemeralFileNames.remove(fileName);
 				}
 				if(listener != null){
-					listener.onComplete(response.getSuccess());
+					listener.onComplete(deleteFileResponse.getSuccess());
 				}
 			}
 		});
@@ -238,7 +256,10 @@ abstract class BaseFileManager extends BaseSubManager {
 
 			@Override
 			public void onResponse(int correlationId, RPCResponse response) {
-				if(response.getSuccess()){
+				PutFileResponse putFileResponse = (PutFileResponse) response;
+				if(putFileResponse.getSuccess()){
+					bytesAvailable = putFileResponse.getSpaceAvailable() != null ? putFileResponse.getSpaceAvailable() : SPACE_AVAILABLE_MAX_VALUE;
+
 					if(fileNameMap.get(correlationId) != null){
 						if(deletionOperation){
 							remoteFiles.remove(fileNameMap.get(correlationId));
@@ -269,12 +290,15 @@ abstract class BaseFileManager extends BaseSubManager {
 		putFile.setOnRPCResponseListener(new OnRPCResponseListener() {
 			@Override
 			public void onResponse(int correlationId, RPCResponse response) {
-				if(response.getSuccess()){
+				PutFileResponse putFileResponse = (PutFileResponse) response;
+				if(putFileResponse.getSuccess()){
+					bytesAvailable = putFileResponse.getSpaceAvailable() != null ? putFileResponse.getSpaceAvailable() : SPACE_AVAILABLE_MAX_VALUE;
+
 					remoteFiles.add(file.getName());
 					uploadedEphemeralFileNames.add(file.getName());
 				}
 				if(listener != null){
-					listener.onComplete(response.getSuccess());
+					listener.onComplete(putFileResponse.getSuccess());
 				}
 			}
 


### PR DESCRIPTION
Fixes #1133 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests have been updated. To smoke test the new method:
```
sdlManager.getFileManager().getBytesAvailable()
```

### Summary
This PR adds `getBytesAvailable()` API to `FileManager` to let the developer know the number of bytes still available for files.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
