### PR TITLE
sdl manager crashes when non-mandatory language is null

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -243,7 +243,7 @@ public class SdlManager extends BaseSdlManager{
 	protected void checkLifecycleConfiguration(){
 		final Language actualLanguage =  this.getRegisterAppInterfaceResponse().getLanguage();
 
-		if (!actualLanguage.equals(hmiLanguage)) {
+		if (actualLanguage != null && !actualLanguage.equals(hmiLanguage)) {
 
 			final LifecycleConfigurationUpdate lcu = managerListener.managerShouldUpdateLifecycle(actualLanguage);
 

--- a/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -233,7 +233,7 @@ public class SdlManager extends BaseSdlManager{
 	protected void checkLifecycleConfiguration() {
 		final Language actualLanguage = lifecycleManager.getRegisterAppInterfaceResponse().getLanguage();
 		
-		if (!actualLanguage.equals(hmiLanguage)) {
+		if (actualLanguage != null && !actualLanguage.equals(hmiLanguage)) {
 
 			final LifecycleConfigurationUpdate lcu = managerListener.managerShouldUpdateLifecycle(actualLanguage);
 


### PR DESCRIPTION
Sdl manager crashes if language is null in the RAIR. THis param is optional, therefore it should not crash

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
