### PR TITLE
Bugfix/issue_1235_and_1236

### DIFF
--- a/android/hello_sdl_android/src/main/AndroidManifest.xml
+++ b/android/hello_sdl_android/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <!-- Required to check if WiFi is enabled -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
     <!-- Required to use the USB Accessory mode -->
     <uses-feature android:name="android.hardware.usb.accessory" />

--- a/base/src/main/java/com/smartdevicelink/protocol/SdlProtocolBase.java
+++ b/base/src/main/java/com/smartdevicelink/protocol/SdlProtocolBase.java
@@ -765,6 +765,9 @@ public class SdlProtocolBase {
                     listenerList = new ArrayList<>();
                     secondaryTransportListeners.put(secondaryTransportType, listenerList);
                 }
+                else {
+                    listenerList.clear();
+                }
 
                 //Check to see if the primary transport can also be used as a backup
                 final boolean primaryTransportBackup = transportPriorityForServiceMap.get(serviceType).contains(PRIMARY_TRANSPORT_ID);
@@ -1171,6 +1174,13 @@ public class SdlProtocolBase {
                 return;
             } else {
                 Log.d(TAG, "onTransportDisconnected - " + disconnectedTransport.getType().name());
+                if (disconnectedTransport.getType() == TransportType.TCP && secondaryTransportParams != null){
+                    if (activeTransports.containsValue(disconnectedTransport)) {
+                        //If the established TCP connection is disconnected, the corresponding IP and port are invalid and should be removed from the list.
+                        // Otherwise, istransportforserviceavailable is always true after disconnection
+                        secondaryTransportParams.remove(TransportType.TCP);
+                    }
+                }
             }
 
             //In the future we will actually compare the record but at this point we can assume only


### PR DESCRIPTION
Fixes #1235 and #1236 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by Unit tests.

### Summary
**Reason** 
#1235 After App connected HU successfully by the way of WiFi，App update local status data but not to start a TCP connection request.
#1236 If App connect WIFI with HU failed the first time, Proxy will not start WIFI connection request again after 150 seconds.

**Solution** 
There is a complete solution to these problems.

① Proxy add WIFI status listener
② reference IOS's design, modify the timing of request TCP connection,
　　②-1  Proxy receive Mobile's WIFI connected successfully
　　②-2  Proxy receive valid IP and port from HU
　　②-3  Proxy receive onHmiStatus(FULL) from HU(the Existing process of current proxy)
③ Proxy receive TCP TransportDisconnected, clear IP and port

**Sequence**
![image](https://user-images.githubusercontent.com/35795928/73036936-7d806280-3e90-11ea-8cba-7898797bf3ba.png)
 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)