### PR TITLE
Fix potential NPEs in BaseMenuManager

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/MenuManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/MenuManagerTests.java
@@ -425,6 +425,27 @@ public class MenuManagerTests extends AndroidTestCase2 {
 		assertEquals(menuManager.keepsOld.size(), 3);
 	}
 
+	public void testSettingNullMenu(){
+
+		// Make sure we can send an empty menu with no issues
+		// start fresh
+		menuManager.oldMenuCells = null;
+		menuManager.menuCells = null;
+		menuManager.inProgressUpdate = null;
+		menuManager.waitingUpdateMenuCells = null;
+		menuManager.waitingOnHMIUpdate = false;
+
+		menuManager.currentHMILevel = HMILevel.HMI_FULL;
+		// send new cells. They should set the old way
+		List<MenuCell> oldMenu = createDynamicMenu1();
+		List<MenuCell> newMenu = null;
+		menuManager.setMenuCells(oldMenu);
+		assertEquals(menuManager.menuCells.size(), 4);
+
+		menuManager.setMenuCells(newMenu);
+		assertEquals(menuManager.menuCells.size(), 0);
+	}
+
 	public void testClearingMenu(){
 
 		// Make sure we can send an empty menu with no issues

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseMenuManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseMenuManager.java
@@ -175,7 +175,11 @@ abstract class BaseMenuManager extends BaseSubManager {
 		if (currentHMILevel == null || currentHMILevel.equals(HMILevel.HMI_NONE) || currentSystemContext.equals(SystemContext.SYSCTXT_MENU)){
 			// We are in NONE or the menu is in use, bail out of here
 			waitingOnHMIUpdate = true;
-			waitingUpdateMenuCells = new ArrayList<>(clonedCells);
+			if (clonedCells == null) {
+				waitingUpdateMenuCells = new ArrayList<>();
+			} else {
+				waitingUpdateMenuCells = new ArrayList<>(clonedCells);
+			}
 			return;
 		}
 		waitingOnHMIUpdate = false;
@@ -186,7 +190,11 @@ abstract class BaseMenuManager extends BaseSubManager {
 			oldMenuCells = new ArrayList<>(menuCells);
 		}
 		// copy new list
-		menuCells = new ArrayList<>(clonedCells);
+		if (clonedCells == null) {
+			menuCells = new ArrayList<>();
+		} else {
+			menuCells = new ArrayList<>(clonedCells);
+		}
 
 		// HashSet order doesnt matter / does not allow duplicates
 		HashSet<String> titleCheckSet = new HashSet<>();

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseMenuManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseMenuManager.java
@@ -175,10 +175,9 @@ abstract class BaseMenuManager extends BaseSubManager {
 		if (currentHMILevel == null || currentHMILevel.equals(HMILevel.HMI_NONE) || currentSystemContext.equals(SystemContext.SYSCTXT_MENU)){
 			// We are in NONE or the menu is in use, bail out of here
 			waitingOnHMIUpdate = true;
-			if (clonedCells == null) {
-				waitingUpdateMenuCells = new ArrayList<>();
-			} else {
-				waitingUpdateMenuCells = new ArrayList<>(clonedCells);
+			waitingUpdateMenuCells = new ArrayList<>();
+			if (clonedCells != null) {
+				waitingUpdateMenuCells.addAll(clonedCells);
 			}
 			return;
 		}
@@ -190,10 +189,9 @@ abstract class BaseMenuManager extends BaseSubManager {
 			oldMenuCells = new ArrayList<>(menuCells);
 		}
 		// copy new list
-		if (clonedCells == null) {
-			menuCells = new ArrayList<>();
-		} else {
-			menuCells = new ArrayList<>(clonedCells);
+		menuCells = new ArrayList<>();
+		if (clonedCells != null) {
+			menuCells.addAll(clonedCells);
 		}
 
 		// HashSet order doesnt matter / does not allow duplicates

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseMenuManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseMenuManager.java
@@ -176,7 +176,7 @@ abstract class BaseMenuManager extends BaseSubManager {
 			// We are in NONE or the menu is in use, bail out of here
 			waitingOnHMIUpdate = true;
 			waitingUpdateMenuCells = new ArrayList<>();
-			if (clonedCells != null) {
+			if (clonedCells != null && !clonedCells.isEmpty()) {
 				waitingUpdateMenuCells.addAll(clonedCells);
 			}
 			return;
@@ -190,7 +190,7 @@ abstract class BaseMenuManager extends BaseSubManager {
 		}
 		// copy new list
 		menuCells = new ArrayList<>();
-		if (clonedCells != null) {
+		if (clonedCells != null && !clonedCells.isEmpty()) {
 			menuCells.addAll(clonedCells);
 		}
 


### PR DESCRIPTION
Fixes #1215 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Try setting the menu to `null` and make sure the menu cells are getting cleared correctly without crashing the app:
```
sdlManager.getScreenManager().setMenu(null);
```

### Summary
This PR fixes some potential NPEs in `MenuManager` when setting the menu to `null` 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
