### PR TITLE
Deprecate DeviceInfo.DEVICE_OS

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/RPCRequestFactory.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/RPCRequestFactory.java
@@ -1022,7 +1022,7 @@ public class RPCRequestFactory {
 	{
 		DeviceInfo msg = new DeviceInfo();
 		msg.setHardware(android.os.Build.MODEL);
-		msg.setOs(DeviceInfo.DEVICE_OS);
+		msg.setOs("Android");
 		msg.setOsVersion(Build.VERSION.RELEASE);
 		msg.setCarrier(carrierName);
 		return msg;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -6721,7 +6721,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 
 		DeviceInfo deviceInfo = new DeviceInfo();
 		deviceInfo.setHardware(android.os.Build.MODEL);
-		deviceInfo.setOs(DeviceInfo.DEVICE_OS);
+		deviceInfo.setOs("Android");
 		deviceInfo.setOsVersion(Build.VERSION.RELEASE);
 		deviceInfo.setCarrier(carrierName);
 

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/DeviceInfo.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/DeviceInfo.java
@@ -108,6 +108,7 @@ public class DeviceInfo extends RPCStruct{
     public static final String KEY_OS_VERSION = "osVersion";
     public static final String KEY_CARRIER = "carrier";
     public static final String KEY_MAX_NUMBER_RFCOMM_PORTS = "maxNumberRFCOMMPorts";
+    @Deprecated
     public static final String DEVICE_OS = "Android";
 
     public DeviceInfo() { }


### PR DESCRIPTION
Fixes #1290 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

### Summary
This PR depreciates `DeviceInfo.DEVICE_OS`as it doesn't exist in the spec

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
