### PR TITLE
Fix an issue in setVoiceCommands()

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
@@ -126,7 +126,10 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
 		waitingOnHMIUpdate = false;
 		lastVoiceCommandId = voiceCommandIdMin;
 		updateIdsOnVoiceCommands(voiceCommands);
-		this.oldVoiceCommands = new ArrayList<>(this.voiceCommands);
+		this.oldVoiceCommands = new ArrayList<>();
+		if (this.voiceCommands != null && !this.voiceCommands.isEmpty()) {
+			this.oldVoiceCommands.addAll(this.voiceCommands);
+		}
 		this.voiceCommands = new ArrayList<>(voiceCommands);
 
 		update();

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
@@ -56,8 +56,7 @@ import java.util.List;
 
 abstract class BaseVoiceCommandManager extends BaseSubManager {
 
-	List<VoiceCommand> voiceCommands;
-	List<VoiceCommand> oldVoiceCommands;
+	List<VoiceCommand> voiceCommands, oldVoiceCommands;
 
 	List<AddCommand> inProgressUpdate;
 
@@ -127,7 +126,7 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
 		waitingOnHMIUpdate = false;
 		lastVoiceCommandId = voiceCommandIdMin;
 		updateIdsOnVoiceCommands(voiceCommands);
-		oldVoiceCommands = new ArrayList<>(voiceCommands);
+		this.oldVoiceCommands = new ArrayList<>(this.voiceCommands);
 		this.voiceCommands = new ArrayList<>(voiceCommands);
 
 		update();


### PR DESCRIPTION
Fixes #1293

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Core Tests
1- Set voice commands and verify they are working correctly
2- Set different voice command and make sure they are updated correctly

### Summary
This PR fixes an issue `setVoiceCommands()`. Where `oldVoiceCommands` is set to the wrong value. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
