### PR TITLE
Register legacyBT BR to listen for state change

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/TransportManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/TransportManager.java
@@ -32,6 +32,7 @@
 
 package com.smartdevicelink.transport;
 
+import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
@@ -413,7 +414,10 @@ public class TransportManager extends TransportManagerBase{
             legacyBluetoothHandler = new LegacyBluetoothHandler(this);
             legacyBluetoothTransport = new MultiplexBluetoothTransport(legacyBluetoothHandler);
             if(contextWeakReference.get() != null){
-                contextWeakReference.get().registerReceiver(legacyDisconnectReceiver,new IntentFilter(BluetoothDevice.ACTION_ACL_DISCONNECTED) );
+                IntentFilter intentFilter = new IntentFilter();
+                intentFilter.addAction(BluetoothDevice.ACTION_ACL_DISCONNECTED);
+                intentFilter.addAction(BluetoothAdapter.ACTION_STATE_CHANGED);
+                contextWeakReference.get().registerReceiver(legacyDisconnectReceiver, intentFilter );
             }
         }else{
             new Handler().postDelayed(new Runnable() {
@@ -451,8 +455,15 @@ public class TransportManager extends TransportManagerBase{
         @Override
         public void onReceive(Context context, Intent intent) {
             if(intent != null){
-                if(BluetoothDevice.ACTION_ACL_DISCONNECTED.equals(intent.getAction())){
+                String action = intent.getAction();
+                if(BluetoothDevice.ACTION_ACL_DISCONNECTED.equals(action)){
                     exitLegacyMode("Bluetooth disconnected");
+                }else if(action.equalsIgnoreCase(BluetoothAdapter.ACTION_STATE_CHANGED)){
+                    int bluetoothState = intent.getIntExtra(BluetoothAdapter.EXTRA_STATE, -1);
+                    if(bluetoothState == BluetoothAdapter.STATE_TURNING_OFF || bluetoothState == BluetoothAdapter.STATE_OFF){
+                        Log.d(TAG, "Bluetooth is shutting off, exiting legacy mode.");
+                        exitLegacyMode("Bluetooth adapter shutting off");
+                    }
                 }
             }
         }


### PR DESCRIPTION

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- Force app into legacy mode to use legacy BT
- Turn off the bluetooth adapter
- Ensure legacy mode is exited

### Summary
- Added STATE_CHANG as action to listen for while running in legacy mode BT 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
