### PR TITLE
Add Override Equals method to softButtonObject

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
@@ -807,11 +807,10 @@ public class FileManagerTests extends AndroidTestCase2 {
 	/**
 	 * 	Test custom overridden SdlFile equals method
 	 */
-	public void testSdlFIleEq() {
+	public void testSdlFileEquals() {
 		// Case 1: object is null, assertFalse
 		SdlFile artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, true);
 		SdlFile artwork2 = null;
-
 		assertFalse(artwork1.equals(artwork2));
 
 		// Case 2 SoftButtonObjects are the same, assertTrue
@@ -824,18 +823,15 @@ public class FileManagerTests extends AndroidTestCase2 {
 		artwork1.setStaticIcon(true);
 		artwork2 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, true);
 		artwork2.setStaticIcon(false);
-
 		assertFalse(artwork1.equals(artwork2));
 
 		// Case 5: different Persistent status, assertFalse
 		artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
 		artwork2 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, true);
-
 		assertFalse(artwork1.equals(artwork2));
 
 		// Case 6: different name, assertFalse
 		artwork2 = new SdlFile("image2", FileType.GRAPHIC_PNG, 1, false);
-
 		assertFalse(artwork1.equals(artwork2));
 
 		// Case 7: different Uri
@@ -843,30 +839,24 @@ public class FileManagerTests extends AndroidTestCase2 {
 		Uri uri2 = Uri.parse("testUri2");
 		artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, uri1, false);
 		artwork2 = new SdlFile("image1", FileType.GRAPHIC_PNG, uri2, false);
-
 		assertFalse(artwork1.equals(artwork2));
 
 		// Case 8: different FileData
 		artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
 		artwork2 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
-
 		byte[] GENERAL_BYTE_ARRAY2 = new byte[2];
-
 		artwork1.setFileData(Test.GENERAL_BYTE_ARRAY);
 		artwork2.setFileData(GENERAL_BYTE_ARRAY2);
-
 		assertFalse(artwork1.equals(artwork2));
 
 		// Case 9 different FileType, assertFalse
 		artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
 		artwork2 = new SdlFile("image1", FileType.AUDIO_WAVE, 1, false);
-
 		assertFalse(artwork1.equals(artwork2));
 
 		// Case 10: they are equal, assertTrue
 		artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
 		artwork2 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
-
 		assertTrue(artwork1.equals(artwork2));
 	}
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
@@ -818,7 +818,6 @@ public class FileManagerTests extends AndroidTestCase2 {
 		assertTrue(artwork1.equals(artwork1));
 
 		// Case 3: object is not an instance of SoftButtonObject, assertFalse
-
 		assertFalse(artwork1.equals("Test"));
 
 		// Case 4: different StaticIcon status, assertFalse
@@ -846,7 +845,6 @@ public class FileManagerTests extends AndroidTestCase2 {
 		artwork2 = new SdlFile("image1", FileType.GRAPHIC_PNG, uri2, false);
 
 		assertFalse(artwork1.equals(artwork2));
-
 
 		// Case 8: different FileData
 		artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
@@ -803,4 +803,72 @@ public class FileManagerTests extends AndroidTestCase2 {
 		assertEquals(fileManagerConfig.getArtworkRetryCount(), 2);
 		assertEquals(fileManagerConfig.getFileRetryCount(), 2);
 	}
+
+	/**
+	 * 	Test custom overridden SdlFile equals method
+	 */
+	public void testSdlFIleEq() {
+		// Case 1: object is null, assertFalse
+		SdlFile artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, true);
+		SdlFile artwork2 = null;
+
+		assertFalse(artwork1.equals(artwork2));
+
+		// Case 2 SoftButtonObjects are the same, assertTrue
+		assertTrue(artwork1.equals(artwork1));
+
+		// Case 3: object is not an instance of SoftButtonObject, assertFalse
+
+		assertFalse(artwork1.equals("Test"));
+
+		// Case 4: different StaticIcon status, assertFalse
+		artwork1.setStaticIcon(true);
+		artwork2 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, true);
+		artwork2.setStaticIcon(false);
+
+		assertFalse(artwork1.equals(artwork2));
+
+		// Case 5: different Persistent status, assertFalse
+		artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
+		artwork2 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, true);
+
+		assertFalse(artwork1.equals(artwork2));
+
+		// Case 6: different name, assertFalse
+		artwork2 = new SdlFile("image2", FileType.GRAPHIC_PNG, 1, false);
+
+		assertFalse(artwork1.equals(artwork2));
+
+		// Case 7: different Uri
+		Uri uri1 = Uri.parse("testUri1");
+		Uri uri2 = Uri.parse("testUri2");
+		artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, uri1, false);
+		artwork2 = new SdlFile("image1", FileType.GRAPHIC_PNG, uri2, false);
+
+		assertFalse(artwork1.equals(artwork2));
+
+
+		// Case 8: different FileData
+		artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
+		artwork2 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
+
+		byte[] GENERAL_BYTE_ARRAY2 = new byte[2];
+
+		artwork1.setFileData(Test.GENERAL_BYTE_ARRAY);
+		artwork2.setFileData(GENERAL_BYTE_ARRAY2);
+
+		assertFalse(artwork1.equals(artwork2));
+
+		// Case 9 different FileType, assertFalse
+		artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
+		artwork2 = new SdlFile("image1", FileType.AUDIO_WAVE, 1, false);
+
+		assertFalse(artwork1.equals(artwork2));
+
+		// Case 10: they are equal, assertTrue
+		artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
+		artwork2 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
+
+		assertTrue(artwork1.equals(artwork2));
+	}
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
@@ -505,4 +505,72 @@ public class FileManagerTests extends AndroidTestCase2 {
 			}
 		});
 	}
