### PR TITLE
Fix issue with video streaming stability

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -737,13 +737,18 @@ public class SdlManager extends BaseSdlManager{
 		@Override
 		public void startVideoService(VideoStreamingParameters parameters, boolean encrypted) {
 			if(proxy.getIsConnected()){
-				proxy.startVideoStream(encrypted,parameters);
+				proxy.startVideoService(encrypted,parameters);
 			}
 		}
 
 		@Override
 		public IVideoStreamListener startVideoStream(boolean isEncrypted, VideoStreamingParameters parameters){
-			return proxy.startVideoStream(isEncrypted, parameters);
+			if(proxy.getIsConnected()){
+				return proxy.startVideoStream(isEncrypted, parameters);
+			}else{
+				DebugTool.logError("Unable to start video stream, proxy not connected");
+				return null;
+			}
 		}
 
 		@Override

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -5296,6 +5296,27 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
         }
     }
 
+	/**
+	 * This method will try to start the video service with the requested parameters.
+	 * When it returns it will attempt to store the accepted parameters if available.
+	 * @param isEncrypted if the service should be encrypted
+	 * @param parameters the desiered video streaming parameters
+	 */
+	public void startVideoService(boolean isEncrypted, VideoStreamingParameters parameters) {
+		if (sdlSession == null) {
+			DebugTool.logWarning("SdlSession is not created yet.");
+			return;
+		}
+		if (!sdlSession.getIsConnected()) {
+			DebugTool.logWarning("Connection is not available.");
+			return;
+		}
+
+		sdlSession.setDesiredVideoParams(parameters);
+
+		tryStartVideoStream(isEncrypted, parameters);
+	}
+
     /**
      *Closes the opened video service (serviceType 11)
      *@return true if the video service is closed successfully, return false otherwise

--- a/android/sdl_android/src/main/java/com/smartdevicelink/streaming/StreamPacketizer.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/streaming/StreamPacketizer.java
@@ -38,6 +38,7 @@ import com.smartdevicelink.protocol.ProtocolMessage;
 import com.smartdevicelink.protocol.enums.SessionType;
 import com.smartdevicelink.proxy.interfaces.IAudioStreamListener;
 import com.smartdevicelink.proxy.interfaces.IVideoStreamListener;
+import com.smartdevicelink.util.DebugTool;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -79,6 +80,7 @@ public class StreamPacketizer extends AbstractPacketizer implements IVideoStream
 		if (bufferSize == 0) {
 			// fail safe
 			bufferSize = BUFF_READ_SIZE;
+			buffer = new byte[bufferSize];
 		}
 		if(isServiceProtected){ //If our service is encrypted we can only use 1024 as the max buffer size. 
 			bufferSize = BUFF_READ_SIZE;
@@ -147,6 +149,9 @@ public class StreamPacketizer extends AbstractPacketizer implements IVideoStream
 						frame = byteBufferWithListener.byteBuffer;
 						completionListener = byteBufferWithListener.completionListener;
 					} catch (InterruptedException e) {
+						if(DebugTool.isDebugEnabled()){
+							e.printStackTrace();
+						}
 						Thread.currentThread().interrupt();
 						break;
 					}
@@ -169,7 +174,7 @@ public class StreamPacketizer extends AbstractPacketizer implements IVideoStream
 						frame.position(frame.position() + len);
 					}
 
-					if (!frame.hasRemaining() && completionListener != null){
+					if (completionListener != null){
 						completionListener.onComplete(true);
 					}
 				}
@@ -187,8 +192,6 @@ public class StreamPacketizer extends AbstractPacketizer implements IVideoStream
 			}else{
 				_session.endService(_serviceType,_rpcSessionID);
 			}
-
-
 		}
 	}
 
@@ -297,8 +300,8 @@ public class StreamPacketizer extends AbstractPacketizer implements IVideoStream
 	}
 
 	private class ByteBufferWithListener{
-		ByteBuffer byteBuffer;
-		CompletionListener completionListener;
+		final ByteBuffer byteBuffer;
+		final CompletionListener completionListener;
 		ByteBufferWithListener (ByteBuffer byteBuffer, CompletionListener completionListener){
 			this.byteBuffer = byteBuffer;
 			this.completionListener = completionListener;

--- a/base/src/main/java/com/smartdevicelink/protocol/SdlProtocolBase.java
+++ b/base/src/main/java/com/smartdevicelink/protocol/SdlProtocolBase.java
@@ -1046,27 +1046,31 @@ public class SdlProtocolBase {
                 }
             }
         } else {
-            TransportRecord transportRecord = packet.getTransportRecord();
-            if(transportRecord == null || (requiresHighBandwidth
-                    && TransportType.BLUETOOTH.equals(transportRecord.getType()))){
-                //transport can't support high bandwidth
-                onTransportNotAccepted((transportRecord != null ? transportRecord.getType().toString() : "Transport") + "can't support high bandwidth requirement, and secondary transport not supported in this protocol version");
-                return;
-            }
-            //If version < 5 and transport is acceptable we need to just add these
-            activeTransports.put(SessionType.RPC, transportRecord);
-            activeTransports.put(SessionType.BULK_DATA, transportRecord);
-            activeTransports.put(SessionType.CONTROL, transportRecord);
-            activeTransports.put(SessionType.NAV, transportRecord);
-            activeTransports.put(SessionType.PCM, transportRecord);
-
-            if (protocolVersion.getMajor() > 1){
-                if (packet.payload!= null && packet.dataSize == 4){ //hashid will be 4 bytes in length
-                    hashID = BitConverter.intFromByteArray(packet.payload, 0);
+            if(serviceType.equals(SessionType.RPC)) {
+                TransportRecord transportRecord = packet.getTransportRecord();
+                if (transportRecord == null || (requiresHighBandwidth
+                        && TransportType.BLUETOOTH.equals(transportRecord.getType()))) {
+                    //transport can't support high bandwidth
+                    onTransportNotAccepted((transportRecord != null ? transportRecord.getType().toString() : "Transport ") + "can't support high bandwidth requirement, and secondary transport not supported in this protocol version");
+                    return;
                 }
+                //If version < 5 and transport is acceptable we need to just add these
+                activeTransports.put(SessionType.RPC, transportRecord);
+                activeTransports.put(SessionType.BULK_DATA, transportRecord);
+                activeTransports.put(SessionType.CONTROL, transportRecord);
+                activeTransports.put(SessionType.NAV, transportRecord);
+                activeTransports.put(SessionType.PCM, transportRecord);
+
+                if (protocolVersion.getMajor() > 1) {
+                    if (packet.payload != null && packet.dataSize == 4) { //hashid will be 4 bytes in length
+                        hashID = BitConverter.intFromByteArray(packet.payload, 0);
+                    }
+                }
+            }else if(serviceType.equals(SessionType.NAV)) {
+                //Protocol versions <5 don't support param negotiation
+                iSdlProtocol.setAcceptedVideoParams(iSdlProtocol.getDesiredVideoParams());
             }
         }
-
         iSdlProtocol.onProtocolSessionStarted(serviceType, (byte) packet.getSessionId(), (byte)protocolVersion.getMajor(), "", hashID, packet.isEncrypted());
     }
 


### PR DESCRIPTION
Fixes #1110 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
1. Create a sample video streaming application
2. Connect with IVI system, select app, and observe video stream starting
3. Disconnect transport during streaming
4. Reconnect transport, observe video stream starting
5. Repeat process multiple times and ensure stream starts every time

### Summary
- Correctly identify if high bandwidth transport is required and shutdown service if not available during transport disconnection
- Remove incorrect call to start two stream packetizers by accident
- Handle case where older systems didn't perform video streaming param negotiation

### Changelog


##### Bug Fixes
* The reported bug occured because the buffer that the `put` call was used on was full. This happened because there was actually an error in the `VideoStreamingManager` that prevented the buffer to ever have any data taken off. This occurred for a few reasons that are fixed in this PR.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
