### PR TITLE
Make Github Actions run on opening a PR

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -35,7 +35,7 @@ jobs:
       run: ./javaEE/gradlew -p ./javaEE test
       
     - name: Codecov	
-      uses: codecov/codecov-action@v1.0.4	
+      uses: codecov/codecov-action@v1.0.5	
       with:	
         token: ${{secrets.CODECOV_TOKEN}}
         yml: ./codecov.yml

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,6 +1,6 @@
 name: GitHub CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
Fixes #1297 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

### Summary
This PR updates the Github Actions `android.yml` file to trigger the CI on opening a pull request. This makes the CI run when the pull request is started from a fork.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