+
+	/**
+	 * Test custom overridden SdlFile equals method
+	 */
+	public void testSdlFIleEq() {
+		// Case 1: object is null, assertFalse
+		SdlFile artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, true);
+		SdlFile artwork2 = null;
+
+		assertFalse(artwork1.equals(artwork2));
+
+		// Case 2 SoftButtonObjects are the same, assertTrue
+		assertTrue(artwork1.equals(artwork1));
+
+		// Case 3: object is not an instance of SoftButtonObject, assertFalse
+
+		assertFalse(artwork1.equals("Test"));
+
+		// Case 4: different StaticIcon status, assertFalse
+		artwork1.setStaticIcon(true);
+		artwork2 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, true);
+		artwork2.setStaticIcon(false);
+
+		assertFalse(artwork1.equals(artwork2));
+
+		// Case 5: different Persistent status, assertFalse
+		artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
+		artwork2 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, true);
+
+		assertFalse(artwork1.equals(artwork2));
+
+		// Case 6: different name, assertFalse
+		artwork2 = new SdlFile("image2", FileType.GRAPHIC_PNG, 1, false);
+
+		assertFalse(artwork1.equals(artwork2));
+
+		// Case 7: different Uri
+		Uri uri1 = Uri.parse("testUri1");
+		Uri uri2 = Uri.parse("testUri2");
+		artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, uri1, false);
+		artwork2 = new SdlFile("image1", FileType.GRAPHIC_PNG, uri2, false);
+
+		assertFalse(artwork1.equals(artwork2));
+
+
+		// Case 8: different FileData
+		artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
+		artwork2 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
+
+		byte[] GENERAL_BYTE_ARRAY2 = new byte[2];
+
+		artwork1.setFileData(Test.GENERAL_BYTE_ARRAY);
+		artwork2.setFileData(GENERAL_BYTE_ARRAY2);
+
+		assertFalse(artwork1.equals(artwork2));
+
+		// Case 9 different FileType, assertFalse
+		artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
+		artwork2 = new SdlFile("image1", FileType.AUDIO_WAVE, 1, false);
+
+		assertFalse(artwork1.equals(artwork2));
+
+		// Case 10: they are equal, assertTrue
+		artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
+		artwork2 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
+
+		assertTrue(artwork1.equals(artwork2));
+	}
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -313,7 +313,7 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
     /**
      * Test custom overridden softButtonObject equals method
      */
-    public void testSoftButtonEq() {
+    public void testSoftButtonEquals() {
         SoftButtonObject softButtonObject1;
         SoftButtonObject softButtonObject2;
 
@@ -340,7 +340,6 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
         // Case 1: object is null, assertFalse
         softButtonObject1 = new SoftButtonObject("test", softButtonState1, null);
         softButtonObject2 = null;
-
         assertFalse(softButtonObject1.equals(softButtonObject2));
 
         // Case 2 SoftButtonObjects are the same, assertTrue
@@ -348,27 +347,21 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
 
         // Case 3: object is not an instance of SoftButtonObject assertFalse
         SdlArtwork artwork = new SdlArtwork("image1", FileType.GRAPHIC_PNG, 1, true);
-
         assertFalse(softButtonObject1.equals(artwork));
 
         // Case 4: SoftButtonObjectState List are not same size, assertFalse
         List<SoftButtonState> softButtonStateList = new ArrayList<>();
         List<SoftButtonState> softButtonStateList2 = new ArrayList<>();
-
         softButtonStateList.add(softButtonState1);
-
         softButtonStateList2.add(softButtonState1);
         softButtonStateList2.add(softButtonState2);
-
         softButtonObject1 = new SoftButtonObject("hi", softButtonStateList, "Hi", null);
         softButtonObject2 = new SoftButtonObject("hi", softButtonStateList2, "Hi", null);
-
         assertFalse(softButtonObject1.equals(softButtonObject2));
 
         // Case 5: SoftButtonStates are not the same, assertFalse
         softButtonObject1 = new SoftButtonObject("test", softButtonState1, null);
         softButtonObject2 = new SoftButtonObject("test", softButtonState2, null);
-
         assertFalse(softButtonObject1.equals(softButtonObject2));
 
         // Case 6: SoftButtonObject names are not same, assertFalse
@@ -379,33 +372,28 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
         // Case 7: SoftButtonObject currentStateName not same, assertFalse
         softButtonObject1 = new SoftButtonObject("hi", softButtonStateList, "Hi", null);
         softButtonObject2 = new SoftButtonObject("hi", softButtonStateList, "Hi2", null);
-
         assertFalse(softButtonObject1.equals(softButtonObject2));
 
         // Case 8: SoftButtonObject onEventListener not same, assert false
         softButtonObject1 = new SoftButtonObject("hi", softButtonStateList, "Hi", testOnEventList1);
         softButtonObject2 = new SoftButtonObject("hi", softButtonStateList, "Hi", testOnEventList2);
-
         assertFalse(softButtonObject1.equals(softButtonObject2));
 
         // Case 9: onEventListeners not null, everything same, assertTrue
         softButtonObject1 = new SoftButtonObject("hi", softButtonStateList, "Hi", testOnEventList1);
         softButtonObject2 = new SoftButtonObject("hi", softButtonStateList, "Hi", testOnEventList1);
-
         assertTrue(softButtonObject1.equals(softButtonObject2));
 
         // Case10: onEventListeners null, everything same, assertTrue
         softButtonObject1 = new SoftButtonObject("test", softButtonState1, null);
         softButtonObject2 = new SoftButtonObject("test", softButtonState1, null);
-
         assertTrue(softButtonObject1.equals(softButtonObject2));
-
     }
 
     /**
      * Test custom overridden softButtonState equals method
      */
-    public void testSoftButtonStateEq() {
+    public void testSoftButtonStateEquals() {
         assertFalse(softButtonState1.equals(softButtonState2));
         SdlArtwork artwork1 = new SdlArtwork("image1", FileType.GRAPHIC_PNG, 1, true);
         SdlArtwork artwork2 = new SdlArtwork("image2", FileType.GRAPHIC_PNG, 1, true);
@@ -413,29 +401,24 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
         // Case 1: object is null, assertFalse
         softButtonState1 = new SoftButtonState("object1-state1", "o1s1", artwork1);
         softButtonState2 = null;
-
         assertFalse(softButtonState1.equals(softButtonState2));
 
         // Case 2 SoftButtonObjects are the same, assertTrue
         assertTrue(softButtonState1.equals(softButtonState1));
 
         // Case 3: object is not an instance of SoftButtonState, assertFalse
-
         assertFalse(softButtonState1.equals(artwork1));
 
         // Case 4: different artwork, assertFalse
         softButtonState2 = new SoftButtonState("object1-state1", "o1s1", artwork2);
-
         assertFalse(softButtonState1.equals(softButtonState2));
 
         // Case 5: different name, assertFalse
         softButtonState2 = new SoftButtonState("object1-state1 different name", "o1s1", artwork1);
-
         assertFalse(softButtonState1.equals(softButtonState2));
 
         // Case 6 they are equal, assertTrue
         softButtonState2 = new SoftButtonState("object1-state1", "o1s1", artwork1);
-
         assertTrue(softButtonState1.equals(softButtonState2));
     }
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -305,4 +305,25 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
         assertEquals("SoftButtonObject id doesn't match the expected value", 100, sbo4.getButtonId());
         assertEquals("SoftButtonObject id doesn't match the expected value", 103, sbo5.getButtonId());
     }
+
+    public void testSoftButtonEq(){
+        SoftButtonObject softButtonObject1;
+        SoftButtonObject softButtonObject2;
+        //Case 1 should call the created equals method in softButtonObject and compare them by name and return True
+        softButtonObject1 = new SoftButtonObject( "test", softButtonState1, null);
+        softButtonObject2 = new SoftButtonObject( "test", softButtonState2, null);
+
+        assertTrue(softButtonObject1.equals(softButtonObject2));
+
+        //Case 2 should return false, the names of both softButtonObjects is are not the same
+        softButtonObject1 = new SoftButtonObject( "test", softButtonState1, null);
+        softButtonObject2 = new SoftButtonObject( "test23123", softButtonState2, null);
+        assertFalse(softButtonObject1.equals(softButtonObject2));
+
+        //Case 3 should return false because one of the objects is false
+        softButtonObject1 = new SoftButtonObject( "test", softButtonState1, null);
+        softButtonObject2 = null;
+        assertFalse(softButtonObject1.equals(softButtonObject2));
+    }
+
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -193,7 +193,7 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
         assertNull("Returned SoftButtonObject doesn't match the expected value", softButtonManager.getSoftButtonObjectById(5555));
     }
 
