### PR TITLE
Rename getTemplateTitle() to getTitle()

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/ScreenManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/ScreenManagerTests.java
@@ -45,7 +45,7 @@ public class ScreenManagerTests extends AndroidTestCase2 {
 		assertNull(screenManager.getTextField2());
 		assertNull(screenManager.getTextField3());
 		assertNull(screenManager.getTextField4());
-		assertNull(screenManager.getTemplateTitle());
+		assertNull(screenManager.getTitle());
 		assertNull(screenManager.getMediaTrackTextField());
 		assertNull(screenManager.getPrimaryGraphic());
 		assertNull(screenManager.getSecondaryGraphic());
@@ -74,7 +74,7 @@ public class ScreenManagerTests extends AndroidTestCase2 {
 		assertEquals(screenManager.getTextField2(), "Wednesday");
 		assertEquals(screenManager.getTextField3(), "My");
 		assertEquals(screenManager.getTextField4(), "Dudes");
-		assertEquals(screenManager.getTemplateTitle(), "title");
+		assertEquals(screenManager.getTitle(), "title");
 	}
 
 	public void testMediaTrackTextFields() {

--- a/base/src/main/java/com/smartdevicelink/managers/screen/BaseScreenManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/BaseScreenManager.java
@@ -356,7 +356,7 @@ abstract class BaseScreenManager extends BaseSubManager {
 	 * Gets the title of the new template that will be displayed
 	 * @return title - String value that represents the title of the new template that will be displayed
 	 */
-	public String getTemplateTitle(){
+	public String getTitle(){
 		return this.textAndGraphicManager.getTitle();
 	}
 


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Summary
This PR renames `getTemplateTitle()` in the ScreenManager to `getTitle()`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
