### PR TITLE
Fix potential overflow issue in BestRouterComparator

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/SdlAppInfo.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/SdlAppInfo.java
@@ -153,12 +153,12 @@ public class SdlAppInfo {
                     int versionCompare =  two.routerServiceVersion  - one.routerServiceVersion;
 
                     if(versionCompare == 0){ //Versions are equal so lets use the one that has been updated most recently
-                        int updateTime =  (int)(two.lastUpdateTime - one.lastUpdateTime);
+                        long updateTime =  two.lastUpdateTime - one.lastUpdateTime;
                         if(updateTime == 0){
                             //This is arbitrary, but we want to ensure all lists are sorted in the same order
                             return  one.routerServiceComponentName.getPackageName().compareTo(two.routerServiceComponentName.getPackageName());
                         }else{
-                            return updateTime;
+                            return (updateTime < 0 ? -1 : 1);
                         }
                     }else{
                         return versionCompare;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/SdlAppInfo.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/SdlAppInfo.java
@@ -161,7 +161,7 @@ public class SdlAppInfo {
                             return (updateTime < 0 ? -1 : 1);
                         }
                     }else{
-                        return versionCompare;
+                        return (versionCompare < 0 ? -1 : 1);
                     }
 
                 }else{


### PR DESCRIPTION
Fixes #1227 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Install two sdl apps on the phone and make sure the router service is selected based on the compare function in `BestRouterComparator`

### Summary
This PR fixes a potential overflow issue that could happen if the result of subtracting to `long` numbers is outside the boundaries of an `int`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