-    public void testSoftButtonState(){
+    public void testSoftButtonState() {
         // Test SoftButtonState.getName()
         String nameExpectedValue = "object1-state1";
         assertEquals("Returned state name doesn't match the expected value", nameExpectedValue, softButtonState1.getName());
@@ -214,7 +214,7 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
         assertTrue("Returned SoftButton doesn't match the expected value", Validator.validateSoftButton(softButtonExpectedValue, softButtonState1.getSoftButton()));
     }
 
-    public void testSoftButtonObject(){
+    public void testSoftButtonObject() {
         // Test SoftButtonObject.getName()
         assertEquals("Returned object name doesn't match the expected value", "object1", softButtonObject1.getName());
 
@@ -400,5 +400,42 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
 
         assertTrue(softButtonObject1.equals(softButtonObject2));
 
+    }
+
+    /**
+     * Test custom overridden softButtonState equals method
+     */
+    public void testSoftButtonStateEq() {
+        assertFalse(softButtonState1.equals(softButtonState2));
+        SdlArtwork artwork1 = new SdlArtwork("image1", FileType.GRAPHIC_PNG, 1, true);
+        SdlArtwork artwork2 = new SdlArtwork("image2", FileType.GRAPHIC_PNG, 1, true);
+
+        // Case 1: object is null, assertFalse
+        softButtonState1 = new SoftButtonState("object1-state1", "o1s1", artwork1);
+        softButtonState2 = null;
+
+        assertFalse(softButtonState1.equals(softButtonState2));
+
+        // Case 2 SoftButtonObjects are the same, assertTrue
+        assertTrue(softButtonState1.equals(softButtonState1));
+
+        // Case 3: object is not an instance of SoftButtonState, assertFalse
+
+        assertFalse(softButtonState1.equals(artwork1));
+
+        // Case 4: different artwork, assertFalse
+        softButtonState2 = new SoftButtonState("object1-state1", "o1s1", artwork2);
+
+        assertFalse(softButtonState1.equals(softButtonState2));
+
+        // Case 5: different name, assertFalse
+        softButtonState2 = new SoftButtonState("object1-state1 different name", "o1s1", artwork1);
+
+        assertFalse(softButtonState1.equals(softButtonState2));
+
+        // Case 6 they are equal, assertTrue
+        softButtonState2 = new SoftButtonState("object1-state1", "o1s1", artwork1);
+
+        assertTrue(softButtonState1.equals(softButtonState2));
     }
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -382,7 +382,7 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
 
         assertFalse(softButtonObject1.equals(softButtonObject2));
 
-        // Case 8: SoftButtonObject onEventListener are same, assert false
+        // Case 8: SoftButtonObject onEventListener not same, assert false
         softButtonObject1 = new SoftButtonObject("hi", softButtonStateList, "Hi", testOnEventList1);
         softButtonObject2 = new SoftButtonObject("hi", softButtonStateList, "Hi", testOnEventList2);
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -320,13 +320,20 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
         softButtonObject2 = new SoftButtonObject( "test23123", softButtonState2, null);
         assertFalse(softButtonObject1.equals(softButtonObject2));
 
-        //Case 3 should return false because one of the objects is false
+        //Case 3 should return false because one of the objects is null
         softButtonObject1 = new SoftButtonObject( "test", softButtonState1, null);
         softButtonObject2 = null;
         assertFalse(softButtonObject1.equals(softButtonObject2));
 
-        //Case4 should return false because a softButtonObject was not passed to this method{
+        //Case4 should return false because a softButtonObject was not passed to this method
+        softButtonObject1 = new SoftButtonObject( "test", softButtonState1, null);
         assertFalse(softButtonObject1.equals(softButtonState1));
+
+        //Case5 if SoftButton object name is null that you are trying to compare
+        softButtonObject1 = new SoftButtonObject( "test", softButtonState1, null);
+        softButtonObject2 = new SoftButtonObject( null, softButtonState2, null);
+        assertFalse(softButtonObject1.equals(softButtonObject2));
+
 
     }
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -324,6 +324,10 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
         softButtonObject1 = new SoftButtonObject( "test", softButtonState1, null);
         softButtonObject2 = null;
         assertFalse(softButtonObject1.equals(softButtonObject2));
+
+        //Case4 should return false because a softButtonObject was not passed to this method{
+        assertFalse(softButtonObject1.equals(softButtonState1));
+
     }
 
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -6,9 +6,12 @@ import com.smartdevicelink.managers.CompletionListener;
 import com.smartdevicelink.managers.file.FileManager;
 import com.smartdevicelink.managers.file.MultipleFileCompletionListener;
 import com.smartdevicelink.managers.file.filetypes.SdlArtwork;
