### PR TITLE
ISdlServiceListener not called when RPC is service started again

### DIFF
--- a/base/src/main/java/com/smartdevicelink/protocol/SdlProtocolBase.java
+++ b/base/src/main/java/com/smartdevicelink/protocol/SdlProtocolBase.java
@@ -993,7 +993,8 @@ public class SdlProtocolBase {
                         notifyDevTransportListener();
 
                     } else {
-                        Log.w(TAG, "Received a start service ack for RPC service while already active on a different transport.");
+                        DebugTool.logInfo("Received a start service ack for RPC service while already active on a different transport.");
+                        iSdlProtocol.onProtocolSessionStarted(serviceType, (byte) packet.getSessionId(), (byte)protocolVersion.getMajor(), "", hashID, packet.isEncrypted());
                         return;
                     }
 


### PR DESCRIPTION
Fixes #1181 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR fixes an issue that causes RPC service `ISdlServiceListener` not to be called when the service is started again as an encrypted service

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
