### PR TITLE
Delete notification channel when possible

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1444,8 +1444,9 @@ public class SdlRouterService extends Service{
 		PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent, 0);
 		builder.setContentIntent(pendingIntent);
 
-        if(chronometerLength > 0 && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        if(chronometerLength > (FOREGROUND_TIMEOUT/1000) && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
         	//The countdown method is only available in SDKs >= 24
+        	// Only add countdown if it is over the min timeout
         	builder.setWhen(chronometerLength + System.currentTimeMillis());
         	builder.setUsesChronometer(true);
         	builder.setChronometerCountDown(true);

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -139,7 +139,7 @@ public class SdlRouterService extends Service{
 	/**
 	 * <b> NOTE: DO NOT MODIFY THIS UNLESS YOU KNOW WHAT YOU'RE DOING.</b>
 	 */
-	protected static final int ROUTER_SERVICE_VERSION_NUMBER = 10;
+	protected static final int ROUTER_SERVICE_VERSION_NUMBER = 11;
 
 	private static final String ROUTER_SERVICE_PROCESS = "com.smartdevicelink.router";
 	

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -69,6 +69,7 @@ import android.os.Parcel;
 import android.os.ParcelFileDescriptor;
 import android.os.Parcelable;
 import android.os.RemoteException;
+import android.service.notification.StatusBarNotification;
 import android.support.annotation.NonNull;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
@@ -1516,6 +1517,27 @@ public class SdlRouterService extends Service{
 		synchronized (NOTIFICATION_LOCK) {
 			if (isForeground && !isPrimaryTransportConnected()) {	//Ensure that the service is in the foreground and no longer connected to a transport
 				this.stopForeground(true);
+				NotificationManager notificationManager = (NotificationManager)getSystemService(Context.NOTIFICATION_SERVICE);
+				if (notificationManager!= null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+					try {
+						boolean notificationHasDisplayed = false;
+						StatusBarNotification[] notifications = notificationManager.getActiveNotifications();
+						for (StatusBarNotification notification : notifications) {
+							if(notification != null && FOREGROUND_SERVICE_ID == notification.getId()){
+								DebugTool.logInfo("Service notification is being displayed");
+								notificationHasDisplayed = true;
+								break;
+							}
+						}
+						if (notificationHasDisplayed) {
+							notificationManager.deleteNotificationChannel(SDL_NOTIFICATION_CHANNEL_ID);
+						}
+						//else leave the notification channel alone to avoid deleting it before the
+						//foreground service notification has a chance to be displayed.
+					} catch (Exception e){
+						DebugTool.logError("Issue when deleting notification channel", e);
+					}
+				}
 				isForeground = false;
 			}
 		}

--- a/android/sdl_android/src/main/res/values/sdl.xml
+++ b/android/sdl_android/src/main/res/values/sdl.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="sdl_router_service_version_name" translatable="false">sdl_router_version</string>
 
-    <integer name="sdl_router_service_version_value">10</integer>
+    <integer name="sdl_router_service_version_value">11</integer>
 
     <string name="sdl_router_service_is_custom_name" translatable="false">sdl_custom_router</string>
 </resources>


### PR DESCRIPTION
Fixes #1267 (partially)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested Android

#### Core Tests
-None specifically. This revolves around bluetooth connections.

### Summary
Added the notification channel delete method call back into the router service. Some phones like the pixel 2 & 3 were only clearing the notification 5-7 seconds after the service called stopForeground. Deleting the channel removes the notification instantly. We added a check to avoid a race condition in which the channel is deleted before the notification was actually shown.


### Changelog

##### Bug Fixes
* Notification being displayed even after service leaves foreground
* Added check to timer to make sure it is not going to negative numbers
* Incremented router service version

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
