### PR TITLE
Fix for issue-1190

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1173,9 +1173,7 @@ public class SdlRouterService extends Service{
 		disconnectFilter.addAction(BluetoothDevice.ACTION_CLASS_CHANGED);
 		disconnectFilter.addAction(BluetoothDevice.ACTION_ACL_DISCONNECTED);
 		disconnectFilter.addAction(BluetoothDevice.ACTION_ACL_DISCONNECT_REQUESTED);
-		if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB){
-			disconnectFilter.addAction(BluetoothAdapter.ACTION_CONNECTION_STATE_CHANGED);
-		}
+		disconnectFilter.addAction(BluetoothAdapter.ACTION_STATE_CHANGED);
 		registerReceiver(mListenForDisconnect,disconnectFilter );
 		
 		IntentFilter filter = new IntentFilter();


### PR DESCRIPTION
Fix for issue-1190: register ACTION_STATE_CHANGED, so that mListenForDisconnect can handle the action correctly.

Fixes #1190 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
N/A

### Summary
Fix for issue-1190: register ACTION_STATE_CHANGED, so that mListenForDisconnect can handle the action correctly.

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* This PR fixes the issue #1190: SdlRouterService does not handle the case where Bluetooth Adapter is turned off.

### Tasks Remaining:
- N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
