### PR TITLE
IOS_Alignment/retry failed uploads

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
@@ -309,10 +309,10 @@ public class FileManagerTests extends AndroidTestCase2 {
 	public void testFileUploadSuccess(){
 		ISdl internalInterface = mock(ISdl.class);
 
-		doAnswer(onListFilesSuccess).when(internalInterface).sendRPCRequest(any(ListFiles.class));
-		doAnswer(onPutFileSuccess).when(internalInterface).sendRPCRequest(any(PutFile.class));
-
-		final FileManager fileManager = new FileManager(internalInterface, mTestContext);
+		doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
+		doAnswer(onPutFileSuccess).when(internalInterface).sendRPC(any(PutFile.class));
+		FileManagerConfig fileManagerConfig = new FileManagerConfig();
+		final FileManager fileManager = new FileManager(internalInterface, mTestContext, fileManagerConfig);
 		fileManager.start(new CompletionListener() {
 			@Override
 			public void onComplete(boolean success) {

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
@@ -261,7 +261,7 @@ public class FileManagerTests extends AndroidTestCase2 {
 
 		FileManagerConfig fileManagerConfig = new FileManagerConfig();
 		fileManagerConfig.setArtworkRetryCount(2);
-		validFile.setType(FileType.GRAPHIC_PNG);
+		validFile.setType(FileType.GRAPHIC_JPEG);
 		final FileManager fileManager = new FileManager(internalInterface, mTestContext,fileManagerConfig);
 		fileManager.start(new CompletionListener() {
 			@Override
@@ -663,5 +663,12 @@ public class FileManagerTests extends AndroidTestCase2 {
 				assertTrue(fileManager.hasUploadedFile(file));
 			}
 		});
+	}
+	public void testFileManagerConfig(){
+		FileManagerConfig fileManagerConfig = new FileManagerConfig();
+		fileManagerConfig.setFileRetryCount(2);
+		fileManagerConfig.setArtworkRetryCount(2);
+		assertEquals(fileManagerConfig.getArtworkRetryCount(), 2);
+		assertEquals(fileManagerConfig.getFileRetryCount(), 2);
 	}
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
@@ -247,6 +247,17 @@ public class FileManagerTests extends AndroidTestCase2 {
 
 		doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
 		doAnswer(onPutFileFailureOnError).when(internalInterface).sendRPC(any(PutFile.class));
+		final SdlFile validFile2 = new SdlFile();
+		validFile2.setName(Test.GENERAL_STRING + "2");
+		validFile2.setFileData(Test.GENERAL_BYTE_ARRAY);
+		validFile2.setPersistent(false);
+		validFile2.setType(FileType.GRAPHIC_PNG);
+
+		final SdlFile validFile3 = new SdlFile();
+		validFile3.setName(Test.GENERAL_STRING + "3");
+		validFile3.setFileData(Test.GENERAL_BYTE_ARRAY);
+		validFile3.setPersistent(false);
+		validFile3.setType(FileType.GRAPHIC_BMP);
 
 		FileManagerConfig fileManagerConfig = new FileManagerConfig();
 		fileManagerConfig.setArtworkRetryCount(2);
@@ -261,6 +272,22 @@ public class FileManagerTests extends AndroidTestCase2 {
 					public void onComplete(boolean success) {
 						assertFalse(success);
 						verify(internalInterface, times(4)).sendRPC(any(RPCMessage.class));
+					}
+				});
+
+				fileManager.uploadFile(validFile2, new CompletionListener() {
+					@Override
+					public void onComplete(boolean success) {
+						assertFalse(success);
+						verify(internalInterface, times(7)).sendRPC(any(RPCMessage.class));
+					}
+				});
+
+				fileManager.uploadFile(validFile3, new CompletionListener() {
+					@Override
+					public void onComplete(boolean success) {
+						assertFalse(success);
+						verify(internalInterface, times(10)).sendRPC(any(RPCMessage.class));
 					}
 				});
 			}

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -44,6 +44,7 @@ import android.util.Log;
 import com.smartdevicelink.exception.SdlException;
 import com.smartdevicelink.managers.audio.AudioStreamManager;
 import com.smartdevicelink.managers.file.FileManager;
+import com.smartdevicelink.managers.file.FileManagerConfig;
 import com.smartdevicelink.managers.file.filetypes.SdlArtwork;
 import com.smartdevicelink.managers.lifecycle.LifecycleConfigurationUpdate;
 import com.smartdevicelink.managers.lockscreen.LockScreenConfig;
@@ -120,6 +121,7 @@ public class SdlManager extends BaseSdlManager{
 	private SdlManagerListener managerListener;
 	private List<Class<? extends SdlSecurityBase>> sdlSecList;
 	private LockScreenConfig lockScreenConfig;
+	private FileManagerConfig fileManagerConfig;
 	private ServiceEncryptionListener serviceEncryptionListener;
 
 	// Managers
@@ -308,7 +310,7 @@ public class SdlManager extends BaseSdlManager{
 	protected void initialize(){
 		// Instantiate sub managers
 		this.permissionManager = new PermissionManager(_internalInterface);
-		this.fileManager = new FileManager(_internalInterface, context);
+		this.fileManager = new FileManager(_internalInterface, context, fileManagerConfig);
 		if (lockScreenConfig.isEnabled()) {
 			this.lockScreenManager = new LockScreenManager(lockScreenConfig, context, _internalInterface);
 		}
@@ -512,6 +514,8 @@ public class SdlManager extends BaseSdlManager{
 	// PROTECTED GETTERS
 
 	protected LockScreenConfig getLockScreenConfig() { return lockScreenConfig; }
+	protected FileManagerConfig getFileManagerConfig() { return fileManagerConfig; }
+
 
 	// SENDING REQUESTS
 
@@ -1040,6 +1044,17 @@ public class SdlManager extends BaseSdlManager{
 		}
 
 		/**
+		 * Sets the FileManagerConfig for the session. <br>
+		 * <strong>Note: If not set, the default configuration will be used.</strong>
+		 * @param FileManagerConfig - configuration options
+		 */
+		public Builder setFileManagerConfig (final FileManagerConfig fileManagerConfig){
+			sdlManager.fileManagerConfig = fileManagerConfig;
+			return this;
+		}
+
+
+		/**
 		 * Sets the icon for the app on head unit / In-Vehicle-Infotainment system <br>
 		 * @param sdlArtwork the icon that will be used to represent this application on the
 		 *                         connected module
@@ -1179,6 +1194,11 @@ public class SdlManager extends BaseSdlManager{
 			if (sdlManager.lockScreenConfig == null){
 				// if lock screen params are not set, use default
 				sdlManager.lockScreenConfig = new LockScreenConfig();
+			}
+
+			if(sdlManager.fileManagerConfig == null){
+				//if FileManagerConfig is not set use default
+				sdlManager.fileManagerConfig = new FileManagerConfig();
 			}
 
 			if (sdlManager.hmiLanguage == null){

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -1046,7 +1046,7 @@ public class SdlManager extends BaseSdlManager{
 		/**
 		 * Sets the FileManagerConfig for the session. <br>
 		 * <strong>Note: If not set, the default configuration will be used.</strong>
-		 * @param FileManagerConfig - configuration options
+		 * @param fileManagerConfig - configuration options
 		 */
 		public Builder setFileManagerConfig (final FileManagerConfig fileManagerConfig){
 			sdlManager.fileManagerConfig = fileManagerConfig;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/FileManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/FileManager.java
@@ -67,7 +67,7 @@ public class FileManager extends BaseFileManager {
 	int artworkRetryCount, fileRetryCount;
 
 	public FileManager(ISdl internalInterface, Context context, FileManagerConfig fileManagerConfig) {
-		super(internalInterface);
+		super(internalInterface, fileManagerConfig);
 
 		// setup
 		artworkRetryCount = fileManagerConfig.getArtworkRetryCount();

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/FileManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/FileManager.java
@@ -64,18 +64,18 @@ import java.lang.ref.WeakReference;
 public class FileManager extends BaseFileManager {
 
 	private final WeakReference<Context> context;
-	int artworkRetryCount, fileRetryCount;
 
-	public FileManager(ISdl internalInterface, Context context, FileManagerConfig fileManagerConfig) {
-		super(internalInterface, fileManagerConfig);
-
-		// setup
-		artworkRetryCount = fileManagerConfig.getArtworkRetryCount();
-		fileRetryCount = fileManagerConfig.getFileRetryCount();
+	@Deprecated
+	public FileManager(ISdl internalInterface, Context context) {
+		super(internalInterface);
 
 		this.context = new WeakReference<>(context);
 	}
 
+	public FileManager(ISdl internalInterface, Context context, FileManagerConfig fileManagerConfig) {
+		super(internalInterface, fileManagerConfig);
+		this.context = new WeakReference<>(context);
+	}
 	/**
 	 * Creates and returns a PutFile request that would upload a given SdlFile
 	 * @param file SdlFile with fileName and one of A) fileData, B) Uri, or C) resourceID set

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/FileManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/FileManager.java
@@ -64,11 +64,15 @@ import java.lang.ref.WeakReference;
 public class FileManager extends BaseFileManager {
 
 	private final WeakReference<Context> context;
+	int artworkRetryCount, fileRetryCount;
 
-	public FileManager(ISdl internalInterface, Context context) {
+	public FileManager(ISdl internalInterface, Context context, FileManagerConfig fileManagerConfig) {
+		super(internalInterface);
 
 		// setup
-		super(internalInterface);
+		artworkRetryCount = fileManagerConfig.getArtworkRetryCount();
+		fileRetryCount = fileManagerConfig.getFileRetryCount();
+
 		this.context = new WeakReference<>(context);
 	}
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/FileManagerConfig.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/FileManagerConfig.java
@@ -1,5 +1,15 @@
 package com.smartdevicelink.managers.file;
 
+/**
+ * <strong>FileManagerConfig</strong> <br>
+ *
+ * This is set during SdlManager instantiation. <br>
+ *
+ * <li> artWorkRetryCount - if not set, will be set to 1 to allow for retry upload attempts for SDLArtWork</li>
+ *
+ * <li> fileRetryCount - if not set, will be set to 1 to allow for retry upload attempts for SDLFiles</li>
+ */
+
 public class FileManagerConfig {
 
     private int artworkRetryCount, fileRetryCount;
@@ -12,17 +22,11 @@ public class FileManagerConfig {
 
     public void setArtworkRetryCount(int artworkRetryCount) { this.artworkRetryCount = artworkRetryCount; }
 
-
-    public int getArtworkRetryCount() {
-        return artworkRetryCount;
-    }
+    public int getArtworkRetryCount() { return artworkRetryCount; }
 
     public void setFileRetryCount(int fileRetryCount) { this.fileRetryCount = fileRetryCount; }
 
-
-    public int getFileRetryCount() {
-        return fileRetryCount;
-    }
+    public int getFileRetryCount() { return fileRetryCount; }
 
 }
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/FileManagerConfig.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/FileManagerConfig.java
@@ -1,0 +1,28 @@
+package com.smartdevicelink.managers.file;
+
+public class FileManagerConfig {
+
+    private int artworkRetryCount, fileRetryCount;
+
+    public FileManagerConfig(){
+        // set default values to 1 retry attempt
+        this.artworkRetryCount = 1;
+        this.fileRetryCount = 1;
+    }
+
+    public void setArtworkRetryCount(int artworkRetryCount) { this.artworkRetryCount = artworkRetryCount; }
+
+
+    public int getArtworkRetryCount() {
+        return artworkRetryCount;
+    }
+
+    public void setFileRetryCount(int fileRetryCount) { this.fileRetryCount = fileRetryCount; }
+
+
+    public int getFileRetryCount() {
+        return fileRetryCount;
+    }
+
+}
+

--- a/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
@@ -263,8 +263,10 @@ abstract class BaseFileManager extends BaseSubManager {
 					}
 				} else if (!deletionOperation) {
 					final List<RPCRequest> reRequest = new ArrayList<>();
-					if (errors.isEmpty() && customErrors.isEmpty() && listener != null) {
-						listener.onComplete(null); //if first time no errors and listener is not null
+					if (errors.isEmpty() && !customErrors.isEmpty()) {
+						if(listener != null){
+							listener.onComplete(customErrors); //last file uploaded successfully, had another file in list run out of attempts first.
+						}
 					} else {
 						Set<String> keys = errors.keySet();
 						for (String key : keys) {

--- a/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
@@ -293,6 +293,7 @@ abstract class BaseFileManager extends BaseSubManager {
 							}
 						}
 						if (!reRequest.isEmpty()) { // if there are files to be sent.
+							errors.clear();
 							sendMultipleFileOperations(reRequest, listener, customErrors);
 						} else {
 							if (listener != null) { // no more retries available send all errors back.
@@ -311,8 +312,7 @@ abstract class BaseFileManager extends BaseSubManager {
 			public void onError(int correlationId, Result resultCode, String info) {
 				if(fileNameMap != null && fileNameMap.get(correlationId) != null){
 					errors.put(fileNameMap.get(correlationId), buildErrorString(resultCode, info));
-					//	fileNameMap.remove((fileNameMap.))
-				}// else no fileName for given correlation ID
+				}
 			}
 
 			@Override
@@ -330,6 +330,8 @@ abstract class BaseFileManager extends BaseSubManager {
 							uploadedEphemeralFileNames.add(fileNameMap.get(correlationId));
 						}
 					}
+				}else if(fileNameMap != null && fileNameMap.get(correlationId) != null){
+					errors.put(fileNameMap.get(correlationId),putFileResponse.getSuccess().toString());
 				}
 			}
 		};

--- a/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
@@ -379,7 +379,6 @@ abstract class BaseFileManager extends BaseSubManager {
 			public void onError(int correlationId, Result resultCode, String info) {
 				super.onError(correlationId, resultCode, info);
 				if(checkFileForReUpload(file)){
-					Log.i("Julian", "onError: ReUploading file");
 					uploadFile(file, listener);
 				}else if (listener != null){
 					listener.onComplete(false);

--- a/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
@@ -249,7 +249,6 @@ abstract class BaseFileManager extends BaseSubManager {
 					fileNameMap.put(correlationid, ((DeleteFile) requests.get(fileNum++)).getSdlFileName());
 				}else{
 					fileNameMap.put(correlationid, ((PutFile) requests.get(fileNum++)).getSdlFileName());
-
 				}
 			}
 

--- a/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -36,6 +36,7 @@ import android.support.annotation.NonNull;
 import android.util.Log;
 
 import com.smartdevicelink.managers.file.FileManager;
+import com.smartdevicelink.managers.file.FileManagerConfig;
 import com.smartdevicelink.managers.file.filetypes.SdlArtwork;
 import com.smartdevicelink.managers.lifecycle.LifecycleConfigurationUpdate;
 import com.smartdevicelink.managers.lifecycle.LifecycleManager;
@@ -100,6 +101,7 @@ public class SdlManager extends BaseSdlManager{
 
 	// Managers
 	private LifecycleManager lifecycleManager;
+	private FileManagerConfig fileManagerConfig;
 	private PermissionManager permissionManager;
 	private FileManager fileManager;
     private ScreenManager screenManager;
@@ -287,7 +289,7 @@ public class SdlManager extends BaseSdlManager{
 	protected void initialize(){
 		// Instantiate sub managers
 		this.permissionManager = new PermissionManager(_internalInterface);
-		this.fileManager = new FileManager(_internalInterface);
+		this.fileManager = new FileManager(_internalInterface, fileManagerConfig);
 		this.screenManager = new ScreenManager(_internalInterface, this.fileManager);
 
 		// Start sub managers
@@ -411,6 +413,8 @@ public class SdlManager extends BaseSdlManager{
 	public String getAuthToken(){
 		return this.lifecycleManager.getAuthToken();
 	}
+
+	protected FileManagerConfig getFileManagerConfig() { return fileManagerConfig; }
 
 	// SENDING REQUESTS
 
@@ -683,6 +687,11 @@ public class SdlManager extends BaseSdlManager{
 			return this;
 		}
 
+		public Builder setFileManagerConfig (final FileManagerConfig fileManagerConfig){
+			sdlManager.fileManagerConfig = fileManagerConfig;
+			return this;
+		}
+
 		/**
 		 * Sets the voice recognition synonyms that can be used to identify this application.
 		 * @param vrSynonyms a vector of Strings that can be associated with this app. For example the app's name should
@@ -773,6 +782,11 @@ public class SdlManager extends BaseSdlManager{
 				hmiTypesDefault.add(AppHMIType.DEFAULT);
 				sdlManager.hmiTypes = hmiTypesDefault;
 				sdlManager.isMediaApp = false;
+			}
+
+			if(sdlManager.fileManagerConfig == null){
+				//if FileManagerConfig is not set use default
+				sdlManager.fileManagerConfig = new FileManagerConfig();
 			}
 
 			if (sdlManager.hmiLanguage == null){

--- a/javaSE/src/main/java/com/smartdevicelink/managers/file/FileManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/file/FileManager.java
@@ -55,11 +55,19 @@ import com.smartdevicelink.util.FileUtls;
  */
 public class FileManager extends BaseFileManager {
 
+	@Deprecated
 	public FileManager(ISdl internalInterface) {
 
 		// setup
 		super(internalInterface);
 	}
+
+	public FileManager(ISdl internalInterface, FileManagerConfig fileManagerConfig) {
+
+		// setup
+		super(internalInterface, fileManagerConfig);
+	}
+
 
 	/**
 	 * Creates and returns a PutFile request that would upload a given SdlFile

--- a/javaSE/src/main/java/com/smartdevicelink/managers/file/FileManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/file/FileManager.java
@@ -57,13 +57,11 @@ public class FileManager extends BaseFileManager {
 
 	@Deprecated
 	public FileManager(ISdl internalInterface) {
-
 		// setup
 		super(internalInterface);
 	}
 
 	public FileManager(ISdl internalInterface, FileManagerConfig fileManagerConfig) {
-
 		// setup
 		super(internalInterface, fileManagerConfig);
 	}

--- a/javaSE/src/main/java/com/smartdevicelink/managers/file/FileManagerConfig.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/file/FileManagerConfig.java
@@ -20,9 +20,7 @@ public class FileManagerConfig {
     }
     public void setArtworkRetryCount(int artworkRetryCount) { this.artworkRetryCount = artworkRetryCount; }
 
-    public int getArtworkRetryCount() {
-        return artworkRetryCount;
-    }
+    public int getArtworkRetryCount() { return artworkRetryCount; }
 
     public void setFileRetryCount(int fileRetryCount) { this.fileRetryCount = fileRetryCount; }
 

--- a/javaSE/src/main/java/com/smartdevicelink/managers/file/FileManagerConfig.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/file/FileManagerConfig.java
@@ -1,0 +1,30 @@
+package com.smartdevicelink.managers.file;
+
+/**
+ * <strong>FileManagerConfig</strong> <br>
+ *
+ * This is set during SdlManager instantiation. <br>
+ *
+ * <li> artWorkRetryCount - if not set, will be set to 1 to allow for retry upload attempts for SDLArtWork</li>
+ *
+ * <li> fileRetryCount - if not set, will be set to 1 to allow for retry upload attempts for SDLFiles</li>
+ */
+
+public class FileManagerConfig {
+    private int artworkRetryCount, fileRetryCount;
+
+    public FileManagerConfig(){
+        // set default values to 1 retry attempt
+        this.artworkRetryCount = 1;
+        this.fileRetryCount = 1;
+    }
+    public void setArtworkRetryCount(int artworkRetryCount) { this.artworkRetryCount = artworkRetryCount; }
+
+    public int getArtworkRetryCount() {
+        return artworkRetryCount;
+    }
+
+    public void setFileRetryCount(int fileRetryCount) { this.fileRetryCount = fileRetryCount; }
+
+    public int getFileRetryCount() { return fileRetryCount; }
+}


### PR DESCRIPTION
Fixes #830 

This PR is **not ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [X] I have tested Android, Java SE, and Java EE

#### Unit Tests
Created Unit test in FileManagerTest to simulate SdlFile/SdlArtwork failing to upload, then retrying upload base on FileManagerConfig:
* testFileUploadRetry()
* testArtworkUploadRetry()

Created Unit test in FileManagerTest to simulate a list of files failing and then retrying to upload them:
* testListFilesUploadRetry()

#### Core Tests
* Set FileManagerConfig values artworkRetryCount and fileRetryCount to at-least 2 or higher, (5) would be better and set each value different.(FileManagerConfig is set in sdlManager builder, see Summary below for example)
*  Commented out setting file data in FileManager createPutFile to simulate File Failing
* Created SdlFile with a type of Audio_Wave, log every time file would retry to upload in baseFileManager uploadFile, in the onError of the listener where it recursively calls uploadFile.
* Repeat with an Artwork filetype: BMP, JPEG, PNG.

* Test uploading a list of files the same way except logging where it uploads in BaseFileManager sendMultipleFileOperations, in onFinished() where it recursively calls sendMultipleFileOperations.
* With a list of files test setting one file to an instance of SdlArtwork and the other audio, have each file upload retry count be different and verify that you get both errors back on the developers side.

### Summary
If a file fails to upload, the File will now retry to upload depending on what is set in FileManagerConfig setFileRetryCount() and setFielArtworkRetryCount(). Each value is set to 1 by default and initialized in sdlManager. If you want to set it higher, you can create an instance of FileManagerConfig and set it when you create the SdlManager Builder:

FileManagerConfig fileManagerConfig = new FileManagerConfig();
fileManagerConfig.setArtworkRetryCount(4);
fileManagerConfig.setFileRetryCount(5);

builder.setFileManagerConfig(fileManagerConfig);
sdlManager.start();

##### Enhancements
* Added functionality to retry failed file uploads.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
