### PR TITLE
Update SCM to notify listeners if fresh copy of capability is received

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SystemCapabilityManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SystemCapabilityManagerTests.java
@@ -608,7 +608,7 @@ public class SystemCapabilityManagerTests extends AndroidTestCase2 {
 
 
 		// Test case 3 (Remove listener)
-		// When the last DISPLAY listener is removed, GetSystemCapability request should not go out
+		// When the last DISPLAYS listener is removed, GetSystemCapability request should not go out
 		scm.removeOnSystemCapabilityListener(SystemCapabilityType.DISPLAYS, onSystemCapabilityListener1);
 		verify(internalInterface, times(0)).sendRPC(any(GetSystemCapability.class));
 	}

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SystemCapabilityManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SystemCapabilityManagerTests.java
@@ -490,7 +490,7 @@ public class SystemCapabilityManagerTests extends AndroidTestCase2 {
 		verify(internalInterface, times(1)).sendRPC(any(GetSystemCapability.class));
 	}
 
-	public void testAddOnSystemCapabilityListenerThenGetCapability() {
+	public void testAddOnSystemCapabilityListenerThenGetCapabilityWhenSubscriptionsAreNotSupported() {
 		SdlMsgVersion sdlMsgVersion = new SdlMsgVersion(5, 0); // This version doesn't support capability subscriptions
 		sdlMsgVersion.setPatchVersion(0);
 		ISdl internalInterface = mock(ISdl.class);

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SystemCapabilityManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SystemCapabilityManagerTests.java
@@ -457,7 +457,7 @@ public class SystemCapabilityManagerTests extends AndroidTestCase2 {
 		// Add listener1
 		// When the first listener is added, GetSystemCapability request should out because because capability is not cached
 		OnSystemCapabilityListener onSystemCapabilityListener1 = mock(OnSystemCapabilityListener.class);
-		doAnswer(createOnSendGetSystemCapabilityAnswer(true, true)).when(internalInterface).sendRPC(any(GetSystemCapability.class));
+		doAnswer(createOnSendGetSystemCapabilityAnswer(true, false)).when(internalInterface).sendRPC(any(GetSystemCapability.class));
 		scm.addOnSystemCapabilityListener(SystemCapabilityType.VIDEO_STREAMING, onSystemCapabilityListener1);
 		verify(internalInterface, times(1)).sendRPC(any(GetSystemCapability.class));
 		verify(onSystemCapabilityListener1, times(1)).onCapabilityRetrieved(any(Object.class));

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SystemCapabilityManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SystemCapabilityManagerTests.java
@@ -500,7 +500,7 @@ public class SystemCapabilityManagerTests extends AndroidTestCase2 {
 
 
 		// Add listener1
-		// When the first listener is added, GetSystemCapability request should go out with subscribe=true
+		// When the first listener is added, GetSystemCapability request should go out with subscribe=false
 		OnSystemCapabilityListener onSystemCapabilityListener1 = mock(OnSystemCapabilityListener.class);
 		doAnswer(createOnSendGetSystemCapabilityAnswer(true, false)).when(internalInterface).sendRPC(any(GetSystemCapability.class));
 		scm.addOnSystemCapabilityListener(SystemCapabilityType.VIDEO_STREAMING, onSystemCapabilityListener1);

--- a/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
@@ -312,6 +312,7 @@ public class SystemCapabilityManager {
                                                 // this notification can return only affected windows (hence not all windows)
                                                 List<DisplayCapability> newCapabilities = (List<DisplayCapability>) capability;
                                                 updateCachedDisplayCapabilityList(newCapabilities);
+                                                systemCapabilitiesSubscriptionStatus.put(SystemCapabilityType.DISPLAYS, true);
                                         }
                                     }
                                     if (capability != null) {
@@ -527,7 +528,7 @@ public class SystemCapabilityManager {
 					&& onSystemCapabilityListeners.get(systemCapabilityType) != null) {
 				success = onSystemCapabilityListeners.get(systemCapabilityType).remove(listener);
 				// If the last listener for the supplied capability type is removed, unsubscribe from the capability type
-				if (success && onSystemCapabilityListeners.get(systemCapabilityType).isEmpty() && isSubscribedToSystemCapability(systemCapabilityType)) {
+				if (success && onSystemCapabilityListeners.get(systemCapabilityType).isEmpty() && isSubscribedToSystemCapability(systemCapabilityType) && systemCapabilityType != SystemCapabilityType.DISPLAYS) {
 					retrieveCapability(systemCapabilityType, null, false);
 				}
 			}
@@ -540,7 +541,7 @@ public class SystemCapabilityManager {
 	 * @param subscribe flag to subscribe to updates of the supplied capability type. True means subscribe; false means cancel subscription; null means don't change current subscription status.
 	 */
 	private void retrieveCapability(final SystemCapabilityType systemCapabilityType, final OnSystemCapabilityListener scListener, final Boolean subscribe) {
-		if (!systemCapabilityType.isQueryable()) {
+		if (!systemCapabilityType.isQueryable() || systemCapabilityType == SystemCapabilityType.DISPLAYS) {
 			String message = "This systemCapabilityType cannot be queried for";
 			DebugTool.logError(message);
 			if (scListener != null) {

--- a/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
@@ -566,6 +566,7 @@ public class SystemCapabilityManager {
 					Object retrievedCapability = ((GetSystemCapabilityResponse) response).getSystemCapability().getCapabilityForType(systemCapabilityType);
 					setCapability(systemCapabilityType, retrievedCapability);
 					// If the listener is not included in the onSystemCapabilityListeners map, then notify it
+					// This will be triggered if we are just getting capability without adding a listener to the map
 					if (scListener != null) {
 						synchronized (LISTENER_LOCK) {
 							CopyOnWriteArrayList<OnSystemCapabilityListener> notifiedListeners = onSystemCapabilityListeners.get(systemCapabilityType);

--- a/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
@@ -335,11 +335,11 @@ public class SystemCapabilityManager {
 	 * Sets a capability in the cached map. This should only be done when an RPC is received and contains updates to the capability
 	 * that is being cached in the SystemCapabilityManager.
 	 * @param systemCapabilityType the system capability type that will be set
-	 * @param capability the value of the capability that will be set
+	 * @param capability           the value of the capability that will be set
 	 */
 	public synchronized void setCapability(SystemCapabilityType systemCapabilityType, Object capability) {
-			cachedSystemCapabilities.put(systemCapabilityType, capability);
-			notifyListeners(systemCapabilityType, capability);
+		cachedSystemCapabilities.put(systemCapabilityType, capability);
+		notifyListeners(systemCapabilityType, capability);
 	}
 
 	/**

--- a/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
@@ -550,7 +550,13 @@ public class SystemCapabilityManager {
 		}
 		final GetSystemCapability request = new GetSystemCapability();
 		request.setSystemCapabilityType(systemCapabilityType);
-		// If subscribe is null, then don't change the current subscription status
+
+		/*
+		The subscription flag in the request should be set based on multiple variables:
+		- if subscribe is null (no change), shouldSubscribe = current subscription status
+		- if subscribe is false, then shouldSubscribe = false
+		- if subscribe is true and the HU supports subscriptions, then shouldSubscribe = true
+		*/
 		final boolean shouldSubscribe = ((subscribe != null) ? subscribe : isSubscribedToSystemCapability(systemCapabilityType)) && supportsSubscriptions();
 		request.setSubscribe(shouldSubscribe);
 		request.setOnRPCResponseListener(new OnRPCResponseListener() {

--- a/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
@@ -558,8 +558,9 @@ public class SystemCapabilityManager {
 		- if subscribe is false, then shouldSubscribe = false
 		- if subscribe is true and the HU supports subscriptions, then shouldSubscribe = true
 		*/
-		final boolean shouldSubscribe = ((subscribe != null) ? subscribe : isSubscribedToSystemCapability(systemCapabilityType)) && supportsSubscriptions();
-		request.setSubscribe(shouldSubscribe);
+		boolean shouldSubscribe = (subscribe != null) ? subscribe : isSubscribedToSystemCapability(systemCapabilityType);
+		final boolean willSubscribe = shouldSubscribe && supportsSubscriptions();
+		request.setSubscribe(willSubscribe);
 		request.setOnRPCResponseListener(new OnRPCResponseListener() {
 			@Override
 			public void onResponse(int correlationId, RPCResponse response) {
@@ -578,7 +579,7 @@ public class SystemCapabilityManager {
 						}
 					}
 					if (supportsSubscriptions()) {
-						systemCapabilitiesSubscriptionStatus.put(systemCapabilityType, shouldSubscribe);
+						systemCapabilitiesSubscriptionStatus.put(systemCapabilityType, willSubscribe);
 					}
 				} else {
 					if (scListener != null) {

--- a/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
@@ -554,7 +554,7 @@ public class SystemCapabilityManager {
 
 		/*
 		The subscription flag in the request should be set based on multiple variables:
-		- if subscribe is null (no change), shouldSubscribe = current subscription status
+		- if subscribe is null (no change), shouldSubscribe = current subscription status, or false if the HU does not support subscriptions
 		- if subscribe is false, then shouldSubscribe = false
 		- if subscribe is true and the HU supports subscriptions, then shouldSubscribe = true
 		*/

--- a/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
@@ -335,7 +335,7 @@ public class SystemCapabilityManager {
 	 * Sets a capability in the cached map. This should only be done when an RPC is received and contains updates to the capability
 	 * that is being cached in the SystemCapabilityManager.
 	 * @param systemCapabilityType the system capability type that will be set
-	 * @param capability           the value of the capability that will be set
+	 * @param capability the value of the capability that will be set
 	 */
 	public synchronized void setCapability(SystemCapabilityType systemCapabilityType, Object capability) {
 		cachedSystemCapabilities.put(systemCapabilityType, capability);
@@ -563,7 +563,7 @@ public class SystemCapabilityManager {
 					if (scListener != null) {
 						synchronized (LISTENER_LOCK) {
 							CopyOnWriteArrayList<OnSystemCapabilityListener> notifiedListeners = onSystemCapabilityListeners.get(systemCapabilityType);
-							boolean listenerAlreadyNotified = notifiedListeners != null && notifiedListeners.contains(scListener);
+							boolean listenerAlreadyNotified = (notifiedListeners != null) && notifiedListeners.contains(scListener);
 							if (!listenerAlreadyNotified) {
 								scListener.onCapabilityRetrieved(retrievedCapability);
 							}


### PR DESCRIPTION
Fixes #1275 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Unit Tests
Added more unit tests to test the fix

#### Core Tests
1. Use `SCM.addOnSystemCapabilityListener()` to add a listener for `NAVIGATION` capability for example
2. Make sure the listener is called
3. Call `SCM.getCapability(SystemCapabilityType.NAVIGATION, ..., true)`
3. Confirm the listener that was added in step 1  is called again 

### Summary
This PR fixes an issue with `addOnSystemCapabilityListener()` method that causes the listeners not to be triggered if a fresh copy of the capability is received when the developer calls `getCapability()` and sets `forceUpdate` to `true`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
