### PR TITLE
Bugfix/issue 1284 UploadFiles() doesn't handle static icons correctly

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
@@ -498,7 +498,7 @@ public class FileManagerTests extends AndroidTestCase2 {
 		assertEquals(Test.GENERAL_INT, fileManager.getBytesAvailable());
 	}
 
-	public void testFileUploadFailure(){
+	public void testFileUploadFailure() {
 		ISdl internalInterface = mock(ISdl.class);
 
 		doAnswer(onListFilesSuccess).when(internalInterface).sendRPCRequest(any(ListFiles.class));
@@ -521,12 +521,16 @@ public class FileManagerTests extends AndroidTestCase2 {
 		});
 	}
 
-	public void testFileUploadForStaticIcon(){
+	/**
+	 * Testing uploadFile for a staticIcon, verifying that it doesn't actually upload.
+	 */
+	public void testFileUploadForStaticIcon() {
 		ISdl internalInterface = mock(ISdl.class);
 
-		doAnswer(onListFilesSuccess).when(internalInterface).sendRPCRequest(any(ListFiles.class));
+		doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
 
-		final FileManager fileManager = new FileManager(internalInterface, mTestContext);
+		FileManagerConfig fileManagerConfig = new FileManagerConfig();
+		final FileManager fileManager = new FileManager(internalInterface, mTestContext, fileManagerConfig);
 		fileManager.start(new CompletionListener() {
 			@Override
 			public void onComplete(boolean success) {
@@ -540,6 +544,70 @@ public class FileManagerTests extends AndroidTestCase2 {
 				});
 			}
 		});
+		verify(internalInterface, times(1)).sendRPC(any(RPCMessage.class));
+	}
+
+	/**
+	 * Testing uploadFiles for staticIcons, verifying that it doesn't actually upload.
+	 */
+	public void testMultipleFileUploadsForStaticIcon() {
+		ISdl internalInterface = mock(ISdl.class);
+
+		doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
+		doAnswer(onListFileUploadSuccess).when(internalInterface).sendRequests(any(List.class), any(OnMultipleRequestListener.class));
+
+		FileManagerConfig fileManagerConfig = new FileManagerConfig();
+		final FileManager fileManager = new FileManager(internalInterface, mTestContext, fileManagerConfig);
+		fileManager.start(new CompletionListener() {
+			@Override
+			public void onComplete(boolean success) {
+				assertTrue(success);
+				SdlArtwork artwork = new SdlArtwork(StaticIconName.ALBUM);
+				SdlArtwork artwork2 = new SdlArtwork(StaticIconName.FILENAME);
+				List<SdlArtwork> testStaticIconUpload = new ArrayList<>();
+				testStaticIconUpload.add(artwork);
+				testStaticIconUpload.add(artwork2);
+				fileManager.uploadFiles(testStaticIconUpload, new MultipleFileCompletionListener() {
+					@Override
+					public void onComplete(Map<String, String> errors) {
+						assertTrue(errors == null);
+					}
+				});
+			}
+		});
+		verify(internalInterface, times(0)).sendRequests(any(List.class), any(OnMultipleRequestListener.class));
+	}
+
+	/**
+	 * Testing uploadFiles for static icons and nonStatic icons in the same list.
+	 */
+	public void testMultipleFileUploadsForPartialStaticIcon() {
+		ISdl internalInterface = mock(ISdl.class);
+
+		doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
+		doAnswer(onListFileUploadSuccess).when(internalInterface).sendRequests(any(List.class), any(OnMultipleRequestListener.class));
+
+		FileManagerConfig fileManagerConfig = new FileManagerConfig();
+		final FileManager fileManager = new FileManager(internalInterface, mTestContext, fileManagerConfig);
+		fileManager.start(new CompletionListener() {
+			@Override
+			public void onComplete(boolean success) {
+				assertTrue(success);
+				SdlArtwork artwork = new SdlArtwork(StaticIconName.ALBUM);
+				SdlArtwork artwork2 = new SdlArtwork(StaticIconName.FILENAME);
+				List<SdlFile> testFileuploads = new ArrayList<>();
+				testFileuploads.add(artwork);
+				testFileuploads.add(artwork2);
+				testFileuploads.add(validFile);
+				fileManager.uploadFiles(testFileuploads, new MultipleFileCompletionListener() {
+					@Override
+					public void onComplete(Map<String, String> errors) {
+						assertTrue(errors == null);
+					}
+				});
+			}
+		});
+		verify(internalInterface, times(1)).sendRequests(any(List.class), any(OnMultipleRequestListener.class));
 	}
 
 	public void testInvalidSdlFileInput(){

--- a/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
@@ -383,7 +383,7 @@ abstract class BaseFileManager extends BaseSubManager {
 
 	/**
 	 * Attempts to upload a list of SdlFiles to core
-	 * @param files    list of SdlFiles with file name and one of A) fileData, B) Uri, or C) resourceID set
+	 * @param files list of SdlFiles with file name and one of A) fileData, B) Uri, or C) resourceID set
 	 * @param listener callback that is called once core responds to all upload requests
 	 */
 	public void uploadFiles(@NonNull List<? extends SdlFile> files, final MultipleFileCompletionListener listener) {

--- a/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
@@ -383,19 +383,27 @@ abstract class BaseFileManager extends BaseSubManager {
 
 	/**
 	 * Attempts to upload a list of SdlFiles to core
-	 * @param files list of SdlFiles with file name and one of A) fileData, B) Uri, or C) resourceID set
+	 * @param files    list of SdlFiles with file name and one of A) fileData, B) Uri, or C) resourceID set
 	 * @param listener callback that is called once core responds to all upload requests
 	 */
-	public void uploadFiles(@NonNull List<? extends SdlFile> files, final MultipleFileCompletionListener listener){
-		if(files.isEmpty()){
+	public void uploadFiles(@NonNull List<? extends SdlFile> files, final MultipleFileCompletionListener listener) {
+		if (files.isEmpty()) {
 			return;
 		}
 		final List<PutFile> putFileRequests = new ArrayList<>();
-		for(SdlFile file : files){
-			putFileRequests.add(createPutFile(file));
+		for (SdlFile file : files) {
+			if (!file.isStaticIcon()) {
+				putFileRequests.add(createPutFile(file));
+			}
 		}
-		final Map<String, String> errors = new HashMap<>();
-		sendMultipleFileOperations(putFileRequests, listener, errors);
+		// if all files are static icons we complete listener with no errors
+		if (putFileRequests.isEmpty()) {
+			Log.w(TAG, "Static icons don't need to be uploaded");
+			listener.onComplete(null);
+		} else {
+			final Map<String, String> errors = new HashMap<>();
+			sendMultipleFileOperations(putFileRequests, listener, errors);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1284 

This PR is **ready**

### Risk
This PR makes **no** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [X] I have tested Android, Java SE, and Java EE

#### Unit Tests
Added unit test to test to make sure static icons are not uploaded.

#### Core Tests
Tested using Manticore

### Summary
Added logic to align uploadFiles() to uploadFile() in baseFileManager to handle static Icons the same. Before uploadFiles would upload static icons and uploadFile would not and return the lister as success. Now uploadFiles will not upload static icons.

### Changelog
##### Bug Fixes
* Aligned uploadFiles with uploadFile in BaseFileManager to handle static Icons the same.


### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
