### PR TITLE
Add AppInfo to RegisterAppInterface RPC

### DIFF
--- a/android/sdl_android/src/androidTest/assets/json/RegisterAppInterface.json
+++ b/android/sdl_android/src/androidTest/assets/json/RegisterAppInterface.json
@@ -29,6 +29,12 @@
         "carrier":"nobody",
         "maxNumberRFCOMMPorts":2
       },
+      "appInfo":{
+        "appDisplayName":"Test",
+        "appBundleID":"com.sample.test",
+        "appVersion":"1.0",
+        "appIcon":"icon.png"
+      },
       "appName":"Dumb app",
       "ngnMediaScreenAppName":"DA",
       "isMediaApplication":true,

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/Test.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/Test.java
@@ -16,6 +16,7 @@ import com.smartdevicelink.protocol.SdlProtocol;
 import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.proxy.SdlProxyBase;
 import com.smartdevicelink.proxy.TTSChunkFactory;
+import com.smartdevicelink.proxy.rpc.AppInfo;
 import com.smartdevicelink.proxy.rpc.AppServiceCapability;
 import com.smartdevicelink.proxy.rpc.AppServiceData;
 import com.smartdevicelink.proxy.rpc.AppServiceManifest;
@@ -262,6 +263,7 @@ public class Test {
 	public static final VrHelpItem                     GENERAL_VRHELPITEM                     = new VrHelpItem();
 	public static final ImageField                     GENERAL_IMAGEFIELD                     = new ImageField();
 	public static final DeviceInfo	                   GENERAL_DEVICEINFO	                  = new DeviceInfo();
+	public static final AppInfo                        GENERAL_APPINFO	                      = new AppInfo();
 	public static final LayoutMode                     GENERAL_LAYOUTMODE                     = LayoutMode.LIST_ONLY;
 	public static final MenuParams                     GENERAL_MENUPARAMS                     = new MenuParams();
 	public static final SoftButton                     GENERAL_SOFTBUTTON                     = new SoftButton();
@@ -535,6 +537,7 @@ public class Test {
 	public static final JSONObject JSON_SOFTBUTTON                = new JSONObject();
 	public static final JSONObject JSON_MENUPARAMS                = new JSONObject();
 	public static final JSONObject JSON_DEVICEINFO                = new JSONObject();
+	public static final JSONObject JSON_APPINFO                   = new JSONObject();
 	public static final JSONObject JSON_VRHELPITEM                = new JSONObject();
 	public static final JSONObject JSON_SCREENPARAMS              = new JSONObject();
 	public static final JSONObject JSON_SDLMSGVERSION             = new JSONObject();

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/Validator.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/Validator.java
@@ -2598,6 +2598,24 @@ public class Validator{
         return true;
     }
 
+    public static boolean validateAppInfo (AppInfo item1, AppInfo item2) {
+        if (item1 == null) {
+            return ( item2 == null );
+        }
+        if (item2 == null) {
+            return ( item1 == null );
+        }
+
+        if (item1.getAppDisplayName() != item1.getAppDisplayName()
+        || item1.getAppBundleID() != item2.getAppBundleID()
+        || item1.getAppVersion() != item2.getAppVersion()
+        || item1.getAppIcon() != item2.getAppIcon()) {
+            return false;
+        }
+
+        return true;
+    }
+
     public static boolean validateTemplateColorScheme (TemplateColorScheme item1, TemplateColorScheme item2) {
         if (item1 == null) {
             return ( item2 == null );

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/RPCConstructorsTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/RPCConstructorsTests.java
@@ -88,7 +88,7 @@ public class RPCConstructorsTests extends AndroidTestCase2 {
                                     rpcName = "OasisAddress";
                                 } else if(rpcName.equals("ShowConstantTBT")) {
                                     rpcName = "ShowConstantTbt";
-                                } else if (rpcName.equals("EncodedSyncPData") || rpcName.equals("OnEncodedSyncPData") || rpcName.equals("EncodedSyncPDataResponse") || rpcName.equals("AppInfo")){
+                                } else if (rpcName.equals("EncodedSyncPData") || rpcName.equals("OnEncodedSyncPData") || rpcName.equals("EncodedSyncPDataResponse")){
                                     ignoreRPC = true;
                                 }
                             // -------------------------------------------------------------------------------------------------------------

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/AppInfoTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/AppInfoTests.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2019 Livio, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Livio Inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.smartdevicelink.test.rpc.datatypes;
+
+import com.smartdevicelink.proxy.rpc.AppInfo;
+import com.smartdevicelink.test.JsonUtils;
+import com.smartdevicelink.test.Test;
+
+import junit.framework.TestCase;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Iterator;
+
+/**
+ * This is a unit test class for the SmartDeviceLink library project class :
+ * {@link com.smartdevicelink.proxy.rpc.AppInfo}
+ */
+public class AppInfoTests extends TestCase {
+
+	private AppInfo msg;
+
+	@Override
+	public void setUp() {
+
+		msg = new AppInfo();
+		msg.setAppDisplayName(Test.GENERAL_STRING);
+		msg.setAppBundleID(Test.GENERAL_STRING);
+		msg.setAppVersion(Test.GENERAL_STRING);
+		msg.setAppIcon(Test.GENERAL_STRING);
+	}
+
+	/**
+	 * Tests the expected values of the RPC message.
+	 */
+	public void testRpcValues () {
+		// Test Values
+		String appDisplayName = msg.getAppDisplayName();
+		String appBundleID = msg.getAppBundleID();
+		String appVersion = msg.getAppVersion();
+		String appIcon = msg.getAppIcon();
+
+		// Valid Tests
+		assertEquals(Test.GENERAL_STRING, appDisplayName);
+		assertEquals(Test.GENERAL_STRING, appBundleID);
+		assertEquals(Test.GENERAL_STRING, appVersion);
+		assertEquals(Test.GENERAL_STRING, appIcon);
+
+		// Invalid/Null Tests
+		AppInfo msg = new AppInfo();
+		assertNotNull(Test.NOT_NULL, msg);
+
+		assertNull(Test.NULL, msg.getAppDisplayName());
+		assertNull(Test.NULL, msg.getAppBundleID());
+		assertNull(Test.NULL, msg.getAppVersion());
+		assertNull(Test.NULL, msg.getAppIcon());
+	}
+
+	public void testJson(){
+		JSONObject reference = new JSONObject();
+
+		try{
+			reference.put(AppInfo.KEY_APP_DISPLAY_NAME, Test.GENERAL_STRING);
+			reference.put(AppInfo.KEY_APP_BUNDLE_ID, Test.GENERAL_STRING);
+			reference.put(AppInfo.KEY_APP_VERSION, Test.GENERAL_STRING);
+			reference.put(AppInfo.KEY_APP_ICON, Test.GENERAL_STRING);
+
+			JSONObject underTest = msg.serializeJSON();
+			assertEquals(Test.MATCH, reference.length(), underTest.length());
+
+			Iterator<?> iterator = reference.keys();
+			while(iterator.hasNext()){
+				String key = (String) iterator.next();
+				assertEquals(Test.MATCH, JsonUtils.readObjectFromJsonObject(reference, key), JsonUtils.readObjectFromJsonObject(underTest, key));
+			}
+		} catch(JSONException e){
+			fail(Test.JSON_FAIL);
+		}
+	}
+
+}

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/requests/RegisterAppInterfaceTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/requests/RegisterAppInterfaceTests.java
@@ -3,6 +3,7 @@ package com.smartdevicelink.test.rpc.requests;
 import com.smartdevicelink.marshal.JsonRPCMarshaller;
 import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.proxy.RPCMessage;
+import com.smartdevicelink.proxy.rpc.AppInfo;
 import com.smartdevicelink.proxy.rpc.DeviceInfo;
 import com.smartdevicelink.proxy.rpc.RegisterAppInterface;
 import com.smartdevicelink.proxy.rpc.SdlMsgVersion;
@@ -46,6 +47,7 @@ public class RegisterAppInterfaceTests extends BaseRpcTests {
 		msg.setAppHMIType(Test.GENERAL_APPHMITYPE_LIST);
 		msg.setIsMediaApplication(Test.GENERAL_BOOLEAN);
 		msg.setDeviceInfo(Test.GENERAL_DEVICEINFO);
+		msg.setAppInfo(Test.GENERAL_APPINFO);
 		msg.setDayColorScheme(Test.GENERAL_DAYCOLORSCHEME);
 		msg.setNightColorScheme(Test.GENERAL_NIGHTCOLORSCHEME);
 
@@ -80,6 +82,7 @@ public class RegisterAppInterfaceTests extends BaseRpcTests {
 			result.put(RegisterAppInterface.KEY_APP_HMI_TYPE, JsonUtils.createJsonArrayOfJsonNames(Test.GENERAL_APPHMITYPE_LIST, SDL_VERSION_UNDER_TEST));
 			result.put(RegisterAppInterface.KEY_IS_MEDIA_APPLICATION, Test.GENERAL_BOOLEAN);
 			result.put(RegisterAppInterface.KEY_DEVICE_INFO, Test.JSON_DEVICEINFO);
+			result.put(RegisterAppInterface.KEY_APP_INFO, Test.JSON_APPINFO);
 			result.put(RegisterAppInterface.KEY_DAY_COLOR_SCHEME, Test.JSON_DAYCOLORSCHEME);
 			result.put(RegisterAppInterface.KEY_NIGHT_COLOR_SCHEME, Test.JSON_NIGHTCOLORSCHEME);
 		} catch (JSONException e) {
@@ -107,6 +110,7 @@ public class RegisterAppInterfaceTests extends BaseRpcTests {
 		List<AppHMIType> testApps = ( (RegisterAppInterface) msg).getAppHMIType();
 		Boolean testMedia = ( (RegisterAppInterface) msg).getIsMediaApplication();
 		DeviceInfo testDeviceInfo = ( (RegisterAppInterface) msg).getDeviceInfo();
+		AppInfo testAppInfo = ( (RegisterAppInterface) msg).getAppInfo();
 		TemplateColorScheme testDayColorScheme = ( (RegisterAppInterface) msg).getDayColorScheme();
 		TemplateColorScheme testNightColorScheme = ( (RegisterAppInterface) msg).getNightColorScheme();
 
@@ -124,6 +128,7 @@ public class RegisterAppInterfaceTests extends BaseRpcTests {
 		assertEquals(Test.MATCH, Test.GENERAL_APPHMITYPE_LIST, testApps);
 		assertEquals(Test.MATCH, (Boolean) Test.GENERAL_BOOLEAN, testMedia);
 		assertTrue(Test.TRUE, Validator.validateDeviceInfo(Test.GENERAL_DEVICEINFO, testDeviceInfo));
+		assertTrue(Test.TRUE, Validator.validateAppInfo(Test.GENERAL_APPINFO, testAppInfo));
 		assertTrue(Test.TRUE, Validator.validateTemplateColorScheme(Test.GENERAL_DAYCOLORSCHEME, testDayColorScheme));
 		assertTrue(Test.TRUE, Validator.validateTemplateColorScheme(Test.GENERAL_NIGHTCOLORSCHEME, testNightColorScheme));
 
@@ -145,6 +150,7 @@ public class RegisterAppInterfaceTests extends BaseRpcTests {
 		assertNull(Test.NULL, msg.getAppHMIType());
 		assertNull(Test.NULL, msg.getIsMediaApplication());
 		assertNull(Test.NULL, msg.getDeviceInfo());
+		assertNull(Test.NULL, msg.getAppInfo());
 		assertNull(Test.NULL, msg.getDayColorScheme());
 		assertNull(Test.NULL, msg.getNightColorScheme());
 	}
@@ -192,6 +198,10 @@ public class RegisterAppInterfaceTests extends BaseRpcTests {
 			assertEquals(Test.MATCH, JsonUtils.readStringFromJsonObject(parameters, RegisterAppInterface.KEY_APP_NAME), cmd.getAppName());
 			assertEquals(Test.MATCH, JsonUtils.readStringFromJsonObject(parameters, RegisterAppInterface.KEY_NGN_MEDIA_SCREEN_APP_NAME), cmd.getNgnMediaScreenAppName());
 			assertEquals(Test.MATCH, JsonUtils.readBooleanFromJsonObject(parameters, RegisterAppInterface.KEY_IS_MEDIA_APPLICATION), cmd.getIsMediaApplication());
+
+			JSONObject appInfoObj = JsonUtils.readJsonObjectFromJsonObject(parameters, RegisterAppInterface.KEY_APP_INFO);
+			AppInfo appInfo = new AppInfo(JsonRPCMarshaller.deserializeJSONObject(appInfoObj));
+			assertTrue(Test.TRUE,  Validator.validateAppInfo(appInfo, cmd.getAppInfo()));
 
 			List<String> vrSynonymsList = JsonUtils.readStringListFromJsonObject(parameters, RegisterAppInterface.KEY_VR_SYNONYMS);
 			List<String> testSynonymsList = cmd.getVrSynonyms();

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/AppInfo.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/AppInfo.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2019 Livio, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Livio Inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.smartdevicelink.proxy.rpc;
+
+import android.support.annotation.NonNull;
+
+import com.smartdevicelink.proxy.RPCStruct;
+
+import java.util.Hashtable;
+
+public class AppInfo extends RPCStruct {
+
+	public static final String KEY_APP_DISPLAY_NAME = "appDisplayName";
+	public static final String KEY_APP_BUNDLE_ID = "appBundleID";
+	public static final String KEY_APP_VERSION = "appVersion";
+	public static final String KEY_APP_ICON = "appIcon";
+
+	/**
+	 * Constructs a new AppInfo object
+	 */
+	public AppInfo() { }
+
+	/**
+	 * Constructs a new AppInfo object indicated by the Hashtable parameter
+	 * @param hash The Hashtable to use
+	 */
+	public AppInfo(Hashtable<String, Object> hash) {
+		super(hash);
+	}
+
+	/**
+	 * Constructs a new AppInfo object
+	 * @param appDisplayName - name displayed for the mobile application on the mobile device
+	 * @param appBundleID - package name of the application.
+	 * @param appVersion - build version number of this particular mobile app.
+	 */
+	public AppInfo(@NonNull String appDisplayName, String appBundleID, String appVersion){
+		this();
+		setAppDisplayName(appDisplayName);
+		setAppBundleID(appBundleID);
+		setAppVersion(appVersion);
+	}
+
+	/** Sets the name displayed for the mobile application on the mobile device (can differ from the app name set in the initial RAI request).
+	 * @param appDisplayName - name displayed for the mobile application on the mobile device.
+	 */
+	public void setAppDisplayName(@NonNull String appDisplayName) {
+		setValue(KEY_APP_DISPLAY_NAME, appDisplayName);
+	}
+
+	/** Gets the name displayed for the mobile application on the mobile device (can differ from the app name set in the initial RAI request).
+	 * @return appDisplayName - name displayed for the mobile application on the mobile device.
+	 */
+	public String getAppDisplayName() {
+		return getString(KEY_APP_DISPLAY_NAME);
+	}
+
+	/** Sets package name of the Android application. This supports App Launch strategies for each platform.
+	 * @param appBundleID - package name of the application
+	 */
+	public void setAppBundleID(@NonNull String appBundleID) {
+		setValue(KEY_APP_BUNDLE_ID, appBundleID);
+	}
+
+	/** Gets package name of the Android application. This supports App Launch strategies for each platform.
+	 * @return appBundleID - package name of the application.
+	 */
+	public String getAppBundleID() {
+		return getString(KEY_APP_BUNDLE_ID);
+	}
+
+	/** Sets build version number of this particular mobile app.
+	 * @param appVersion - build version number of this particular mobile app.
+	 */
+	public void setAppVersion(@NonNull String appVersion) {
+		setValue(KEY_APP_VERSION, appVersion);
+	}
+
+	/** Gets build version number of this particular mobile app.
+	 * @return appVersion - build version number of this particular mobile app.
+	 */
+	public String getAppVersion() {
+		return getString(KEY_APP_VERSION);
+	}
+
+	/** Sets file reference to the icon utilized by this app (simplifies the process of setting an app icon during app registration).
+	 * @param appIcon - file reference to the icon utilized by this app
+	 */
+	public void setAppIcon(String appIcon) {
+		setValue(KEY_APP_ICON, appIcon);
+	}
+
+	/** Gets build version number of this particular mobile app.
+	 * @return appIcon - build version number of this particular mobile app.
+	 */
+	public String getAppIcon() {
+		return getString(KEY_APP_ICON);
+	}
+}

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterface.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterface.java
@@ -286,6 +286,7 @@ public class RegisterAppInterface extends RPCRequest {
 	public static final String KEY_VR_SYNONYMS = "vrSynonyms";
 	public static final String KEY_SDL_MSG_VERSION = "syncMsgVersion";
 	public static final String KEY_HASH_ID = "hashID";
+	public static final String KEY_APP_INFO = "appInfo";
 	public static final String KEY_DAY_COLOR_SCHEME = "dayColorScheme";
 	public static final String KEY_NIGHT_COLOR_SCHEME = "nightColorScheme";
 	private static final int APP_ID_MAX_LENGTH = 10;
@@ -615,6 +616,22 @@ public class RegisterAppInterface extends RPCRequest {
     public void setHashID(String hashID) {
 		setParameters(KEY_HASH_ID, hashID);
     }
+
+	/**
+	 * Gets the detailed information about the registered application
+	 * @return appInfo - detailed information about the registered application
+	 */
+	public String getAppInfo() {
+		return getString(KEY_APP_INFO);
+	}
+
+	/**
+	 * Sets detailed information about the registered application
+	 * @param appInfo - detailed information about the registered application
+	 */
+	public void setAppInfo(String appInfo) {
+		setParameters(KEY_APP_INFO, appInfo);
+	}
 
 	/**
 	 * Gets the unique ID, which an app will be given when approved

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterface.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterface.java
@@ -621,15 +621,15 @@ public class RegisterAppInterface extends RPCRequest {
 	 * Gets the detailed information about the registered application
 	 * @return appInfo - detailed information about the registered application
 	 */
-	public String getAppInfo() {
-		return getString(KEY_APP_INFO);
+	public AppInfo getAppInfo() {
+		return (AppInfo) getObject(AppInfo.class, KEY_APP_INFO);
 	}
 
 	/**
 	 * Sets detailed information about the registered application
 	 * @param appInfo - detailed information about the registered application
 	 */
-	public void setAppInfo(String appInfo) {
+	public void setAppInfo(AppInfo appInfo) {
 		setParameters(KEY_APP_INFO, appInfo);
 	}
 


### PR DESCRIPTION
Fixes #1217 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests are added to test `AppInfo` struct and the RAI

### Summary
This PR adds the `AppInfo` struct that was missing from the java suite library

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
