### PR TITLE
Fix VR optional issue in ChoiceSetManager

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/CheckChoiceVROptionalOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/CheckChoiceVROptionalOperation.java
@@ -80,17 +80,15 @@ class CheckChoiceVROptionalOperation implements Runnable {
 					isVROptional = true;
 					deleteTestChoiceSet();
 				}else{
+					DebugTool.logWarning("Head unit doesn't support choices with no VR.");
 					sendTestChoiceWithVR();
 				}
 			}
 
 			@Override
 			public void onError(int correlationId, Result resultCode, String info){
-				DebugTool.logError("There was an error in the check choice vr optional operation. Send test choice with no VR failed. Error: " + info + " resultCode: " + resultCode);
-				isVROptional = false;
-				if (checkChoiceVROptionalInterface != null){
-					checkChoiceVROptionalInterface.onError(info);
-				}
+				DebugTool.logWarning("Head unit doesn't support choices with no VR. Error: " + info + " resultCode: " + resultCode);
+				sendTestChoiceWithVR();
 			}
 		});
 


### PR DESCRIPTION
Fixes #1137 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Test presenting a choice set with a head unit that requires VR for choices 

### Summary
This PR fixes an issue with `ChoiceSetManager` when it is tested against a head unit that requires VR for choices.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
