### PR TITLE
Add missing enums

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lifecycle/RpcConverterTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lifecycle/RpcConverterTest.java
@@ -25,6 +25,7 @@ public class RpcConverterTest extends AndroidTestCase2 {
         FunctionID[] functionIDs = FunctionID.values();
         for(FunctionID functionID : functionIDs) {
             switch (functionID){
+                case RESERVED:
                 case SYNC_P_DATA:
                 case ON_SYNC_P_DATA:
                 case ENCODED_SYNC_P_DATA:
@@ -54,6 +55,7 @@ public class RpcConverterTest extends AndroidTestCase2 {
             rpcClassName.append(RPC_PACKAGE);
 
             switch (functionID) {
+                case RESERVED:
                 case SYNC_P_DATA:
                 case ON_SYNC_P_DATA:
                 case ENCODED_SYNC_P_DATA:
@@ -91,6 +93,7 @@ public class RpcConverterTest extends AndroidTestCase2 {
 
         for(FunctionID functionID : functionIDs){
             switch (functionID){
+                case RESERVED:
                 case SYNC_P_DATA:
                 case ON_SYNC_P_DATA:
                 case ENCODED_SYNC_P_DATA:

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/AppInterfaceUnregisteredReasonTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/AppInterfaceUnregisteredReasonTests.java
@@ -42,6 +42,8 @@ public class AppInterfaceUnregisteredReasonTests extends TestCase {
 		AppInterfaceUnregisteredReason enumAppAuthorized = AppInterfaceUnregisteredReason.valueForString(example);
 		example = "PROTOCOL_VIOLATION";
 		AppInterfaceUnregisteredReason enumProtocolViolation = AppInterfaceUnregisteredReason.valueForString(example);
+		example = "UNSUPPORTED_HMI_RESOURCE";
+		AppInterfaceUnregisteredReason enumUnsupportedHMIResource = AppInterfaceUnregisteredReason.valueForString(example);
 				
 		assertNotNull("USER_EXIT returned null", enumUserExit);
 		assertNotNull("IGNITION_OFF returned null", enumIgnitionOff);
@@ -55,6 +57,7 @@ public class AppInterfaceUnregisteredReasonTests extends TestCase {
 		assertNotNull("FACTORY_DEFAULTS returned null", enumFactoryDefaults);
 		assertNotNull("APP_UNAUTHORIZED returned null", enumAppAuthorized);
 		assertNotNull("PROTOCOL_VIOLATION returned null", enumProtocolViolation);
+		assertNotNull("UNSUPPORTED_HMI_RESOURCE returned null", enumUnsupportedHMIResource);
 	}
 	
 	/**
@@ -104,6 +107,7 @@ public class AppInterfaceUnregisteredReasonTests extends TestCase {
 		enumTestList.add(AppInterfaceUnregisteredReason.FACTORY_DEFAULTS);	
 		enumTestList.add(AppInterfaceUnregisteredReason.APP_UNAUTHORIZED);
 		enumTestList.add(AppInterfaceUnregisteredReason.PROTOCOL_VIOLATION);
+		enumTestList.add(AppInterfaceUnregisteredReason.UNSUPPORTED_HMI_RESOURCE);
 
 		assertTrue("Enum value list does not match enum class list", 
 				enumValueList.containsAll(enumTestList) && enumTestList.containsAll(enumValueList));

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/MaintenanceModeStatusTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/MaintenanceModeStatusTests.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2020 Livio, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Livio Inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.smartdevicelink.test.rpc.enums;
+
+import com.smartdevicelink.proxy.rpc.enums.MaintenanceModeStatus;
+
+import junit.framework.TestCase;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This is a unit test class for the SmartDeviceLink library project class :
+ * {@link com.smartdevicelink.proxy.rpc.enums.MaintenanceModeStatus}
+ */
+public class MaintenanceModeStatusTests extends TestCase {
+
+	/**
+	 * Verifies that the enum values are not null upon valid assignment.
+	 */
+	public void testValidEnums () {
+		String example = "NORMAL";
+		MaintenanceModeStatus enumNormal = MaintenanceModeStatus.valueForString(example);
+		example = "NEAR";
+		MaintenanceModeStatus enumNear = MaintenanceModeStatus.valueForString(example);
+		example = "ACTIVE";
+		MaintenanceModeStatus enumActive = MaintenanceModeStatus.valueForString(example);
+		example = "FEATURE_NOT_PRESENT";
+		MaintenanceModeStatus enumFeatureNotPResent = MaintenanceModeStatus.valueForString(example);
+
+		assertNotNull("NORMAL returned null", enumNormal);
+		assertNotNull("NEAR returned null", enumNear);
+		assertNotNull("ACTIVE returned null", enumActive);
+		assertNotNull("FEATURE_NOT_PRESENT returned null", enumFeatureNotPResent);
+	}
+
+	/**
+	 * Verifies that an invalid assignment is null.
+	 */
+	public void testInvalidEnum () {
+		String example = "normAL";
+		try {
+			MaintenanceModeStatus temp = MaintenanceModeStatus.valueForString(example);
+			assertNull("Result of valueForString should be null.", temp);
+		}
+		catch (IllegalArgumentException exception) {
+			fail("Invalid enum throws IllegalArgumentException.");
+		}
+	}
+
+	/**
+	 * Verifies that a null assignment is invalid.
+	 */
+	public void testNullEnum () {
+		String example = null;
+		try {
+			MaintenanceModeStatus temp = MaintenanceModeStatus.valueForString(example);
+			assertNull("Result of valueForString should be null.", temp);
+		}
+		catch (NullPointerException exception) {
+			fail("Null string throws NullPointerException.");
+		}
+	}
+
+	/**
+	 * Verifies the possible enum values of MaintenanceModeStatus.
+	 */
+	public void testListEnum() {
+		List<MaintenanceModeStatus> enumValueList = Arrays.asList(MaintenanceModeStatus.values());
+
+		List<MaintenanceModeStatus> enumTestList = new ArrayList<>();
+		enumTestList.add(MaintenanceModeStatus.NORMAL);
+		enumTestList.add(MaintenanceModeStatus.NEAR);
+		enumTestList.add(MaintenanceModeStatus.ACTIVE);
+		enumTestList.add(MaintenanceModeStatus.FEATURE_NOT_PRESENT);
+
+		assertTrue("Enum value list does not match enum class list",
+				enumValueList.containsAll(enumTestList) && enumTestList.containsAll(enumValueList));
+	}
+}

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/MessageTypeTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/MessageTypeTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2020 Livio, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Livio Inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.smartdevicelink.test.rpc.enums;
+
+import com.smartdevicelink.proxy.rpc.enums.MessageType;
+
+import junit.framework.TestCase;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This is a unit test class for the SmartDeviceLink library project class :
+ * {@link com.smartdevicelink.proxy.rpc.enums.MessageType}
+ */
+public class MessageTypeTests extends TestCase {
+
+    /**
+     * Verifies that the enum values are not null upon valid assignment.
+     */
+    public void testValidEnums() {
+        int example = 0;
+        MessageType enumRequest = MessageType.valueForInt(example);
+        example = 1;
+        MessageType enumResponse = MessageType.valueForInt(example);
+        example = 2;
+        MessageType enumNotification = MessageType.valueForInt(example);
+
+        assertNotNull("REQUEST returned null", enumRequest);
+        assertNotNull("RESPONSE returned null", enumResponse);
+        assertNotNull("NOTIFICATION returned null", enumNotification);
+
+    }
+
+    /**
+     * Verifies that an invalid assignment is null.
+     */
+    public void testInvalidEnum() {
+        int example = 3;
+        try {
+            MessageType temp = MessageType.valueForInt(example);
+            assertNull("Result of valueForString should be null.", temp);
+        } catch (IllegalArgumentException exception) {
+            fail("Invalid enum throws IllegalArgumentException.");
+        }
+    }
+
+
+    /**
+     * Verifies the possible enum values of MessageType.
+     */
+    public void testListEnum() {
+        List<MessageType> enumValueList = Arrays.asList(MessageType.values());
+
+        List<MessageType> enumTestList = new ArrayList<>();
+        enumTestList.add(MessageType.REQUEST);
+        enumTestList.add(MessageType.RESPONSE);
+        enumTestList.add(MessageType.NOTIFICATION);
+
+        assertTrue("Enum value list does not match enum class list",
+                enumValueList.containsAll(enumTestList) && enumTestList.containsAll(enumValueList));
+    }
+}

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/PermissionStatusTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/PermissionStatusTests.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2020 Livio, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Livio Inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.smartdevicelink.test.rpc.enums;
+
+import com.smartdevicelink.proxy.rpc.enums.PermissionStatus;
+
+import junit.framework.TestCase;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This is a unit test class for the SmartDeviceLink library project class :
+ * {@link com.smartdevicelink.proxy.rpc.enums.PermissionStatus}
+ */
+public class PermissionStatusTests extends TestCase {
+
+	/**
+	 * Verifies that the enum values are not null upon valid assignment.
+	 */
+	public void testValidEnums () {
+		String example = "ALLOWED";
+		PermissionStatus enumAllowed = PermissionStatus.valueForString(example);
+		example = "DISALLOWED";
+		PermissionStatus enumDisallowed = PermissionStatus.valueForString(example);
+		example = "USER_DISALLOWED";
+		PermissionStatus enumUserDisallowed = PermissionStatus.valueForString(example);
+		example = "USER_CONSENT_PENDING";
+		PermissionStatus enumUserConsentPending = PermissionStatus.valueForString(example);
+
+		assertNotNull("ALLOWED returned null", enumAllowed);
+		assertNotNull("DISALLOWED returned null", enumDisallowed);
+		assertNotNull("USER_DISALLOWED returned null", enumUserDisallowed);
+		assertNotNull("USER_CONSENT_PENDING returned null", enumUserConsentPending);
+	}
+
+	/**
+	 * Verifies that an invalid assignment is null.
+	 */
+	public void testInvalidEnum () {
+		String example = "DISALLOwed";
+		try {
+			PermissionStatus temp = PermissionStatus.valueForString(example);
+			assertNull("Result of valueForString should be null.", temp);
+		}
+		catch (IllegalArgumentException exception) {
+			fail("Invalid enum throws IllegalArgumentException.");
+		}
+	}
+
+	/**
+	 * Verifies that a null assignment is invalid.
+	 */
+	public void testNullEnum () {
+		String example = null;
+		try {
+			PermissionStatus temp = PermissionStatus.valueForString(example);
+			assertNull("Result of valueForString should be null.", temp);
+		}
+		catch (NullPointerException exception) {
+			fail("Null string throws NullPointerException.");
+		}
+	}
+
+	/**
+	 * Verifies the possible enum values of PermissionStatus.
+	 */
+	public void testListEnum() {
+		List<PermissionStatus> enumValueList = Arrays.asList(PermissionStatus.values());
+
+		List<PermissionStatus> enumTestList = new ArrayList<>();
+		enumTestList.add(PermissionStatus.ALLOWED);
+		enumTestList.add(PermissionStatus.DISALLOWED);
+		enumTestList.add(PermissionStatus.USER_DISALLOWED);
+		enumTestList.add(PermissionStatus.USER_CONSENT_PENDING);
+
+		assertTrue("Enum value list does not match enum class list",
+				enumValueList.containsAll(enumTestList) && enumTestList.containsAll(enumValueList));
+	}
+}

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/ResultTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/ResultTests.java
@@ -28,6 +28,8 @@ public class ResultTests extends TestCase {
 		Result enumOutOfMemory = Result.valueForString(example);
 		example = "TOO_MANY_PENDING_REQUESTS";
 		Result enumTooManyPendingRequests = Result.valueForString(example);
+		example = "CHAR_LIMIT_EXCEEDED";
+		Result enumCharLimitExceeded = Result.valueForString(example);
 		example = "INVALID_ID";
 		Result enumInvalidId = Result.valueForString(example);
 		example = "DUPLICATE_NAME";
@@ -96,6 +98,7 @@ public class ResultTests extends TestCase {
 		assertNotNull("UNSUPPORTED_REQUEST returned null", enumUnsupportedRequest);
 		assertNotNull("OUT_OF_MEMORY returned null", enumOutOfMemory);
 		assertNotNull("TOO_MANY_PENDING_REQUESTS returned null", enumTooManyPendingRequests);
+		assertNotNull("CHAR_LIMIT_EXCEEDED returned null", enumCharLimitExceeded);
 		assertNotNull("INVALID_ID returned null", enumInvalidId);
 		assertNotNull("DUPLICATE_NAME returned null", enumDuplicateName);
 		assertNotNull("TOO_MANY_APPLICATIONS returned null", enumTooManyApplications);
@@ -169,6 +172,7 @@ public class ResultTests extends TestCase {
 		enumTestList.add(Result.UNSUPPORTED_REQUEST);
 		enumTestList.add(Result.OUT_OF_MEMORY);
 		enumTestList.add(Result.TOO_MANY_PENDING_REQUESTS);
+		enumTestList.add(Result.CHAR_LIMIT_EXCEEDED);
 		enumTestList.add(Result.INVALID_ID);		
 		enumTestList.add(Result.DUPLICATE_NAME);
 		enumTestList.add(Result.TOO_MANY_APPLICATIONS);	

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/TimerModeTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/TimerModeTests.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2020 Livio, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Livio Inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.smartdevicelink.test.rpc.enums;
+
+import com.smartdevicelink.proxy.rpc.enums.TimerMode;
+
+import junit.framework.TestCase;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This is a unit test class for the SmartDeviceLink library project class :
+ * {@link com.smartdevicelink.proxy.rpc.enums.TimerMode}
+ */
+public class TimerModeTests extends TestCase {
+
+	/**
+	 * Verifies that the enum values are not null upon valid assignment.
+	 */
+	public void testValidEnums () {
+		String example = "UP";
+		TimerMode enumUp = TimerMode.valueForString(example);
+		example = "DOWN";
+		TimerMode enumDown = TimerMode.valueForString(example);
+		example = "NONE";
+		TimerMode enumNone = TimerMode.valueForString(example);
+
+		assertNotNull("UP returned null", enumUp);
+		assertNotNull("DOWN returned null", enumDown);
+		assertNotNull("NONE returned null", enumNone);
+	}
+
+	/**
+	 * Verifies that an invalid assignment is null.
+	 */
+	public void testInvalidEnum () {
+		String example = "NonE";
+		try {
+			TimerMode temp = TimerMode.valueForString(example);
+			assertNull("Result of valueForString should be null.", temp);
+		}
+		catch (IllegalArgumentException exception) {
+			fail("Invalid enum throws IllegalArgumentException.");
+		}
+	}
+
+	/**
+	 * Verifies that a null assignment is invalid.
+	 */
+	public void testNullEnum () {
+		String example = null;
+		try {
+			TimerMode temp = TimerMode.valueForString(example);
+			assertNull("Result of valueForString should be null.", temp);
+		}
+		catch (NullPointerException exception) {
+			fail("Null string throws NullPointerException.");
+		}
+	}
+
+	/**
+	 * Verifies the possible enum values of TimerMode.
+	 */
+	public void testListEnum() {
+		List<TimerMode> enumValueList = Arrays.asList(TimerMode.values());
+
+		List<TimerMode> enumTestList = new ArrayList<>();
+		enumTestList.add(TimerMode.UP);
+		enumTestList.add(TimerMode.DOWN);
+		enumTestList.add(TimerMode.NONE);
+
+		assertTrue("Enum value list does not match enum class list",
+				enumValueList.containsAll(enumTestList) && enumTestList.containsAll(enumValueList));
+	}
+}

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/VehicleDataActiveStatusTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/VehicleDataActiveStatusTests.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2020 Livio, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Livio Inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.smartdevicelink.test.rpc.enums;
+
+import com.smartdevicelink.proxy.rpc.enums.VehicleDataActiveStatus;
+
+import junit.framework.TestCase;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This is a unit test class for the SmartDeviceLink library project class :
+ * {@link com.smartdevicelink.proxy.rpc.enums.VehicleDataActiveStatus}
+ */
+public class VehicleDataActiveStatusTests extends TestCase {
+
+	/**
+	 * Verifies that the enum values are not null upon valid assignment.
+	 */
+	public void testValidEnums () {
+		String example = "INACTIVE_NOT_CONFIRMED";
+		VehicleDataActiveStatus enumInactiveNotConfirmed = VehicleDataActiveStatus.valueForString(example);
+		example = "INACTIVE_CONFIRMED";
+		VehicleDataActiveStatus enumInactiveConfirmed = VehicleDataActiveStatus.valueForString(example);
+		example = "ACTIVE_NOT_CONFIRMED";
+		VehicleDataActiveStatus enumActiveNotConfirmed = VehicleDataActiveStatus.valueForString(example);
+		example = "ACTIVE_CONFIRMED";
+		VehicleDataActiveStatus enumActiveConfirmed = VehicleDataActiveStatus.valueForString(example);
+		example = "FAULT";
+		VehicleDataActiveStatus enumFault = VehicleDataActiveStatus.valueForString(example);
+
+		assertNotNull("INACTIVE_NOT_CONFIRMED returned null", enumInactiveNotConfirmed);
+		assertNotNull("INACTIVE_CONFIRMED returned null", enumInactiveConfirmed);
+		assertNotNull("ACTIVE_NOT_CONFIRMED returned null", enumActiveNotConfirmed);
+		assertNotNull("ACTIVE_CONFIRMED returned null", enumActiveConfirmed);
+		assertNotNull("FAULT returned null", enumFault);
+	}
+
+	/**
+	 * Verifies that an invalid assignment is null.
+	 */
+	public void testInvalidEnum () {
+		String example = "FauLt";
+		try {
+			VehicleDataActiveStatus temp = VehicleDataActiveStatus.valueForString(example);
+			assertNull("Result of valueForString should be null.", temp);
+		}
+		catch (IllegalArgumentException exception) {
+			fail("Invalid enum throws IllegalArgumentException.");
+		}
+	}
+
+	/**
+	 * Verifies that a null assignment is invalid.
+	 */
+	public void testNullEnum () {
+		String example = null;
+		try {
+			VehicleDataActiveStatus temp = VehicleDataActiveStatus.valueForString(example);
+			assertNull("Result of valueForString should be null.", temp);
+		}
+		catch (NullPointerException exception) {
+			fail("Null string throws NullPointerException.");
+		}
+	}
+
+	/**
+	 * Verifies the possible enum values of VehicleDataActiveStatus.
+	 */
+	public void testListEnum() {
+		List<VehicleDataActiveStatus> enumValueList = Arrays.asList(VehicleDataActiveStatus.values());
+
+		List<VehicleDataActiveStatus> enumTestList = new ArrayList<>();
+		enumTestList.add(VehicleDataActiveStatus.INACTIVE_NOT_CONFIRMED);
+		enumTestList.add(VehicleDataActiveStatus.INACTIVE_CONFIRMED);
+		enumTestList.add(VehicleDataActiveStatus.ACTIVE_NOT_CONFIRMED);
+		enumTestList.add(VehicleDataActiveStatus.ACTIVE_CONFIRMED);
+		enumTestList.add(VehicleDataActiveStatus.FAULT);
+
+		assertTrue("Enum value list does not match enum class list",
+				enumValueList.containsAll(enumTestList) && enumTestList.containsAll(enumValueList));
+	}
+}

--- a/base/src/main/java/com/smartdevicelink/protocol/enums/FunctionID.java
+++ b/base/src/main/java/com/smartdevicelink/protocol/enums/FunctionID.java
@@ -43,6 +43,8 @@ public enum FunctionID{
     ENCODED_SYNC_P_DATA(65536, "EncodedSyncPData"),
     ON_ENCODED_SYNC_P_DATA(98304, "OnEncodedSyncPData"),
 
+    RESERVED(0, "RESERVED"),
+
     // REQUESTS & RESPONSES
     REGISTER_APP_INTERFACE(1, "RegisterAppInterface"),
     UNREGISTER_APP_INTERFACE(2, "UnregisterAppInterface"),

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/AppInterfaceUnregisteredReason.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/AppInterfaceUnregisteredReason.java
@@ -113,6 +113,12 @@ public enum AppInterfaceUnregisteredReason {
 	 * @since SmartDeviceLink 4.0
 	 */
 	PROTOCOL_VIOLATION,
+	/**
+	 * The HMI does not resource.
+	 *
+	 * @since SmartDeviceLink 4.1
+	 */
+	UNSUPPORTED_HMI_RESOURCE,
 	;
 	/**
      * Convert String to AppInterfaceUnregisteredReason

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/AppInterfaceUnregisteredReason.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/AppInterfaceUnregisteredReason.java
@@ -114,7 +114,7 @@ public enum AppInterfaceUnregisteredReason {
 	 */
 	PROTOCOL_VIOLATION,
 	/**
-	 * The HMI does not resource.
+	 * The HMI does not support resource.
 	 *
 	 * @since SmartDeviceLink 4.1
 	 */

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/BitsPerSample.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/BitsPerSample.java
@@ -52,14 +52,14 @@ public enum BitsPerSample {
 	 */
 	_16_BIT("16_BIT");
 
-    private final String INTERNAL_NAME;
+    private final String VALUE;
     
-    private BitsPerSample(String internalName) {
-        this.INTERNAL_NAME = internalName;
+    private BitsPerSample(String value) {
+        this.VALUE = value;
     }
     
     public String toString() {
-        return this.INTERNAL_NAME;
+        return this.VALUE;
     }
     
     public static BitsPerSample valueForString(String value) {

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/Dimension.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/Dimension.java
@@ -51,14 +51,14 @@ public enum Dimension {
      */
     _3D("3D");
     
-    private final String INTERNAL_NAME;
+    private final String VALUE;
 
-    private Dimension(String internalName) {
-    	this.INTERNAL_NAME = internalName;
+    private Dimension(String value) {
+    	this.VALUE = value;
     }
     
     public String toString() {
-        return this.INTERNAL_NAME;
+        return this.VALUE;
     }
     
     /**

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/DisplayType.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/DisplayType.java
@@ -99,10 +99,10 @@ public enum DisplayType {
     
     ;
 
-    private final String INTERNAL_NAME;
+    private final String VALUE;
 
-    private DisplayType(String internalName) {
-        this.INTERNAL_NAME = internalName;
+    private DisplayType(String value) {
+        this.VALUE = value;
     }
 
     public static DisplayType valueForString(String value) {
@@ -121,6 +121,6 @@ public enum DisplayType {
 
     @Override
     public String toString() {
-        return INTERNAL_NAME;
+        return VALUE;
     }
 }

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/HMILevel.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/HMILevel.java
@@ -71,14 +71,14 @@ public enum HMILevel {
      */
     HMI_NONE("NONE");
 
-    private final String INTERNAL_NAME;
+    private final String VALUE;
     
-    private HMILevel(String internalName) {
-        this.INTERNAL_NAME = internalName;
+    private HMILevel(String value) {
+        this.VALUE = value;
     }
     
     public String toString() {
-        return this.INTERNAL_NAME;
+        return this.VALUE;
     }
     
     /**

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/Jingle.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/Jingle.java
@@ -41,14 +41,14 @@ public enum Jingle{
     LISTEN("LISTEN_JINGLE"),
     HELP("HELP_JINGLE");
     
-    private final String INTERNAL_NAME;
+    private final String VALUE;
     
-    private Jingle(String name){
-        this.INTERNAL_NAME = name;
+    private Jingle(String value){
+        this.VALUE = value;
     }
     
     public String toString() {
-        return this.INTERNAL_NAME;
+        return this.VALUE;
     }
     
     public static Jingle valueForString(String value) {          

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/Language.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/Language.java
@@ -249,16 +249,16 @@ public enum Language {
 
     TH_TH("TH-TH");
 
-    private final String INTERNAL_NAME;
+    private final String VALUE;
     
-    private Language(String internalName) {
-        this.INTERNAL_NAME = internalName;
+    private Language(String value) {
+        this.VALUE = value;
     }
     /**
      * Returns a String representing a kind of Language
      */
     public String toString() {
-        return this.INTERNAL_NAME;
+        return this.VALUE;
     }
     
     /**

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/MaintenanceModeStatus.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/MaintenanceModeStatus.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2017 - 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.smartdevicelink.proxy.rpc.enums;
+
+/**
+ * Reflects the status of a vehicle maintenance mode.
+ *
+ * @since SmartDeviceLink 2.0.0
+ */
+public enum MaintenanceModeStatus {
+    NORMAL,
+    NEAR,
+    ACTIVE,
+    FEATURE_NOT_PRESENT;
+
+    /**
+     * Convert String to MaintenanceModeStatus
+     * @param value String
+     * @return MaintenanceModeStatus
+     */
+    public static MaintenanceModeStatus valueForString(String value) {
+        try {
+            return valueOf(value);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/MessageType.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/MessageType.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2017 - 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.smartdevicelink.proxy.rpc.enums;
+
+import java.util.EnumSet;
+
+/**
+ * Enumeration linking message types with function types in WiPro protocol. Assumes
+ * enumeration starts at value 0.
+ *
+ * @since SmartDeviceLink 1.0.0
+ */
+public enum MessageType {
+    REQUEST(0),
+    RESPONSE(1),
+    NOTIFICATION(2);
+
+    private final int VALUE;
+
+    /**
+     * Private constructor
+     */
+    private MessageType (int value) {
+        this.VALUE = value;
+    }
+
+    /**
+     * Convert value to MessageType
+     * @param value int
+     * @return MessageType
+     */
+    public static MessageType valueForInt(int value) {
+        for (MessageType anEnum : EnumSet.allOf(MessageType.class)) {
+            if (anEnum.getValue() == value) {
+                return anEnum;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Gets the value for the MessageType
+     * @return value for the MessageType
+     */
+    public int getValue(){
+        return VALUE;
+    }
+}

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/MetadataType.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/MetadataType.java
@@ -102,14 +102,14 @@ public enum MetadataType {
 
 	;
 
-	private final String internalName;
+	private final String VALUE;
 
-	private MetadataType(String internalName) {
-		this.internalName = internalName;
+	private MetadataType(String value) {
+		this.VALUE = value;
 	}
 
 	public String toString() {
-		return this.internalName;
+		return this.VALUE;
 	}
 
 	public static MetadataType valueForString(String value) {

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/PermissionStatus.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/PermissionStatus.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2017 - 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.smartdevicelink.proxy.rpc.enums;
+
+/**
+ * Enumeration that describes possible permission states of a policy table entry.
+ *
+ * @since SmartDeviceLink 2.0.0
+ */
+public enum PermissionStatus {
+    ALLOWED,
+    DISALLOWED,
+    USER_DISALLOWED,
+    USER_CONSENT_PENDING;
+
+    /**
+     * Convert String to PermissionStatus
+     * @param value String
+     * @return PermissionStatus
+     */
+    public static PermissionStatus valueForString(String value) {
+        try {
+            return valueOf(value);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/PredefinedLayout.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/PredefinedLayout.java
@@ -139,16 +139,16 @@ public enum PredefinedLayout {
 	LARGE_GRAPHIC_ONLY("LARGE_GRAPHIC_ONLY"),
 	;
 
-	private final String INTERNAL_NAME;
+	private final String VALUE;
 
-	private PredefinedLayout(String internalName) {
-		this.INTERNAL_NAME = internalName;
+	private PredefinedLayout(String value) {
+		this.VALUE = value;
 	}
 	/**
 	 * Returns a String representing a PredefinedLayout
 	 */
 	public String toString() {
-		return this.INTERNAL_NAME;
+		return this.VALUE;
 	}
 
 	/**

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/Result.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/Result.java
@@ -69,6 +69,7 @@ public enum Result {
 	 * delivered yet). There is a limit of 1000 pending requests at a time
 	 */    
 	TOO_MANY_PENDING_REQUESTS,
+	CHAR_LIMIT_EXCEEDED,
 	/**
 	 * <p>One of the provided IDs is not valid. For example:</p>
 	 * <ul>

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/SamplingRate.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/SamplingRate.java
@@ -64,14 +64,14 @@ public enum SamplingRate {
 	 */
 	_44KHZ("44KHZ");
 
-	private final String INTERNAL_NAME;
+	private final String VALUE;
     
-    private SamplingRate(String internalName) {
-        this.INTERNAL_NAME = internalName;
+    private SamplingRate(String value) {
+        this.VALUE = value;
     }
     
     public String toString() {
-        return this.INTERNAL_NAME;
+        return this.VALUE;
     }
     
     public static SamplingRate valueForString(String value) {

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/SoftButtonType.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/SoftButtonType.java
@@ -52,14 +52,14 @@ public enum SoftButtonType {
 	 */
 	SBT_BOTH("BOTH");
 
-	private final String INTERNAL_NAME;
+	private final String VALUE;
     
-    private SoftButtonType(String internalName) {
-        this.INTERNAL_NAME = internalName;
+    private SoftButtonType(String value) {
+        this.VALUE = value;
     }
     
     public String toString() {
-        return this.INTERNAL_NAME;
+        return this.VALUE;
     }
     
     public static SoftButtonType valueForString(String value) {

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/StaticIconName.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/StaticIconName.java
@@ -913,10 +913,10 @@ public enum StaticIconName {
 
 	;
 
-	private final String INTERNAL_NAME;
+	private final String VALUE;
 
-	private StaticIconName(String internalName) {
-		this.INTERNAL_NAME = internalName;
+	private StaticIconName(String value) {
+		this.VALUE = value;
 	}
 
 	public static StaticIconName valueForString(String value) {
@@ -939,7 +939,7 @@ public enum StaticIconName {
 	 */
 	@Override
 	public String toString() {
-		return INTERNAL_NAME;
+		return VALUE;
 	}
 
 }

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/SystemContext.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/SystemContext.java
@@ -73,14 +73,14 @@ public enum SystemContext {
 	 */
 	SYSCTXT_ALERT("ALERT");
 
-	private final String INTERNAL_NAME;
+	private final String VALUE;
     
-    private SystemContext(String internalName) {
-        this.INTERNAL_NAME = internalName;
+    private SystemContext(String value) {
+        this.VALUE = value;
     }
     
     public String toString() {
-        return this.INTERNAL_NAME;
+        return this.VALUE;
     }
     
     public static SystemContext valueForString(String value) {

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/TimerMode.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/TimerMode.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2017 - 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.smartdevicelink.proxy.rpc.enums;
+
+/**
+ * @since SmartDeviceLink 1.0.0
+ */
+public enum TimerMode {
+    /**
+     * Causes the media clock timer to update from 0:00 to a specified time
+     */
+    UP,
+    /**
+     * Causes the media clock timer to update from a specified time to 0:00
+     */
+    DOWN,
+    /**
+     * Indicates to not use the media clock timer
+     */
+    NONE;
+
+    /**
+     * Convert String to TimerMode
+     *
+     * @param value String
+     * @return TimerMode
+     */
+    public static TimerMode valueForString(String value) {
+        try {
+            return valueOf(value);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/TriggerSource.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/TriggerSource.java
@@ -53,14 +53,14 @@ public enum TriggerSource {
 	
 	TS_KEYBOARD("KEYBOARD");
 
-	private final String INTERNAL_NAME;
+	private final String VALUE;
     
-    private TriggerSource(String internalName) {
-        this.INTERNAL_NAME = internalName;
+    private TriggerSource(String value) {
+        this.VALUE = value;
     }
     
     public String toString() {
-        return this.INTERNAL_NAME;
+        return this.VALUE;
     }
     
     public static TriggerSource valueForString(String value) {

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/VehicleDataActiveStatus.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/VehicleDataActiveStatus.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2017 - 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.smartdevicelink.proxy.rpc.enums;
+
+/**
+ * Reflects the status of given vehicle component.
+ *
+ * @since SmartDeviceLink 2.0.0
+ */
+public enum VehicleDataActiveStatus {
+    INACTIVE_NOT_CONFIRMED,
+    INACTIVE_CONFIRMED,
+    ACTIVE_NOT_CONFIRMED,
+    ACTIVE_CONFIRMED,
+    FAULT;
+
+    /**
+     * Convert String to VehicleDataActiveStatus
+     * @param value String
+     * @return VehicleDataActiveStatus
+     */
+    public static VehicleDataActiveStatus valueForString(String value) {
+        try {
+            return valueOf(value);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1283 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified the behavior 
- [x] I have tested Android

#### Unit Tests
Added unit tests for the new enums

### Summary
This PR adds some missing enums that exist in the RPC Spec but not in Java Suite.
* Added the enums: `MaintenanceModeStatus`, `MessageType`, `PermissionStatus`, `TimerMode`, `VehicleDataActiveStatus`
* Added missing values for existing enums: `FunctionID.RESERVED`, `AppInterfaceUnregisteredReason.UNSUPPORTED_HMI_RESOURCE`, `Result.CHAR_LIMIT_EXCEEDED`
* Rename `INTERNAL_NAME` to `VALUE` for existing enums

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
