### PR TITLE
Fix TransportBroker for Feature/implement sdl0054 change registration manager 

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -4120,7 +4120,8 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					}
 
 					//This needs to be ran on the main thread
-                    _mainUIHandler.post(new Runnable() {
+
+					_mainUIHandler.post(new Runnable() {
 						@Override
 						public void run() {
 							cycleProxy(SdlDisconnectedReason.convertAppInterfaceUnregisteredReason(msg.getReason()));

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -1834,6 +1834,12 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		try{			
 				_cycling = true;
 				cleanProxy(disconnectedReason);
+
+				if(SdlDisconnectedReason.LANGUAGE_CHANGE.equals(disconnectedReason) ){
+					//The VR engine might need time to reset
+					Thread.sleep(5000);
+				}
+
 				initializeProxy();
 				if(!SdlDisconnectedReason.LEGACY_BLUETOOTH_MODE_ENABLED.equals(disconnectedReason)
 						&& !SdlDisconnectedReason.PRIMARY_TRANSPORT_CYCLE_REQUEST.equals(disconnectedReason)){//We don't want to alert higher if we are just cycling for legacy bluetooth
@@ -4108,7 +4114,18 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 
 				if (_advancedLifecycleManagementEnabled) {
 					// This requires the proxy to be cycled
-                    cycleProxy(SdlDisconnectedReason.convertAppInterfaceUnregisteredReason(msg.getReason()));
+
+					if(_mainUIHandler == null){
+						_mainUIHandler = new Handler(Looper.getMainLooper());
+					}
+
+					//This needs to be ran on the main thread
+                    _mainUIHandler.post(new Runnable() {
+						@Override
+						public void run() {
+							cycleProxy(SdlDisconnectedReason.convertAppInterfaceUnregisteredReason(msg.getReason()));
+						}
+					});
                 } else {
 					if (_callbackToUIThread) {
 						// Run in UI thread

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -3173,10 +3173,10 @@ public class SdlRouterService extends Service{
 		 * @return
 		 */
 		private TransportType getCompatPrimaryTransport(){
-			if(this.registeredTransports != null){
+			if(this.registeredTransports != null && this.registeredTransports.size() > 0) {
 				List<TransportType> transportTypes = this.registeredTransports.valueAt(0);
-				if(transportTypes != null){
-					if(transportTypes.get(0) != null){
+				if (transportTypes != null) {
+					if (transportTypes.get(0) != null) {
 						return transportTypes.get(0);
 					}
 				}
@@ -3199,7 +3199,9 @@ public class SdlRouterService extends Service{
 			int flags = receivedBundle.getInt(TransportConstants.BYTES_TO_SEND_FLAGS, TransportConstants.BYTES_TO_SEND_FLAG_NONE);
 			TransportType transportType = TransportType.valueForString(receivedBundle.getString(TransportConstants.TRANSPORT_TYPE));
 			if(transportType == null){
-				transportType = getCompatPrimaryTransport();
+				synchronized (TRANSPORT_LOCK){
+					transportType = getCompatPrimaryTransport();
+				}
 				receivedBundle.putString(TransportConstants.TRANSPORT_TYPE, transportType.name());
 			}
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/TransportBroker.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/TransportBroker.java
@@ -55,6 +55,7 @@ import com.smartdevicelink.transport.enums.TransportType;
 import com.smartdevicelink.transport.utl.ByteAraryMessageAssembler;
 import com.smartdevicelink.transport.utl.ByteArrayMessageSpliter;
 import com.smartdevicelink.transport.utl.TransportRecord;
+import com.smartdevicelink.util.DebugTool;
 
 import java.lang.ref.WeakReference;
 import java.text.SimpleDateFormat;
@@ -119,7 +120,6 @@ public class TransportBroker {
                 Log.d(TAG, "Unbound from service " + className.getClassName());
                 routerServiceMessenger = null;
                 registeredWithRouterService = false;
-                unBindFromRouterService();
                 isBound = false;
                 onHardwareDisconnected(null, null);
             }
@@ -158,6 +158,7 @@ public class TransportBroker {
                         Log.d(TAG, "Dead object while attempting to send packet");
                         routerServiceMessenger = null;
                         registeredWithRouterService = false;
+                        unBindFromRouterService();
                         isBound = false;
                         onHardwareDisconnected(null, null);
                         return false;
@@ -166,6 +167,7 @@ public class TransportBroker {
                     Log.d(TAG, "Null messenger while attempting to send packet"); // NPE, routerServiceMessenger is null
                     routerServiceMessenger = null;
                     registeredWithRouterService = false;
+                    unBindFromRouterService();
                     isBound = false;
                     onHardwareDisconnected(null, null);
                     return false;
@@ -448,7 +450,7 @@ public class TransportBroker {
      * This method will end our communication with the router service.
      */
     public void stop() {
-        //Log.d(TAG, "STOPPING transport broker for " + whereToReply);
+        DebugTool.logInfo("Stopping transport broker for " + whereToReply);
         synchronized (INIT_LOCK) {
             unregisterWithRouterService();
             unBindFromRouterService();
@@ -461,15 +463,13 @@ public class TransportBroker {
 
     private synchronized void unBindFromRouterService() {
         try {
-            if (isBound && getContext() != null && routerConnection != null) {
-                getContext().unbindService(routerConnection);
-                isBound = false;
-            } else {
-                Log.w(TAG, "Unable to unbind from router service. bound? " + isBound + " context? " + (getContext()!=null) + " router connection?" + (routerConnection != null));
-            }
+            getContext().unbindService(routerConnection);
 
-        } catch (IllegalArgumentException e) {
+        } catch (Exception e) {
             //This is ok
+             Log.w(TAG, "Unable to unbind from router service. bound? " + isBound + " context? " + (getContext()!=null) + " router connection?" + (routerConnection != null));
+        }finally {
+            isBound = false;
         }
     }
 

--- a/base/src/main/java/com/smartdevicelink/protocol/SdlProtocolBase.java
+++ b/base/src/main/java/com/smartdevicelink/protocol/SdlProtocolBase.java
@@ -529,6 +529,7 @@ public class SdlProtocolBase {
     public void endSession(byte sessionID, int hashId) {
         SdlPacket header = SdlPacketFactory.createEndSession(SessionType.RPC, sessionID, hashId, (byte)protocolVersion.getMajor(), hashId);
         handlePacketToSend(header);
+        transportManager.close(sessionID);
 
     } // end-method
 


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
- Add a call to close the `TransportManager` when ending a session
- Always try to unbind from `RouterService` when called
- Fix where unbinding attempts were being made
- Fix issue in `RouterService` where a `SparseArray` was empty and the method `valueAt` would return a generic `Object` instance and cause a `ClassCastException`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
