### PR TITLE
Allow Video Service to restart after secondary transport disconnection

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/SdlConnection/SdlSession2.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/SdlConnection/SdlSession2.java
@@ -314,7 +314,7 @@ public class SdlSession2 extends SdlSession implements ISdlProtocol{
         // Notify any listeners of the service being ended
         if(serviceListeners != null && serviceListeners.containsKey(serviceType)){
             CopyOnWriteArrayList<ISdlServiceListener> listeners = serviceListeners.get(serviceType);
-            if (listeners != null) {
+            if (listeners != null && listeners.size() > 0) {
                 for (ISdlServiceListener listener : listeners) {
                     listener.onServiceEnded(this, serviceType);
                 }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/SdlConnection/SdlSession2.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/SdlConnection/SdlSession2.java
@@ -311,7 +311,15 @@ public class SdlSession2 extends SdlSession implements ISdlProtocol{
         }else if(SessionType.PCM.equals(serviceType)){
             stopAudioStream();
         }
-
+        // Notify any listeners of the service being ended
+        if(serviceListeners != null && serviceListeners.containsKey(serviceType)){
+            CopyOnWriteArrayList<ISdlServiceListener> listeners = serviceListeners.get(serviceType);
+            if (listeners != null) {
+                for (ISdlServiceListener listener : listeners) {
+                    listener.onServiceEnded(this, serviceType);
+                }
+            }
+        }
     }
 
     @Override

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -5383,7 +5383,9 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				public void onServiceEnded(SdlSession session, SessionType type) {
 					// reset nav flags so nav can start upon the next transport connection
 					resetNavStartFlags();
-					_proxyListener.onServiceEnded(new OnServiceEnded(type));
+					if (_proxyListener != null) {
+						_proxyListener.onServiceEnded(new OnServiceEnded(type));
+					}
 				}
 
 				@Override

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -5505,6 +5505,9 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	private void NavServiceEnded() {
 		navServiceEndResponseReceived = true;
 		navServiceEndResponse = true;
+		// reset the start response flags to allow resumption
+		navServiceStartResponseReceived = false;
+		navServiceStartResponse = false;
 	}
 	
 	private void NavServiceEndedNACK() {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -5383,8 +5383,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				public void onServiceEnded(SdlSession session, SessionType type) {
 					// reset nav flags so nav can start upon the next transport connection
 					resetNavStartFlags();
-					OnServiceEnded message = new OnServiceEnded(type);
-					queueInternalMessage(message);
+					_proxyListener.onServiceEnded(new OnServiceEnded(type));
 				}
 
 				@Override

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -5383,6 +5383,8 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				public void onServiceEnded(SdlSession session, SessionType type) {
 					// reset nav flags so nav can start upon the next transport connection
 					resetNavStartFlags();
+					OnServiceEnded message = new OnServiceEnded(type);
+					queueInternalMessage(message);
 				}
 
 				@Override

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -253,6 +253,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	private OnSystemRequest lockScreenIconRequest = null;
 	private TelephonyManager telephonyManager = null;
 	private DeviceInfo deviceInfo = null;
+	private ISdlServiceListener navServiceListener;
 	
 	/**
 	 * Contains current configuration for the transport that was selected during 
@@ -349,6 +350,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			if(isConnected()){
 				sdlSession.setDesiredVideoParams(parameters);
 				sdlSession.startService(SessionType.NAV,sdlSession.getSessionId(),encrypted);
+				addNavListener();
 			}
 		}
 
@@ -547,13 +549,13 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 
 		@Override
 		public void onTransportDisconnected(String info, boolean altTransportAvailable, BaseTransportConfig transportConfig) {
+
 			notifyPutFileStreamError(null, info);
 
-			if( altTransportAvailable){
+			if (altTransportAvailable){
 				SdlProxyBase.this._transportConfig = transportConfig;
 				Log.d(TAG, "notifying RPC session ended, but potential primary transport available");
 				cycleProxy(SdlDisconnectedReason.PRIMARY_TRANSPORT_CYCLE_REQUEST);
-
 			}else{
 				notifyProxyClosed(info, new SdlException("Transport disconnected.", SdlExceptionCause.SDL_UNAVAILABLE), SdlDisconnectedReason.TRANSPORT_DISCONNECT);
 			}
@@ -1586,9 +1588,9 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				}
 			}
 
-			if (_transportConfig.getTransportType().equals(TransportType.MULTIPLEX)) {
+			if (_transportConfig != null && _transportConfig.getTransportType().equals(TransportType.MULTIPLEX)) {
 				this.sdlSession = new SdlSession2(_interfaceBroker, (MultiplexTransportConfig) _transportConfig);
-			}else if(_transportConfig.getTransportType().equals(TransportType.TCP)){
+			}else if(_transportConfig != null &&_transportConfig.getTransportType().equals(TransportType.TCP)){
 				this.sdlSession = new SdlSession2(_interfaceBroker, (TCPTransportConfig) _transportConfig);
 			}else {
 				this.sdlSession = SdlSession.createSession((byte)getProtocolVersion().getMajor(),_interfaceBroker, _transportConfig);
@@ -4881,7 +4883,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		sdlSession.setDesiredVideoParams(emptyParam);
 
 		sdlSession.startService(SessionType.NAV, sdlSession.getSessionId(), isEncrypted);
-
+		addNavListener();
 		FutureTask<Void> fTask =  createFutureTask(new CallableMethod(RESPONSE_WAIT_TIME));
 		ScheduledExecutorService scheduler = createScheduler();
 		scheduler.execute(fTask);
@@ -4929,7 +4931,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		sdlSession.setDesiredVideoParams(emptyParam);
 
 		sdlSession.startService(SessionType.NAV, sdlSession.getSessionId(), isEncrypted);
-
+		addNavListener();
 		FutureTask<Void> fTask =  createFutureTask(new CallableMethod(RESPONSE_WAIT_TIME));
 		ScheduledExecutorService scheduler = createScheduler();
 		scheduler.execute(fTask);
@@ -5303,7 +5305,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			navServiceStartRejectedParams = null;
 
 			sdlSession.startService(SessionType.NAV, sdlSession.getSessionId(), isEncrypted);
-
+			addNavListener();
 			FutureTask<Void> fTask = createFutureTask(new CallableMethod(RESPONSE_WAIT_TIME));
 			ScheduledExecutorService scheduler = createScheduler();
 			scheduler.execute(fTask);
@@ -5367,6 +5369,31 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 
         sdlSession.drainEncoder(endOfStream);
     }
+
+    private void addNavListener(){
+
+    	// videos may be started and stopped. Only add this once
+    	if (navServiceListener == null){
+
+    		navServiceListener = new ISdlServiceListener() {
+				@Override
+				public void onServiceStarted(SdlSession session, SessionType type, boolean isEncrypted) { }
+
+				@Override
+				public void onServiceEnded(SdlSession session, SessionType type) {
+					// reset nav flags so nav can start upon the next transport connection
+					resetNavStartFlags();
+				}
+
+				@Override
+				public void onServiceError(SdlSession session, SessionType type, String reason) {
+					// if there is an error reset the flags so that there is a chance to restart streaming
+					resetNavStartFlags();
+				}
+			};
+			this.sdlSession.addServiceListener(SessionType.NAV, navServiceListener);
+		}
+	}
 
     /**
      * Opens a audio service (service type 10) and subsequently provides an IAudioStreamListener
@@ -5505,9 +5532,6 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	private void NavServiceEnded() {
 		navServiceEndResponseReceived = true;
 		navServiceEndResponse = true;
-		// reset the start response flags to allow resumption
-		navServiceStartResponseReceived = false;
-		navServiceStartResponse = false;
 	}
 	
 	private void NavServiceEndedNACK() {
@@ -5523,7 +5547,13 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
     private void AudioServiceEndedNACK() {
 		pcmServiceEndResponseReceived = true;
 		pcmServiceEndResponse = false;
-	}	
+	}
+
+	private void resetNavStartFlags() {
+		navServiceStartResponseReceived = false;
+		navServiceStartResponse = false;
+		navServiceStartRejectedParams = null;
+	}
 	
 	public void setAppService(Service mService)
 	{

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -5383,6 +5383,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				public void onServiceEnded(SdlSession session, SessionType type) {
 					// reset nav flags so nav can start upon the next transport connection
 					resetNavStartFlags();
+					// propagate notification up to proxy listener so the developer will know that the service is ended
 					if (_proxyListener != null) {
 						_proxyListener.onServiceEnded(new OnServiceEnded(type));
 					}

--- a/base/src/main/java/com/smartdevicelink/protocol/SdlProtocolBase.java
+++ b/base/src/main/java/com/smartdevicelink/protocol/SdlProtocolBase.java
@@ -529,7 +529,9 @@ public class SdlProtocolBase {
     public void endSession(byte sessionID, int hashId) {
         SdlPacket header = SdlPacketFactory.createEndSession(SessionType.RPC, sessionID, hashId, (byte)protocolVersion.getMajor(), hashId);
         handlePacketToSend(header);
-        transportManager.close(sessionID);
+        if(transportManager != null) {
+            transportManager.close(sessionID);
+        }
 
     } // end-method
 


### PR DESCRIPTION
Fixes #1150, #1151 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Smoke testing as described in issues

### Summary
Allow the proper video service flags to be reset when video services disconnect. this also fixes the case where sdlproxybase would not know if a video service that was hosted on a secondary transport disconnected. 

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
