### PR TITLE
Change Codecov patch status target

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://github.com/smartdevicelink/sdl_java_suite/workflows/GitHub%20CI/badge.svg)](https://travis-ci.org/smartdevicelink/sdl_java_suite)
+[![Build Status](https://github.com/smartdevicelink/sdl_java_suite/workflows/GitHub%20CI/badge.svg?branch=master)](https://github.com/smartdevicelink/sdl_java_suite/actions)
 [![codecov](https://codecov.io/gh/smartdevicelink/sdl_android/branch/master/graph/badge.svg)](https://codecov.io/gh/smartdevicelink/sdl_java_suite)
 [![Slack Status](http://sdlslack.herokuapp.com/badge.svg)](http://slack.smartdevicelink.com)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://github.com/smartdevicelink/sdl_java_suite/workflows/GitHub%20CI/badge.svg?branch=master)](https://github.com/smartdevicelink/sdl_java_suite/actions)
-[![codecov](https://codecov.io/gh/smartdevicelink/sdl_android/branch/master/graph/badge.svg)](https://codecov.io/gh/smartdevicelink/sdl_java_suite)
+[![codecov](https://codecov.io/gh/smartdevicelink/sdl_java_suite/branch/master/graph/badge.svg)](https://codecov.io/gh/smartdevicelink/sdl_java_suite)
 [![Slack Status](http://sdlslack.herokuapp.com/badge.svg)](http://slack.smartdevicelink.com)
 
 # SmartDeviceLink (SDL)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/smartdevicelink/sdl_java_suite.svg?branch=master)](https://travis-ci.org/smartdevicelink/sdl_java_suite)
+[![Build Status](https://github.com/smartdevicelink/sdl_java_suite/workflows/GitHub%20CI/badge.svg?branch=master)](https://travis-ci.org/smartdevicelink/sdl_java_suite)
 [![codecov](https://codecov.io/gh/smartdevicelink/sdl_android/branch/master/graph/badge.svg)](https://codecov.io/gh/smartdevicelink/sdl_java_suite)
 [![Slack Status](http://sdlslack.herokuapp.com/badge.svg)](http://slack.smartdevicelink.com)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://github.com/smartdevicelink/sdl_java_suite/workflows/GitHub%20CI/badge.svg?branch=master)](https://travis-ci.org/smartdevicelink/sdl_java_suite)
+[![Build Status](https://github.com/smartdevicelink/sdl_java_suite/workflows/GitHub%20CI/badge.svg)](https://travis-ci.org/smartdevicelink/sdl_java_suite)
 [![codecov](https://codecov.io/gh/smartdevicelink/sdl_android/branch/master/graph/badge.svg)](https://codecov.io/gh/smartdevicelink/sdl_java_suite)
 [![Slack Status](http://sdlslack.herokuapp.com/badge.svg)](http://slack.smartdevicelink.com)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,9 @@ coverage:
     project:
       default:
         target: 40%
-    patch: off
+    patch:
+      default:
+        target: 60%
     changes: no
 
 parsers:

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,9 +10,7 @@ coverage:
     project:
       default:
         target: 40%
-    patch:
-      default:
-        target: 40%
+    patch: off
     changes: no
 
 parsers:


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR makes the following changes:
*  Updates `codecov.yml` file for Codecov to set patch status target to 60%. [More info about patch status can be found here](https://docs.codecov.io/docs/commit-status)
* Update Codecov badge  in `README`  (it was broken previously)
* Update CI badge in `README` to use GitHub Actions instead of Travis

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
