### PR TITLE
Add safeguards for null usbAccessory

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/USBTransport.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/USBTransport.java
@@ -529,7 +529,11 @@ public class USBTransport extends SdlTransport {
      * @param accessory Accessory to check
      * @return true if the accessory is right
      */
-    public static boolean isAccessorySupported(UsbAccessory accessory) {
+    public static boolean isAccessorySupported(final UsbAccessory accessory) {
+        if (accessory == null) {
+            return false;
+        }
+
         boolean manufacturerMatches =
                 ACCESSORY_MANUFACTURER.equals(accessory.getManufacturer());
         boolean modelMatches = ACCESSORY_MODEL.equals(accessory.getModel());
@@ -547,6 +551,11 @@ public class USBTransport extends SdlTransport {
      * @param accessory Accessory to connect to
      */
     private void connectToAccessory(UsbAccessory accessory) {
+
+        if (accessory == null) {
+            handleTransportError("Can't connect to null accessory", null);
+        }
+
         final State state = getState();
         switch (state) {
             case LISTENING:


### PR DESCRIPTION
Fixes #1086 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- Connect AOA for both multiplexing and legacy USB connections

### Summary
- Added a check in `USBAccessoryAttachmentActivity` to not send broadcast if `usbAccessory` is null.
- Changed private method signature to take in a reference to the `usbAccessory`
- Added null checks to methods in the `USBTransport` class;

### Changelog

##### Bug Fixes
* Should prevent NPE from happening in known possible case

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