+import com.smartdevicelink.managers.file.filetypes.SdlFile;
 import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.proxy.interfaces.ISdl;
 import com.smartdevicelink.proxy.rpc.Image;
+import com.smartdevicelink.proxy.rpc.OnButtonEvent;
+import com.smartdevicelink.proxy.rpc.OnButtonPress;
 import com.smartdevicelink.proxy.rpc.OnHMIStatus;
 import com.smartdevicelink.proxy.rpc.Show;
 import com.smartdevicelink.proxy.rpc.SoftButton;
@@ -25,6 +28,7 @@ import com.smartdevicelink.test.Validator;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -306,35 +310,95 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
         assertEquals("SoftButtonObject id doesn't match the expected value", 103, sbo5.getButtonId());
     }
 
-    public void testSoftButtonEq(){
+    /**
+     * Test custom overridden softButtonObject equals method
+     */
+    public void testSoftButtonEq() {
         SoftButtonObject softButtonObject1;
         SoftButtonObject softButtonObject2;
-        //Case 1 should call the created equals method in softButtonObject and compare them by name and return True
-        softButtonObject1 = new SoftButtonObject( "test", softButtonState1, null);
-        softButtonObject2 = new SoftButtonObject( "test", softButtonState2, null);
+
+        SoftButtonObject.OnEventListener testOnEventList1 = new SoftButtonObject.OnEventListener() {
+            @Override
+            public void onPress(SoftButtonObject softButtonObject, OnButtonPress onButtonPress) {
+            }
+
+            @Override
+            public void onEvent(SoftButtonObject softButtonObject, OnButtonEvent onButtonEvent) {
+            }
+        };
+
+        SoftButtonObject.OnEventListener testOnEventList2 = new SoftButtonObject.OnEventListener() {
+            @Override
+            public void onPress(SoftButtonObject softButtonObject, OnButtonPress onButtonPress) {
+            }
+
+            @Override
+            public void onEvent(SoftButtonObject softButtonObject, OnButtonEvent onButtonEvent) {
+            }
+        };
+
+        // Case 1: object is null, assertFalse
+        softButtonObject1 = new SoftButtonObject("test", softButtonState1, null);
+        softButtonObject2 = null;
+
+        assertFalse(softButtonObject1.equals(softButtonObject2));
+
+        // Case 2 SoftButtonObjects are the same, assertTrue
+        assertTrue(softButtonObject1.equals(softButtonObject1));
+
+        // Case 3: object is not an instance of SoftButtonObject assertFalse
+        SdlArtwork artwork = new SdlArtwork("image1", FileType.GRAPHIC_PNG, 1, true);
+
+        assertFalse(softButtonObject1.equals(artwork));
+
+        // Case 4: SoftButtonObjectState List are not same size, assertFalse
+        List<SoftButtonState> softButtonStateList = new ArrayList<>();
+        List<SoftButtonState> softButtonStateList2 = new ArrayList<>();
+
+        softButtonStateList.add(softButtonState1);
+
+        softButtonStateList2.add(softButtonState1);
+        softButtonStateList2.add(softButtonState2);
+
+        softButtonObject1 = new SoftButtonObject("hi", softButtonStateList, "Hi", null);
+        softButtonObject2 = new SoftButtonObject("hi", softButtonStateList2, "Hi", null);
+
+        assertFalse(softButtonObject1.equals(softButtonObject2));
+
+        // Case 5: SoftButtonStates are not the same, assertFalse
+        softButtonObject1 = new SoftButtonObject("test", softButtonState1, null);
+        softButtonObject2 = new SoftButtonObject("test", softButtonState2, null);
+
+        assertFalse(softButtonObject1.equals(softButtonObject2));
+
+        // Case 6: SoftButtonObject names are not same, assertFalse
+        softButtonObject1 = new SoftButtonObject("test", softButtonState1, null);
+        softButtonObject2 = new SoftButtonObject("test23123", softButtonState1, null);
+        assertFalse(softButtonObject1.equals(softButtonObject2));
+
+        // Case 7: SoftButtonObject currentStateName not same, assertFalse
+        softButtonObject1 = new SoftButtonObject("hi", softButtonStateList, "Hi", null);
+        softButtonObject2 = new SoftButtonObject("hi", softButtonStateList, "Hi2", null);
+
+        assertFalse(softButtonObject1.equals(softButtonObject2));
+
+        // Case 8: SoftButtonObject onEventListener are same, assert false
+        softButtonObject1 = new SoftButtonObject("hi", softButtonStateList, "Hi", testOnEventList1);
+        softButtonObject2 = new SoftButtonObject("hi", softButtonStateList, "Hi", testOnEventList2);
+
+        assertFalse(softButtonObject1.equals(softButtonObject2));
+
+        // Case 9: onEventListeners not null, everything same, assertTrue
+        softButtonObject1 = new SoftButtonObject("hi", softButtonStateList, "Hi", testOnEventList1);
+        softButtonObject2 = new SoftButtonObject("hi", softButtonStateList, "Hi", testOnEventList1);
 
         assertTrue(softButtonObject1.equals(softButtonObject2));
 
-        //Case 2 should return false, the names of both softButtonObjects are not the same
-        softButtonObject1 = new SoftButtonObject( "test", softButtonState1, null);
-        softButtonObject2 = new SoftButtonObject( "test23123", softButtonState2, null);
-        assertFalse(softButtonObject1.equals(softButtonObject2));
+        // Case10: onEventListeners null, everything same, assertTrue
+        softButtonObject1 = new SoftButtonObject("test", softButtonState1, null);
+        softButtonObject2 = new SoftButtonObject("test", softButtonState1, null);
 
-        //Case 3 should return false because one of the objects is null
-        softButtonObject1 = new SoftButtonObject( "test", softButtonState1, null);
-        softButtonObject2 = null;
-        assertFalse(softButtonObject1.equals(softButtonObject2));
-
-        //Case4 should return false because a softButtonObject was not passed to this method
-        softButtonObject1 = new SoftButtonObject( "test", softButtonState1, null);
-        assertFalse(softButtonObject1.equals(softButtonState1));
-
-        //Case5 if SoftButton object name is null that you are trying to compare
-        softButtonObject1 = new SoftButtonObject( "test", softButtonState1, null);
-        softButtonObject2 = new SoftButtonObject( null, softButtonState2, null);
-        assertFalse(softButtonObject1.equals(softButtonObject2));
-
+        assertTrue(softButtonObject1.equals(softButtonObject2));
 
     }
-
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -315,7 +315,7 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
 
         assertTrue(softButtonObject1.equals(softButtonObject2));
 
-        //Case 2 should return false, the names of both softButtonObjects is are not the same
+        //Case 2 should return false, the names of both softButtonObjects are not the same
         softButtonObject1 = new SoftButtonObject( "test", softButtonState1, null);
         softButtonObject2 = new SoftButtonObject( "test23123", softButtonState2, null);
         assertFalse(softButtonObject1.equals(softButtonObject2));

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
@@ -35,6 +35,7 @@ package com.smartdevicelink.managers.file.filetypes;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 
+import com.smartdevicelink.managers.screen.SoftButtonObject;
 import com.smartdevicelink.proxy.rpc.enums.FileType;
 import com.smartdevicelink.proxy.rpc.enums.StaticIconName;
 
@@ -218,5 +219,42 @@ public class SdlFile{
      */
     public boolean isStaticIcon() {
         return isStaticIcon;
+    }
+
+
+    /**
+     * Used to compile hashcode for SdlFile for use to compare in equals method
+     * @return Custom hashcode of SdlFile variables
+     */
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result += ((getName() == null) ? 0 : Integer.rotateLeft(getName().hashCode(), 1));
+        result += ((getUri() == null) ? 0 : Integer.rotateLeft(getUri().hashCode(), 2));
+        result += ((getFileData() == null) ? 0 : Integer.rotateLeft(getFileData().hashCode(), 3));
+        result += ((getType() == null) ? 0 : Integer.rotateLeft(getType().hashCode(), 4));
+        return result;
+    }
+
+    /**
+     * Uses our custom hashCode for SdlFile objects
+     * @param o - The object to compare
+     * @return boolean of whether the objects are the same or not
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) return false;
+        // if this is the same memory address, its the same
+        if (this == o) return true;
+        // if this is not an instance of this class, not the same
+        if (!(o instanceof SdlFile)) return false;
+        //Cast o to SdlFile
+        SdlFile sdlFile = (SdlFile) o;
+        // if isStaticIcon and isPersistent is not the same for each object, they are not the same
+        if(!(this.isStaticIcon == sdlFile.isStaticIcon && this.isPersistent() == sdlFile.isPersistent())){
+            return false;
+        }
+        // return comparison
+        return hashCode() == o.hashCode();
     }
 }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
@@ -233,6 +233,9 @@ public class SdlFile{
         result += ((getUri() == null) ? 0 : Integer.rotateLeft(getUri().hashCode(), 2));
         result += ((getFileData() == null) ? 0 : Integer.rotateLeft(getFileData().hashCode(), 3));
         result += ((getType() == null) ? 0 : Integer.rotateLeft(getType().hashCode(), 4));
+        result += ((Boolean.valueOf(isStaticIcon) == null) ? 0 : Integer.rotateLeft(Boolean.valueOf(isStaticIcon).hashCode(), 5));
+        result += ((Boolean.valueOf(isPersistent()) == null) ? 0 : Integer.rotateLeft(Boolean.valueOf(isPersistent()).hashCode(), 6));
+        result += ((Integer.valueOf(getResourceId()) == null) ? 0 : Integer.rotateLeft(Integer.valueOf(getResourceId()).hashCode(), 7));
         return result;
     }
 
@@ -249,12 +252,6 @@ public class SdlFile{
         if (this == o) return true;
         // if this is not an instance of SdlFile, not the same
         if (!(o instanceof SdlFile)) return false;
-        // Cast o to SdlFile
-        SdlFile sdlFile = (SdlFile) o;
-        // if isStaticIcon and isPersistent are not the same for each object, they are not the same
-        if (!(this.isStaticIcon == sdlFile.isStaticIcon && this.isPersistent() == sdlFile.isPersistent())) {
-            return false;
-        }
         // return comparison
         return hashCode() == o.hashCode();
     }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
@@ -247,11 +247,11 @@ public class SdlFile{
         if (o == null) return false;
         // if this is the same memory address, it's the same
         if (this == o) return true;
-        // if this is not an instance of this class, not the same
+        // if this is not an instance of SdlFile, not the same
         if (!(o instanceof SdlFile)) return false;
         // Cast o to SdlFile
         SdlFile sdlFile = (SdlFile) o;
-        // if isStaticIcon and isPersistent is not the same for each object, they are not the same
+        // if isStaticIcon and isPersistent are not the same for each object, they are not the same
         if (!(this.isStaticIcon == sdlFile.isStaticIcon && this.isPersistent() == sdlFile.isPersistent())) {
             return false;
         }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
@@ -222,7 +222,7 @@ public class SdlFile{
     }
 
     /**
-     * Used to compile hashcode for SdlFile for use to compare in equals method
+     * Used to compile hashcode for SdlFile for use to compare in overridden equals method
      *
      * @return Custom hashcode of SdlFile variables
      */

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
@@ -221,7 +221,6 @@ public class SdlFile{
         return isStaticIcon;
     }
 
-
     /**
      * Used to compile hashcode for SdlFile for use to compare in equals method
      *

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
@@ -224,6 +224,7 @@ public class SdlFile{
 
     /**
      * Used to compile hashcode for SdlFile for use to compare in equals method
+     *
      * @return Custom hashcode of SdlFile variables
      */
     @Override
@@ -238,20 +239,21 @@ public class SdlFile{
 
     /**
      * Uses our custom hashCode for SdlFile objects
+     *
      * @param o - The object to compare
      * @return boolean of whether the objects are the same or not
      */
     @Override
     public boolean equals(Object o) {
         if (o == null) return false;
-        // if this is the same memory address, its the same
+        // if this is the same memory address, it's the same
         if (this == o) return true;
         // if this is not an instance of this class, not the same
         if (!(o instanceof SdlFile)) return false;
-        //Cast o to SdlFile
+        // Cast o to SdlFile
         SdlFile sdlFile = (SdlFile) o;
         // if isStaticIcon and isPersistent is not the same for each object, they are not the same
-        if(!(this.isStaticIcon == sdlFile.isStaticIcon && this.isPersistent() == sdlFile.isPersistent())){
+        if (!(this.isStaticIcon == sdlFile.isStaticIcon && this.isPersistent() == sdlFile.isPersistent())) {
             return false;
         }
         // return comparison

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -335,7 +335,7 @@ public class SoftButtonObject {
         if (o == null) return false;
         // if this is the same memory address, it's the same
         if (this == o) return true;
-        // if this is not an instance of this class, not the same
+        // if this is not an instance of SoftButtonObject, not the same
         if (!(o instanceof SoftButtonObject)) return false;
         // Casting o to compare SoftButtonStates
         SoftButtonObject softButtonObject = (SoftButtonObject) o;

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -326,24 +326,25 @@ public class SoftButtonObject {
 
     /**
      * Uses our custom hashCode for SoftButtonObject objects
+     *
      * @param o - The object to compare
      * @return boolean of whether the objects are the same or not
      */
     @Override
     public boolean equals(Object o) {
         if (o == null) return false;
-        // if this is the same memory address, its the same
+        // if this is the same memory address, it's the same
         if (this == o) return true;
         // if this is not an instance of this class, not the same
         if (!(o instanceof SoftButtonObject)) return false;
-        //Casting object to compare SoftButtonStates
+        // Casting o to compare SoftButtonStates
         SoftButtonObject softButtonObject = (SoftButtonObject) o;
-        //if List<SoftButtonsStates> are not the same size, not the same
+        // if List<SoftButtonsStates> are not the same size, not the same
         if (softButtonObject.getStates().size() != this.states.size()) return false;
         // Comparing List<SoftButtonStates> to see if all states are the same
-        for(int i = 0; i < this.states.size(); i++){
+        for (int i = 0; i < this.states.size(); i++) {
             // if both List<SoftButtonStates> are not the same, they are not the same
-            if(!(this.states.contains(softButtonObject.getStates().get(i)))) return false;
+            if (!(this.states.contains(softButtonObject.getStates().get(i)))) return false;
         }
         // return comparison
         return hashCode() == o.hashCode();

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -316,7 +316,10 @@ public class SoftButtonObject {
      */
     @Override
     public boolean equals(Object o) {
-         SoftButtonObject softButtonObject = (SoftButtonObject) o;
+        if(o == null){
+            return false;
+        }
+        SoftButtonObject softButtonObject = (SoftButtonObject) o;
         if (softButtonObject.getName().equals(this.getName())) {
             return true;
         }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -320,10 +320,12 @@ public class SoftButtonObject {
             return false;
         }
         if(o instanceof SoftButtonObject) {
-            SoftButtonObject softButtonObject = (SoftButtonObject) o;
-            if (softButtonObject.getName().equals(this.getName())) {
-                return true;
-            }
+                SoftButtonObject softButtonObject = (SoftButtonObject) o;
+                if(softButtonObject.getName() != null){
+                    if (softButtonObject.getName().equals(this.getName())) {
+                        return true;
+                    }
+                }
         }
         return false;
     }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -319,7 +319,7 @@ public class SoftButtonObject {
     public int hashCode() {
         int result = 1;
         result += ((getName() == null) ? 0 : Integer.rotateLeft(getName().hashCode(), 1));
-        result += ((getCurrentStateName() == null) ? 0 : Integer.rotateLeft(getCurrentState().hashCode(), 2));
+        result += ((getCurrentStateName() == null) ? 0 : Integer.rotateLeft(getCurrentStateName().hashCode(), 2));
         result += ((getOnEventListener() == null) ? 0 : Integer.rotateLeft(getOnEventListener().hashCode(), 3));
         return result;
     }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -309,4 +309,17 @@ public class SoftButtonObject {
          */
         void onUpdate();
     }
+
+    /**
+     * @param o
+     * @return true if two SoftButtonObjects have the same name.
+     */
+    @Override
+    public boolean equals(Object o) {
+         SoftButtonObject softButtonObject = (SoftButtonObject) o;
+        if (softButtonObject.getName().equals(this.getName())) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -312,7 +312,6 @@ public class SoftButtonObject {
 
     /**
      * Used to compile hashcode for SoftButtonsObjects for use to compare in equals method
-     *
      * @return Custom hashcode of SoftButtonObjects variables
      */
     @Override
@@ -320,12 +319,14 @@ public class SoftButtonObject {
         int result = 1;
         result += ((getName() == null) ? 0 : Integer.rotateLeft(getName().hashCode(), 1));
         result += ((getCurrentStateName() == null) ? 0 : Integer.rotateLeft(getCurrentStateName().hashCode(), 2));
+        for (int i = 0; i < this.states.size(); i++) {
+            result += ((getStates().get(i) == null) ? 0 : Integer.rotateLeft(getStates().get(i).hashCode(), i + 2));
+        }
         return result;
     }
 
     /**
      * Uses our custom hashCode for SoftButtonObject objects
-     *
      * @param o - The object to compare
      * @return boolean of whether the objects are the same or not
      */
@@ -336,15 +337,6 @@ public class SoftButtonObject {
         if (this == o) return true;
         // if this is not an instance of SoftButtonObject, not the same
         if (!(o instanceof SoftButtonObject)) return false;
-        // Casting o to compare SoftButtonStates
-        SoftButtonObject softButtonObject = (SoftButtonObject) o;
-        // if List<SoftButtonsStates> are not the same size, not the same
-        if (softButtonObject.getStates().size() != this.states.size()) return false;
-        // Comparing List<SoftButtonStates> to see if all states are the same
-        for (int i = 0; i < this.states.size(); i++) {
-            // if both List<SoftButtonStates> are not the same, they are not the same
-            if (!(this.states.contains(softButtonObject.getStates().get(i)))) return false;
-        }
         // return comparison
         return hashCode() == o.hashCode();
     }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -311,22 +311,41 @@ public class SoftButtonObject {
     }
 
     /**
-     * @param o
-     * @return true if two SoftButtonObjects have the same name.
+     * Used to compile hashcode for SoftButtonsObjects for use to compare in equals method
+     *
+     * @return Custom hashcode of SoftButtonObjects variables
+     */
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result += ((getName() == null) ? 0 : Integer.rotateLeft(getName().hashCode(), 1));
+        result += ((getCurrentStateName() == null) ? 0 : Integer.rotateLeft(getCurrentState().hashCode(), 2));
+        result += ((getOnEventListener() == null) ? 0 : Integer.rotateLeft(getOnEventListener().hashCode(), 3));
+        return result;
+    }
+
+    /**
+     * Uses our custom hashCode for SoftButtonObject objects
+     * @param o - The object to compare
+     * @return boolean of whether the objects are the same or not
      */
     @Override
     public boolean equals(Object o) {
-        if(o == null){
-            return false;
+        if (o == null) return false;
+        // if this is the same memory address, its the same
+        if (this == o) return true;
+        // if this is not an instance of this class, not the same
+        if (!(o instanceof SoftButtonObject)) return false;
+        //Casting object to compare SoftButtonStates
+        SoftButtonObject softButtonObject = (SoftButtonObject) o;
+        //if List<SoftButtonsStates> are not the same size, not the same
+        if (softButtonObject.getStates().size() != this.states.size()) return false;
+        // Comparing List<SoftButtonStates> to see if all states are the same
+        for(int i = 0; i < this.states.size(); i++){
+            // if both List<SoftButtonStates> are not the same, they are not the same
+            if(!(this.states.contains(softButtonObject.getStates().get(i)))) return false;
         }
-        if(o instanceof SoftButtonObject) {
-                SoftButtonObject softButtonObject = (SoftButtonObject) o;
-                if(softButtonObject.getName() != null){
-                    if (softButtonObject.getName().equals(this.getName())) {
-                        return true;
-                    }
-                }
-        }
-        return false;
+        // return comparison
+        return hashCode() == o.hashCode();
     }
 }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -320,7 +320,6 @@ public class SoftButtonObject {
         int result = 1;
         result += ((getName() == null) ? 0 : Integer.rotateLeft(getName().hashCode(), 1));
         result += ((getCurrentStateName() == null) ? 0 : Integer.rotateLeft(getCurrentStateName().hashCode(), 2));
-        result += ((getOnEventListener() == null) ? 0 : Integer.rotateLeft(getOnEventListener().hashCode(), 3));
         return result;
     }
 

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -319,9 +319,11 @@ public class SoftButtonObject {
         if(o == null){
             return false;
         }
-        SoftButtonObject softButtonObject = (SoftButtonObject) o;
-        if (softButtonObject.getName().equals(this.getName())) {
-            return true;
+        if(o instanceof SoftButtonObject) {
+            SoftButtonObject softButtonObject = (SoftButtonObject) o;
+            if (softButtonObject.getName().equals(this.getName())) {
+                return true;
+            }
         }
         return false;
     }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
@@ -161,19 +161,18 @@ public class SoftButtonState {
 
     /**
      * Used to compile hashcode for SoftButtonState for use to compare in equals method
-     *
      * @return Custom hashcode of SoftButtonState variables
      */
     @Override
     public int hashCode() {
         int result = 1;
         result += ((getName() == null) ? 0 : Integer.rotateLeft(getName().hashCode(), 1));
+        result += ((getArtwork() == null) ? 0 : getArtwork().hashCode());
         return result;
     }
 
     /**
      * Uses our custom hashCode for SoftButtonState objects
-     *
      * @param o - The object to compare
      * @return boolean of whether the objects are the same or not
      */
@@ -184,12 +183,6 @@ public class SoftButtonState {
         if (this == o) return true;
         // if this is not an instance of SoftButtonState, not the same
         if (!(o instanceof SoftButtonState)) return false;
-        // Cast o to SoftButtonState
-        SoftButtonState softButtonState = (SoftButtonState) o;
-        // if SdlArtwork is not the same, they are not the same
-        if (!(this.artwork != null && softButtonState.getArtwork().equals(this.artwork))) {
-            return false;
-        }
         // return comparison
         return hashCode() == o.hashCode();
     }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
@@ -161,6 +161,7 @@ public class SoftButtonState {
 
     /**
      * Used to compile hashcode for SoftButtonState for use to compare in equals method
+     *
      * @return Custom hashcode of SoftButtonState variables
      */
     @Override
@@ -172,19 +173,20 @@ public class SoftButtonState {
 
     /**
      * Uses our custom hashCode for SoftButtonState objects
+     *
      * @param o - The object to compare
      * @return boolean of whether the objects are the same or not
      */
     @Override
     public boolean equals(Object o) {
         if (o == null) return false;
-        // if this is the same memory address, its the same
+        // if this is the same memory address, it's the same
         if (this == o) return true;
         // if this is not an instance of this class, not the same
         if (!(o instanceof SoftButtonState)) return false;
-        //Cast o to SoftButtonState
+        // Cast o to SoftButtonState
         SoftButtonState softButtonState = (SoftButtonState) o;
-        //If SdlArtwork is not the same, they are not the same
+        // if SdlArtwork is not the same, they are not the same
         if (!(this.artwork != null && softButtonState.getArtwork().equals(this.artwork))) {
             return false;
         }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
@@ -158,4 +158,37 @@ public class SoftButtonState {
     public SdlArtwork getArtwork() {
         return artwork;
     }
+
+    /**
+     * Used to compile hashcode for SoftButtonState for use to compare in equals method
+     * @return Custom hashcode of SoftButtonState variables
+     */
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result += ((getName() == null) ? 0 : Integer.rotateLeft(getName().hashCode(), 1));
+        return result;
+    }
+
+    /**
+     * Uses our custom hashCode for SoftButtonState objects
+     * @param o - The object to compare
+     * @return boolean of whether the objects are the same or not
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) return false;
+        // if this is the same memory address, its the same
+        if (this == o) return true;
+        // if this is not an instance of this class, not the same
+        if (!(o instanceof SoftButtonState)) return false;
+        //Cast o to SoftButtonState
+        SoftButtonState softButtonState = (SoftButtonState) o;
+        //If SdlArtwork is not the same, they are not the same
+        if (!(this.artwork != null && softButtonState.getArtwork().equals(this.artwork))) {
+            return false;
+        }
+        // return comparison
+        return hashCode() == o.hashCode();
+    }
 }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
@@ -167,7 +167,7 @@ public class SoftButtonState {
     public int hashCode() {
         int result = 1;
         result += ((getName() == null) ? 0 : Integer.rotateLeft(getName().hashCode(), 1));
-        result += ((getArtwork() == null) ? 0 : getArtwork().hashCode());
+        result += ((getArtwork() == null) ? 0 : Integer.rotateLeft(getArtwork().hashCode(),2));
         return result;
     }
 

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
@@ -182,7 +182,7 @@ public class SoftButtonState {
         if (o == null) return false;
         // if this is the same memory address, it's the same
         if (this == o) return true;
-        // if this is not an instance of this class, not the same
+        // if this is not an instance of SoftButtonState, not the same
         if (!(o instanceof SoftButtonState)) return false;
         // Cast o to SoftButtonState
         SoftButtonState softButtonState = (SoftButtonState) o;

--- a/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
@@ -212,7 +212,7 @@ public class SdlFile{
         if (o == null) return false;
         // if this is the same memory address, it's the same
         if (this == o) return true;
-        // if this is not an instance of this class, not the same
+        // if this is not an instance of SdlFile, not the same
         if (!(o instanceof SdlFile)) return false;
         // Cast o to SdlFile
         SdlFile sdlFile = (SdlFile) o;

--- a/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
@@ -198,6 +198,8 @@ public class SdlFile{
         result += ((getFilePath() == null) ? 0 : Integer.rotateLeft(getFilePath().hashCode(), 2));
         result += ((getFileData() == null) ? 0 : Integer.rotateLeft(getFileData().hashCode(), 3));
         result += ((getType() == null) ? 0 : Integer.rotateLeft(getType().hashCode(), 4));
+        result += ((Boolean.valueOf(isStaticIcon) == null) ? 0 : Integer.rotateLeft(Boolean.valueOf(isStaticIcon).hashCode(), 5));
+        result += ((Boolean.valueOf(isPersistent()) == null) ? 0 : Integer.rotateLeft(Boolean.valueOf(isPersistent()).hashCode(), 6));
         return result;
     }
 
@@ -214,12 +216,6 @@ public class SdlFile{
         if (this == o) return true;
         // if this is not an instance of SdlFile, not the same
         if (!(o instanceof SdlFile)) return false;
-        // Cast o to SdlFile
-        SdlFile sdlFile = (SdlFile) o;
-        // if isStaticIcon and isPersistent is not the same for each object, they are not the same
-        if (!(this.isStaticIcon == sdlFile.isStaticIcon && this.isPersistent() == sdlFile.isPersistent())) {
-            return false;
-        }
         // return comparison
         return hashCode() == o.hashCode();
     }

--- a/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
@@ -185,4 +185,42 @@ public class SdlFile{
     public boolean isStaticIcon() {
         return isStaticIcon;
     }
+
+    /**
+     * Used to compile hashcode for SdlFile for use to compare in equals method
+     *
+     * @return Custom hashcode of SdlFile variables
+     */
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result += ((getName() == null) ? 0 : Integer.rotateLeft(getName().hashCode(), 1));
+        result += ((getFilePath() == null) ? 0 : Integer.rotateLeft(getFilePath().hashCode(), 2));
+        result += ((getFileData() == null) ? 0 : Integer.rotateLeft(getFileData().hashCode(), 3));
+        result += ((getType() == null) ? 0 : Integer.rotateLeft(getType().hashCode(), 4));
+        return result;
+    }
+
+    /**
+     * Uses our custom hashCode for SdlFile objects
+     *
+     * @param o - The object to compare
+     * @return boolean of whether the objects are the same or not
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) return false;
+        // if this is the same memory address, it's the same
+        if (this == o) return true;
+        // if this is not an instance of this class, not the same
+        if (!(o instanceof SdlFile)) return false;
+        // Cast o to SdlFile
+        SdlFile sdlFile = (SdlFile) o;
+        // if isStaticIcon and isPersistent is not the same for each object, they are not the same
+        if (!(this.isStaticIcon == sdlFile.isStaticIcon && this.isPersistent() == sdlFile.isPersistent())) {
+            return false;
+        }
+        // return comparison
+        return hashCode() == o.hashCode();
+    }
 }


### PR DESCRIPTION
Fixes # 1257

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [X] I have tested Android, Java SE, and Java EE

#### Unit Tests
Added testSoftButtonEq() and testSoftButtonStateEq() to SoftButtonManagerTests and testSdlFIleEq() to FileManagerTest

#### Core Tests
Tested using manticore

### Summary
Added a method in SdlFile in android and JavaSE, softButtonObjects, and SoftButtonState that overrides their equals methods. The new equals methods compare the objects variables instead of their memory address.


##### Enhancements
*  Added a method in softButtonObjects that overrides its equals method. 
*  Added a method in softButtonState that overrides its equals method. 
*  Added a method in SdlFile that overrides its equals method for android and JavaSE. 

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
