### PR TITLE
Remove setting new buffer after PSM FINISHED/ERROR states in USB tarnsport

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexUsbTransport.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexUsbTransport.java
@@ -249,7 +249,7 @@ public class MultiplexUsbTransport extends MultiplexBaseTransport{
                         if(!stateProgress){//We are trying to weed through the bad packet info until we get something
                             //Log.w(TAG, "Packet State Machine did not move forward from state - "+ psm.getState()+". PSM being Reset.");
                             psm.reset();
-                            buffer = new byte[READ_BUFFER_SIZE];
+                            continue; //Move to the next iteration of the loop
                         }
 
                         if(psm.getState() == SdlPsm.FINISHED_STATE){
@@ -259,9 +259,11 @@ public class MultiplexUsbTransport extends MultiplexBaseTransport{
                                 packet.setTransportRecord(getTransportRecord());
                                 handler.obtainMessage(SdlRouterService.MESSAGE_READ, packet).sendToTarget();
                             }
-                            //We put a trace statement in the message read so we can avoid all the extra bytes
+                            //Reset the PSM now that we have a finished packet.
+                            //We will continue to loop through the data to see if any other packet
+                            //is present.
                             psm.reset();
-                            buffer = new byte[READ_BUFFER_SIZE]; //FIXME just do an array copy and send off
+                            continue; //Move to the next iteration of the loop
                         }
                     }
                 } catch (IOException e) {


### PR DESCRIPTION
Fixes #1279

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android


### Summary
Removed a call to reset the buffer array after a packet was found to be finished or entered an error state. The loop would continue but the data in the buffer would be all `0x00`'s. Added a continue call to ensure the loop is continued and easily readable as to what should happen.

### Changelog


##### Bug Fixes
* Fixes #1279 as the data should not be reset before continuing the loop now


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
