### PR TITLE
Fix NPE issue with IsHapticSpatialDataSupported()

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -113,7 +113,7 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 					return;
 				}
 				VideoStreamingCapability capability = (VideoStreamingCapability) internalInterface.getCapability(SystemCapabilityType.VIDEO_STREAMING);
-				if(capability != null && capability.getIsHapticSpatialDataSupported()){
+				if(capability != null && Boolean.TRUE.equals(capability.getIsHapticSpatialDataSupported())){
 					hapticManager = new HapticInterfaceManager(internalInterface);
 				}
 				startEncoder();

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -8368,7 +8368,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				return;
 			}
 			VideoStreamingCapability capability = (VideoStreamingCapability)_systemCapabilityManager.getCapability(SystemCapabilityType.VIDEO_STREAMING);
-			if(capability != null && capability.getIsHapticSpatialDataSupported()){
+			if(capability != null && Boolean.TRUE.equals(capability.getIsHapticSpatialDataSupported())){
 				hapticManager = new HapticInterfaceManager(internalInterface);
 			}
 


### PR DESCRIPTION
Fixes #1245 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
* Connect to a headunit that can send video streaming capability without `hapticSpatialDataSupported`
* Start video streaming
* Make sure app does not crash

### Summary
Fix two NPE issue in `SdlProxyBase` and `VideoStreamManager`

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
