### PR TITLE
Update Bintray groupId to com.smartdevicelink

### DIFF
--- a/javaEE/bintray.gradle
+++ b/javaEE/bintray.gradle
@@ -4,7 +4,6 @@ apply plugin: 'maven'
 
 def siteUrl = 'https://github.com/smartdevicelink/sdl_java_suite'      // Homepage URL of the library
 def gitUrl = 'https://github.com/smartdevicelink/sdl_java_suite.git'   // Git repository URL
-group = "com.smartdevicelink" // Maven Group ID for the artifact
 def libDescription = 'SmartDeviceLink mobile library'
 def libVersion = new File(projectDir.path, ('/../VERSION')).text.trim()
 
@@ -37,7 +36,7 @@ bintray {
 
     pkg {
         repo = props.getProperty("bintray.repo")
-        name = props.getProperty("bintray.artifact")
+        name = props.getProperty("bintray.package")
         websiteUrl = siteUrl
         vcsUrl = gitUrl
         userOrg = props.getProperty("bintray.userorg")
@@ -82,7 +81,7 @@ publishing {
             artifact javadocJar {
                 classifier "javadoc"
             }
-            groupId props.getProperty("bintray.userorg")
+            groupId props.getProperty("bintray.group")
             artifactId props.getProperty("bintray.artifact")
             version libVersion
             pom.withXml {

--- a/javaEE/bintray.properties
+++ b/javaEE/bintray.properties
@@ -1,6 +1,8 @@
 bintray.user=username
 bintray.key=apikey
-bintray.repo=sdl_java_ee
-bintray.artifact=sdl_java_ee
 bintray.userorg=smartdevicelink
+bintray.repo=sdl_java_ee
+bintray.package=sdl_javaee
+bintray.group=com.smartdevicelink
+bintray.artifact=sdl_java_ee
 bintray.publish=true

--- a/javaSE/bintray.gradle
+++ b/javaSE/bintray.gradle
@@ -4,7 +4,6 @@ apply plugin: 'maven'
 
 def siteUrl = 'https://github.com/smartdevicelink/sdl_java_suite'      // Homepage URL of the library
 def gitUrl = 'https://github.com/smartdevicelink/sdl_java_suite.git'   // Git repository URL
-group = "com.smartdevicelink" // Maven Group ID for the artifact
 def libDescription = 'SmartDeviceLink mobile library'
 def libVersion = new File(projectDir.path, ('/../VERSION')).text.trim()
 
@@ -37,7 +36,7 @@ bintray {
 
     pkg {
         repo = props.getProperty("bintray.repo")
-        name = props.getProperty("bintray.artifact")
+        name = props.getProperty("bintray.package")
         websiteUrl = siteUrl
         vcsUrl = gitUrl
         userOrg = props.getProperty("bintray.userorg")
@@ -82,7 +81,7 @@ publishing {
             artifact javadocJar {
                 classifier "javadoc"
             }
-            groupId props.getProperty("bintray.userorg")
+            groupId props.getProperty("bintray.group")
             artifactId props.getProperty("bintray.artifact")
             version libVersion
             pom.withXml {

--- a/javaSE/bintray.properties
+++ b/javaSE/bintray.properties
@@ -1,6 +1,8 @@
 bintray.user=username
 bintray.key=apikey
-bintray.repo=sdl_java_se
-bintray.artifact=sdl_java_se
 bintray.userorg=smartdevicelink
+bintray.repo=sdl_java_se
+bintray.package=sdl_javase
+bintray.group=com.smartdevicelink
+bintray.artifact=sdl_java_se
 bintray.publish=true


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- Update the version `VERSION` file to a temp test version something like `test_4.10.1` 
- Use the `bintrayUpload` Gradle task to make sure that scripts pushes correctly to bintray
```
./gradlew bintrayUpload
```
- Confirm that the compile line starts with `com` like 
```
compile 'com.smartdevicelink:sdl_java_se:{version}'
```
- Use the bintray gradle line to fetch the library and confirm that the library works

### Summary
This PR updates the `groupId` in the bintray compile line for the `JavaSE` & `JavaEE` to `com.smartdevicelink` to match the `Android`'s `groupId`.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
