### PR TITLE
Add missing HMICapabilities

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/util/VersionTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/util/VersionTest.java
@@ -5,10 +5,11 @@ import com.smartdevicelink.util.Version;
 
 public class VersionTest extends AndroidTestCase2 {
 
-    private static final String TEST_VERSION = "1.2.3";
+    private static final String TEST_VERSION_STRING = "1.2.3";
+    private static final Version TEST_VERSION = new Version(1,2,3);
 
     public void testConstructorCorrect(){
-        Version version = new Version(TEST_VERSION);
+        Version version = new Version(TEST_VERSION_STRING);
         assertEquals(1, version.getMajor());
         assertEquals(2, version.getMinor());
         assertEquals(3, version.getPatch());
@@ -24,8 +25,8 @@ public class VersionTest extends AndroidTestCase2 {
     }
 
     public void testToString(){
-        Version version = new Version(TEST_VERSION);
-        assertEquals(version.toString(), TEST_VERSION);
+        Version version = new Version(TEST_VERSION_STRING);
+        assertEquals(version.toString(), TEST_VERSION_STRING);
     }
 
     public void testisNewerThan(){
@@ -43,6 +44,19 @@ public class VersionTest extends AndroidTestCase2 {
 
         //Supplied  version is equal
         assertEquals(0,version1.isNewerThan( new Version(5,0,0)));
+
+    }
+
+    public void testIsBetween(){
+
+        assertEquals(TEST_VERSION.isBetween(new Version(1,0,0), new Version (2,0,0)), 1);
+        assertEquals(TEST_VERSION.isBetween(new Version(2,0,0), new Version (1,0,0)), -1);
+        assertEquals(TEST_VERSION.isBetween(new Version(2,0,0), new Version (3,0,0)), -1);
+
+        assertEquals(TEST_VERSION.isBetween(new Version(1,0,0), new Version (1,2,3)), 0);
+        assertEquals(TEST_VERSION.isBetween(new Version(1,2,3), new Version (3,2,3)), 0);
+
+        assertEquals(TEST_VERSION.isBetween(new Version(1,2,3), new Version (1,2,3)), 0);
 
     }
 }

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/HMICapabilities.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/HMICapabilities.java
@@ -40,6 +40,9 @@ public class HMICapabilities extends RPCStruct{
     public static final String KEY_PHONE_CALL = "phoneCall";
     public static final String KEY_VIDEO_STREAMING = "videoStreaming";
     public static final String KEY_REMOTE_CONTROL = "remoteControl";
+    public static final String KEY_APP_SERVICES = "appServices";
+    public static final String KEY_DISPLAYS = "displays";
+    public static final String KEY_SEAT_LOCATION = "seatLocation";
 
 	public HMICapabilities() { }
 	  
@@ -95,5 +98,40 @@ public class HMICapabilities extends RPCStruct{
 		setValue(KEY_REMOTE_CONTROL, available);
 	}
 
+	public boolean isAppServicesAvailable(){
+		Object available = getValue(KEY_APP_SERVICES);
+		if(available == null){
+			return false;
+		}
+		return (Boolean)available;
+	}
+
+	public void setAppServicesAvailable(Boolean available){
+		setValue(KEY_APP_SERVICES, available);
+	}
+
+	public boolean isDisplaysCapabilityAvailable(){
+		Object available = getValue(KEY_DISPLAYS);
+		if(available == null){
+			return false;
+		}
+		return (Boolean)available;
+	}
+
+	public void setDisplaysCapabilityAvailable(Boolean available){
+		setValue(KEY_DISPLAYS, available);
+	}
+
+	public boolean isSeatLocationAvailable(){
+		Object available = getValue(KEY_SEAT_LOCATION);
+		if(available == null){
+			return false;
+		}
+		return (Boolean)available;
+	}
+
+	public void setSeatLocationAvailable(Boolean available){
+		setValue(KEY_SEAT_LOCATION, available);
+	}
 
 }

--- a/base/src/main/java/com/smartdevicelink/util/Version.java
+++ b/base/src/main/java/com/smartdevicelink/util/Version.java
@@ -32,6 +32,8 @@
 package com.smartdevicelink.util;
 
 
+import android.support.annotation.NonNull;
+
 public class Version {
 
     final int major,minor,patch;
@@ -93,6 +95,32 @@ public class Version {
         return -1;
     }
 
+    /**
+     *
+     * @param minVersion the lowest version to be used in the comparison
+     * @param maxVersion the highest version to be used in the comparison
+     * @return -1 if this number is not between minVersion and maxVersion or if minVersion is greater than maxVersion, <br> 0 if the number is
+     * equal to either minVersion or maxVersion <br> 1 if the number is between the minVersion and maxVersion
+     */
+    public int isBetween(@NonNull Version minVersion, @NonNull Version maxVersion){
+        if(minVersion.isNewerThan(maxVersion) == 1){
+            return -1;
+        }
+
+        int resultsForMin = this.isNewerThan(minVersion);
+        int resultsForMax = this.isNewerThan(maxVersion);
+
+        if(resultsForMin == 0 || resultsForMax == 0){
+            return 0;
+            //return resultsForMin >= 0 && resultsForMax <=0;
+        }else if (resultsForMin == 1 && resultsForMax == -1 ){
+            return 1;
+        }else{
+            return -1;
+        }
+
+    }
+
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
@@ -103,4 +131,6 @@ public class Version {
         builder.append(patch);
         return builder.toString();
     }
+
+
 }


### PR DESCRIPTION
Fixes #1159 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- Test with 6.0.0 RPC spec version of Core and with 5.1.0 version

### Summary
- Added `AppServices`, `Displays`, and `SeatLocation` to HMICapabilities
- Added cases to switch statement in SCM for previously added items
- Added compatibility in case statements for previous RPC spec versions that supported feature but didn't include items


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
