### PR TITLE
Attempts to fix  #1167 

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -52,6 +52,7 @@ import com.smartdevicelink.R;
 import com.smartdevicelink.transport.RouterServiceValidator.TrustedListCallback;
 import com.smartdevicelink.transport.enums.TransportType;
 import com.smartdevicelink.util.AndroidTools;
+import com.smartdevicelink.util.DebugTool;
 import com.smartdevicelink.util.SdlAppInfo;
 import com.smartdevicelink.util.ServiceFinder;
 
@@ -245,6 +246,7 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 								context.startService(serviceIntent);
 							}else {
 								serviceIntent.putExtra(FOREGROUND_EXTRA, true);
+								DebugTool.logInfo("Attempting to startForegroundService - " + System.currentTimeMillis());
 								context.startForegroundService(serviceIntent);
 
 							}
@@ -340,6 +342,7 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 			intent.putExtra(TransportConstants.PING_ROUTER_SERVICE_EXTRA, true);
 			if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){
 				intent.putExtra(FOREGROUND_EXTRA, true);
+				DebugTool.logInfo("Attempting to startForegroundService - " + System.currentTimeMillis());
 				context.startForegroundService(intent);
 			}else {
 				context.startService(intent);

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -70,6 +70,7 @@ import android.os.ParcelFileDescriptor;
 import android.os.Parcelable;
 import android.os.RemoteException;
 import android.support.annotation.NonNull;
+import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 import android.util.SparseArray;
 import android.util.SparseIntArray;
@@ -137,7 +138,7 @@ public class SdlRouterService extends Service{
 	/**
 	 * <b> NOTE: DO NOT MODIFY THIS UNLESS YOU KNOW WHAT YOU'RE DOING.</b>
 	 */
-	protected static final int ROUTER_SERVICE_VERSION_NUMBER = 9;
+	protected static final int ROUTER_SERVICE_VERSION_NUMBER = 10;
 
 	private static final String ROUTER_SERVICE_PROCESS = "com.smartdevicelink.router";
 	
@@ -195,6 +196,7 @@ public class SdlRouterService extends Service{
 
     private boolean wrongProcess = false;
 	private boolean initPassed = false;
+	private boolean hasCalledStartForeground = false;
 
 	public static HashMap<String,RegisteredApp> registeredApps;
 	private SparseArray<String> bluetoothSessionMap, usbSessionMap, tcpSessionMap;
@@ -1098,14 +1100,16 @@ public class SdlRouterService extends Service{
 		super.onCreate();
 		//This must be done regardless of if this service shuts down or not
 		if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+			hasCalledStartForeground = false;
 			enterForeground("Waiting for connection...", FOREGROUND_TIMEOUT/1000, false);
+			hasCalledStartForeground = true;
 			resetForegroundTimeOut(FOREGROUND_TIMEOUT/1000);
 		}
 
 
 		if(!initCheck()){ // Run checks on process and permissions
 			deployNextRouterService();
-			stopSelf();
+			closeSelf();
 			return;
 		}
 		initPassed = true;
@@ -1197,17 +1201,11 @@ public class SdlRouterService extends Service{
 	@SuppressLint({"NewApi", "MissingPermission"})
 	@Override
 	public int onStartCommand(Intent intent, int flags, int startId) {
-		if(!initPassed) {
-			return super.onStartCommand(intent, flags, startId);
-		}
-		if(registeredApps == null){
-			synchronized(REGISTERED_APPS_LOCK){
-				registeredApps = new HashMap<String,RegisteredApp>();
-			}
-		}
 		if(intent != null ){
 			if(intent.getBooleanExtra(FOREGROUND_EXTRA, false)){
-				if(!this.isPrimaryTransportConnected()) {	//If there is no transport connected we need to ensure the service is moved to the foreground
+				hasCalledStartForeground = false;
+
+				if (!this.isPrimaryTransportConnected()) {	//If there is no transport connected we need to ensure the service is moved to the foreground
 					String address = null;
 					if(intent.hasExtra(BluetoothDevice.EXTRA_DEVICE)){
 						BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
@@ -1218,10 +1216,13 @@ public class SdlRouterService extends Service{
 					int timeout = getNotificationTimeout(address);
 					enterForeground("Waiting for connection...", timeout, false);
 					resetForegroundTimeOut(timeout);
-				}else{
+				} else {
 					enterForeground(createConnectedNotificationText(),0,true);
 				}
+
+				hasCalledStartForeground = true;
 			}
+
 			if(intent.hasExtra(TransportConstants.PING_ROUTER_SERVICE_EXTRA)){
 				//Make sure we are listening on RFCOMM
 				if(startSequenceComplete){ //We only check if we are sure we are already through the start up process
@@ -1230,10 +1231,17 @@ public class SdlRouterService extends Service{
 				}
 			}
 		}
+
 		if(!shouldServiceRemainOpen(intent)){
 			closeSelf();
 		}
-		return super.onStartCommand(intent, flags, startId);
+
+		if(registeredApps == null){
+			synchronized(REGISTERED_APPS_LOCK){
+				registeredApps = new HashMap<String,RegisteredApp>();
+			}
+		}
+		return START_REDELIVER_INTENT;
 	}
 
 	@SuppressWarnings("ConstantConditions")
@@ -1386,6 +1394,7 @@ public class SdlRouterService extends Service{
 	@SuppressLint("NewApi")
 	@SuppressWarnings("deprecation")
 	private void enterForeground(String content, long chronometerLength, boolean ongoing) {
+		DebugTool.logInfo("Attempting to enter the foreground - " + System.currentTimeMillis());
 		if(android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.HONEYCOMB){
 			Log.w(TAG, "Unable to start service as foreground due to OS SDK version being lower than 11");
 			isForeground = false;
@@ -1459,6 +1468,7 @@ public class SdlRouterService extends Service{
 					} else {
 						Log.e(TAG, "Unable to retrieve notification Manager service");
 						if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+							safeStartForeground(FOREGROUND_SERVICE_ID, builder.build());
 							stopSelf();	//A valid notification channel must be supplied for SDK 27+
 						}
 					}
@@ -1467,16 +1477,42 @@ public class SdlRouterService extends Service{
 				notification = builder.build();
 			}
 			if (notification == null) {
+				safeStartForeground(FOREGROUND_SERVICE_ID, builder.build());
 				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
 					stopSelf(); //A valid notification must be supplied for SDK 27+
 				}
 				return;
 			}
-			startForeground(FOREGROUND_SERVICE_ID, notification);
+			safeStartForeground(FOREGROUND_SERVICE_ID, notification);
 			isForeground = true;
+
 		}
  
     }
+
+	/**
+	 * This is a simple wrapper around the startForeground method. In the case that the notification
+	 * is null, or a notification was unable to be created we will still attempt to call the
+	 * startForeground method in hopes that Android will not throw the System Exception.
+	 * @param id notification channel id
+	 * @param notification the notification to display when in the foreground
+	 */
+	private void safeStartForeground(int id, Notification notification){
+		try{
+			if(notification == null){
+				//Try the NotificationCompat this time in case there was a previous error
+				NotificationCompat.Builder builder =
+						new NotificationCompat.Builder(this, SDL_NOTIFICATION_CHANNEL_ID)
+								.setContentTitle("SmartDeviceLink")
+								.setContentText("Service Running");
+				notification = builder.build();
+			}
+			startForeground(id, notification);
+			DebugTool.logInfo("Entered the foreground - " + System.currentTimeMillis());
+		}catch (Exception e){
+			DebugTool.logError("Unable to start service in foreground", e);
+		}
+	}
 
 	private void exitForeground(){
 		synchronized (NOTIFICATION_LOCK) {
@@ -1613,8 +1649,13 @@ public class SdlRouterService extends Service{
 	 */
 	public void closeSelf(){
 		closing = true;
+		if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !hasCalledStartForeground ){
+			//This must be called before stopping self
+			safeStartForeground(FOREGROUND_SERVICE_ID, null);
+			exitForeground();
+		}
 
-		if(getBaseContext()!=null){
+		if(getBaseContext()!= null){
 			stopSelf();
 		}
 

--- a/android/sdl_android/src/main/res/values/sdl.xml
+++ b/android/sdl_android/src/main/res/values/sdl.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="sdl_router_service_version_name" translatable="false">sdl_router_version</string>
 
-    <integer name="sdl_router_service_version_value">9</integer>
+    <integer name="sdl_router_service_version_value">10</integer>
 
     <string name="sdl_router_service_is_custom_name" translatable="false">sdl_custom_router</string>
 </resources>


### PR DESCRIPTION
Fixes #1167 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan

#### General
This bug is currently not possibly reproduce in a "testing" setting. We need to work to find a way to actually reproduce the bug.

This PR was tested by making the router service start and stop very quickly, this involved power cycling the bluetooth adapter once a connection was made.

#### UncaughtExceptionHandler

In order to test the new UncaughtExceptionHandler, modify the code in the `SdlRouterService`'s method `enterForeground` to return immediately without creating a notification or calling `startForeground`;

### Summary
- Added a call to `startForegroundService` during many possible cases and before `stopSelf` is called.
- Added an `UncaughtExceptionHandler` that will look for the ANR exception caused by the service not calling `startForeground` in time. It will prevent the ANR, but the router service will still be destroyed. 


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
