### PR TITLE
Dispose main underlying layers when sdlManager is disposed

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -364,6 +364,14 @@ public class SdlManager extends BaseSdlManager{
 			this.audioStreamManager.dispose();
 		}
 
+		if (this.proxy != null) {
+			try {
+				this.proxy.dispose();
+			} catch (SdlException e) {
+				DebugTool.logError("Issue disposing proxy in SdlManager", e);
+			}
+		}
+
 		if(managerListener != null){
 			managerListener.onDestroy();
 			managerListener = null;

--- a/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -299,6 +299,10 @@ public class SdlManager extends BaseSdlManager{
 			this.screenManager.dispose();
 		}
 
+		if (this.lifecycleManager != null) {
+			this.lifecycleManager.stop();
+		}
+
 		if(managerListener != null){
 			managerListener.onDestroy(this);
 			managerListener = null;


### PR DESCRIPTION
Fixes #1172

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- Stop the SdlService as soon as the SdlManager becomes ready. Observe no errors because of missing cleanup.
- Connect and disconnect transport an observe no regression errors.

### Summary

- When SdlManager.dispose() is called the underlying main layers need to also be disposed. The PR calls the dispose and stop methods of the current proxy layer and lifecycle manager layer for the Android and Java projects.

### Changelog
##### Bug Fixes
* The dispose call will now properly shut down and clean up items in the library as to not leak receivers and bound connections to services.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
