### PR TITLE
Bugfix/issue_1260

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexTcpTransport.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexTcpTransport.java
@@ -61,6 +61,7 @@ public class MultiplexTcpTransport extends MultiplexBaseTransport {
 	private static final int READ_BUFFER_SIZE = 4096;
 	private static final int RECONNECT_DELAY = 5000;
 	private static final int RECONNECT_RETRY_COUNT = 30;
+    private static final int MAXDATACOUNT = 10000;
 
     private final String ipAddress;
 	private final int port;
@@ -408,7 +409,9 @@ public class MultiplexTcpTransport extends MultiplexBaseTransport {
 				count = msgBytes.length - offset;
 			}
 			packetQueue.add(new OutPacket(msgBytes, offset, count));
-
+            if (packetQueue.size() > MAXDATACOUNT) {
+                packetQueue.clear();
+            }
 		}
 
 		public synchronized void cancel() {


### PR DESCRIPTION
Fixes #1260 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by Unit tests.

### Summary
**Reason** 
The data of video streaming and audio streaming is saved. There is no limit to the size of the Queue, so the app can save streaming data into the queue without limit. Queue's data can't be sent to HU via TCP immediately when the WiFi signal is extremely weak, so crash happens as OOM due to queue increases.

**Solution** 
Set a max value to the size of the Queue.                 
When the size of the Queue reaches the max value, clear all the data in the Queue.

max value is 10000(how to decide the max value, referred to as follows）

Android   TestData | Pixel3(Android 10.0) | SM-GalaxyS8(Android 8.0) | Redmi5(Android 8.1)
-- | -- | -- | --
①to do nothing when VMP is   showing | size of Queue between 0 and 1 | the same as left | the same as left
②touch playAudioStream | size of Queue between 0 and 20 | the same as left | the same as left
③touch playAudioStream and   touch other button | size of Queue between 0 and 20 | the same as left | the same as left
④repeat touch or move screen | size of Queue between 0 and 1 | the same as left | the same as left
⑤when OOM | size of Queue reach 20000+ | the same as left | 19000+



### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)