### PR TITLE
Keep File Manager from Error State

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
@@ -52,6 +52,7 @@ import com.smartdevicelink.proxy.rpc.PutFileResponse;
 import com.smartdevicelink.proxy.rpc.enums.Result;
 import com.smartdevicelink.proxy.rpc.listeners.OnMultipleRequestListener;
 import com.smartdevicelink.proxy.rpc.listeners.OnRPCResponseListener;
+import com.smartdevicelink.util.DebugTool;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -142,6 +143,7 @@ abstract class BaseFileManager extends BaseSubManager {
 			@Override
 			public void onError(int correlationId, Result resultCode, String info) {
 				// file list could not be received. assume that setting can work and allow SDLManager to start
+				DebugTool.logError("File Manager could not list files");
 				bytesAvailable = SPACE_AVAILABLE_MAX_VALUE;
 				transitionToState(BaseSubManager.READY);
 			}

--- a/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
@@ -141,11 +141,12 @@ abstract class BaseFileManager extends BaseSubManager {
 
 			@Override
 			public void onError(int correlationId, Result resultCode, String info) {
-				// file list could not be received
-				transitionToState(BaseSubManager.ERROR);
+				// file list could not be received. assume that setting can work and allow SDLManager to start
+				bytesAvailable = SPACE_AVAILABLE_MAX_VALUE;
+				transitionToState(BaseSubManager.READY);
 			}
 		});
-		internalInterface.sendRPCRequest(listFiles);
+		internalInterface.sendRPC(listFiles);
 	}
 
 	// DELETION
@@ -173,7 +174,7 @@ abstract class BaseFileManager extends BaseSubManager {
 				}
 			}
 		});
-		internalInterface.sendRPCRequest(deleteFile);
+		internalInterface.sendRPC(deleteFile);
 	}
 
 	/**
@@ -311,7 +312,7 @@ abstract class BaseFileManager extends BaseSubManager {
 			}
 		});
 
-		internalInterface.sendRPCRequest(putFile);
+		internalInterface.sendRPC(putFile);
 	}
 
 	/**


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Change list files on error to allow the manager to transition to ready, and keep SDLManager from transitioning to an error state and not starting 

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
