### PR TITLE
Add overwrite property

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
@@ -871,4 +871,40 @@ public class FileManagerTests extends AndroidTestCase2 {
 		assertEquals(fileManagerConfig.getArtworkRetryCount(), 2);
 		assertEquals(fileManagerConfig.getFileRetryCount(), 2);
 	}
+
+	/**
+	 * Testing Overwrite property for uploading a file.
+	 * Checks to make sure file does not overwrite itself
+	 */
+	public void testOverwriteFileProperty() {
+		ISdl internalInterface = mock(ISdl.class);
+
+		doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
+		doAnswer(onPutFileSuccess).when(internalInterface).sendRPC(any(PutFile.class));
+
+		FileManagerConfig fileManagerConfig = new FileManagerConfig();
+
+		final FileManager fileManager = new FileManager(internalInterface, mTestContext, fileManagerConfig);
+		fileManager.start(new CompletionListener() {
+			@Override
+			public void onComplete(boolean success) {
+				assertTrue(success);
+				fileManager.uploadFile(validFile, new CompletionListener() {
+					@Override
+					public void onComplete(boolean success) {
+						assertTrue(success);
+						validFile.setOverwrite(false);
+						fileManager.uploadFile(validFile, new CompletionListener() {
+							@Override
+							public void onComplete(boolean success) {
+								assertTrue(success);
+							}
+						});
+
+					}
+				});
+			}
+		});
+		verify(internalInterface, times(2)).sendRPC(any(RPCMessage.class));
+	}
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
@@ -873,8 +873,8 @@ public class FileManagerTests extends AndroidTestCase2 {
 	}
 
 	/**
-	 * Testing Overwrite property for uploading a file.
-	 * Checks to make sure file does not overwrite itself
+	 * Tests overwrite property for uploading a file.
+	 * Checks to make sure file does not overwrite itself if overwrite property is set to false
 	 */
 	public void testOverwriteFileProperty() {
 		ISdl internalInterface = mock(ISdl.class);
@@ -906,5 +906,52 @@ public class FileManagerTests extends AndroidTestCase2 {
 			}
 		});
 		verify(internalInterface, times(2)).sendRPC(any(RPCMessage.class));
+	}
+
+	/**
+	 * Tests overwrite property for uploading a list of files.
+	 * Checks to make sure files do not overwrite themselves if overwrite property is set to false.
+	 */
+	public void testOverWriteFilePropertyListFiles() {
+		final ISdl internalInterface = mock(ISdl.class);
+
+		doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
+		doAnswer(onListFileUploadSuccess).when(internalInterface).sendRequests(any(List.class), any(OnMultipleRequestListener.class));
+
+		final SdlFile validFile2 = new SdlFile();
+		validFile2.setName(Test.GENERAL_STRING + "2");
+		validFile2.setFileData(Test.GENERAL_BYTE_ARRAY);
+		validFile2.setPersistent(false);
+		validFile2.setType(FileType.GRAPHIC_JPEG);
+
+		final List<SdlFile> list = new ArrayList<>();
+		list.add(validFile);
+		list.add(validFile2);
+
+		FileManagerConfig fileManagerConfig = new FileManagerConfig();
+		fileManagerConfig.setArtworkRetryCount(2);
+		fileManagerConfig.setFileRetryCount(4);
+
+		final FileManager fileManager = new FileManager(internalInterface, mTestContext, fileManagerConfig);
+		fileManager.start(new CompletionListener() {
+			@Override
+			public void onComplete(boolean success) {
+				fileManager.uploadFiles(list, new MultipleFileCompletionListener() {
+					@Override
+					public void onComplete(Map<String, String> errors) {
+						validFile.setOverwrite(false);
+						validFile2.setOverwrite(false);
+						fileManager.uploadFiles(list, new MultipleFileCompletionListener() {
+							@Override
+							public void onComplete(Map<String, String> errors) {
+								assertNull(errors);
+							}
+						});
+					}
+				});
+
+			}
+		});
+		verify(internalInterface, times(1)).sendRequests(any(List.class), any(OnMultipleRequestListener.class));
 	}
 }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlArtwork.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlArtwork.java
@@ -51,7 +51,9 @@ public class SdlArtwork extends SdlFile implements Cloneable{
     /**
      * Creates a new instance of SdlArtwork
      */
-    public SdlArtwork(){}
+    public SdlArtwork(){
+        super();
+    }
 
     /**
      * Creates a new instance of SdlArtwork

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlArtwork.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlArtwork.java
@@ -51,9 +51,7 @@ public class SdlArtwork extends SdlFile implements Cloneable{
     /**
      * Creates a new instance of SdlArtwork
      */
-    public SdlArtwork(){
-        super();
-    }
+    public SdlArtwork() {}
 
     /**
      * Creates a new instance of SdlArtwork

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
@@ -42,18 +42,22 @@ import com.smartdevicelink.proxy.rpc.enums.StaticIconName;
  * A class representing data to be uploaded to core
  */
 public class SdlFile{
-    private String      fileName;
-    private int         id = -1;
-    private Uri         uri;
-    private byte[]      fileData;
-    private FileType    fileType;
-    private boolean     persistentFile;
-    private boolean     isStaticIcon;
+    private String fileName;
+    private int id = -1;
+    private Uri uri;
+    private byte[] fileData;
+    private FileType fileType;
+    private boolean persistentFile;
+    private boolean isStaticIcon;
+    // Overwrite property by default is set to true in SdlFile constructors indicating that a file can be overwritten
+    private boolean overwrite;
 
     /**
      * Creates a new instance of SdlFile
      */
-    public SdlFile(){}
+    public SdlFile(){
+        overwrite = true;
+    }
 
     /**
      * Creates a new instance of SdlFile
@@ -67,6 +71,7 @@ public class SdlFile{
         this.fileType = fileType;
         this.id = id;
         this.persistentFile = persistentFile;
+        overwrite = true;
     }
 
     /**
@@ -81,6 +86,7 @@ public class SdlFile{
         this.fileType = fileType;
         this.uri = uri;
         this.persistentFile = persistentFile;
+        overwrite = true;
     }
 
     /**
@@ -95,6 +101,7 @@ public class SdlFile{
         this.fileType = fileType;
         this.fileData = data;
         this.persistentFile = persistentFile;
+        overwrite = true;
     }
 
     /**
@@ -106,6 +113,7 @@ public class SdlFile{
         this.fileData = staticIconName.toString().getBytes();
         this.persistentFile = false;
         this.isStaticIcon = true;
+        overwrite = true;
     }
 
     /**
@@ -218,5 +226,21 @@ public class SdlFile{
      */
     public boolean isStaticIcon() {
         return isStaticIcon;
+    }
+
+    /**
+     * Gets the overwrite property for an SdlFile by default its set to true
+     * @return a boolean value that indicates if a file can be overwritten.
+     */
+    public boolean isOverwrite() {
+        return overwrite;
+    }
+
+    /**
+     * Sets the overwrite property for an SdlFile by default its set to true
+     * @param overwrite a boolean value that indicates if a file can be overwritten
+     */
+    public void setOverwrite(boolean overwrite) {
+        this.overwrite = overwrite;
     }
 }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
@@ -50,14 +50,12 @@ public class SdlFile{
     private boolean persistentFile;
     private boolean isStaticIcon;
     // Overwrite property by default is set to true in SdlFile constructors indicating that a file can be overwritten
-    private boolean overwrite;
+    private boolean overwrite = true;
 
     /**
      * Creates a new instance of SdlFile
      */
-    public SdlFile(){
-        overwrite = true;
-    }
+    public SdlFile() { }
 
     /**
      * Creates a new instance of SdlFile
@@ -71,7 +69,6 @@ public class SdlFile{
         this.fileType = fileType;
         this.id = id;
         this.persistentFile = persistentFile;
-        overwrite = true;
     }
 
     /**
@@ -86,7 +83,6 @@ public class SdlFile{
         this.fileType = fileType;
         this.uri = uri;
         this.persistentFile = persistentFile;
-        overwrite = true;
     }
 
     /**
@@ -101,7 +97,6 @@ public class SdlFile{
         this.fileType = fileType;
         this.fileData = data;
         this.persistentFile = persistentFile;
-        overwrite = true;
     }
 
     /**
@@ -113,7 +108,6 @@ public class SdlFile{
         this.fileData = staticIconName.toString().getBytes();
         this.persistentFile = false;
         this.isStaticIcon = true;
-        overwrite = true;
     }
 
     /**

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
@@ -226,7 +226,7 @@ public class SdlFile{
      * Gets the overwrite property for an SdlFile by default its set to true
      * @return a boolean value that indicates if a file can be overwritten.
      */
-    public boolean isOverwrite() {
+    public boolean getOverwrite() {
         return overwrite;
     }
 

--- a/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
@@ -325,12 +325,12 @@ abstract class BaseFileManager extends BaseSubManager {
 	 */
 	public void uploadFile(@NonNull final SdlFile file, final CompletionListener listener) {
 		if (file.isStaticIcon()) {
-			Log.w(TAG, "Static icons don't need to be uploaded");
+			Log.w(TAG, String.format("%s is a static icon and doesn't need to be uploaded", file.getName()));
 			listener.onComplete(true);
 			return;
 		}
 		if (!file.isOverwrite() && hasUploadedFile(file)) {
-			Log.w(TAG, "Files that have already uploaded and have an Overwrite property set to false will not be re-Upload");
+			Log.w(TAG, String.format("%s has already been uploaded and the overwrite property is set to false. It will not be uploaded again", file.getName()));
 			listener.onComplete(true);
 			return;
 		}
@@ -398,11 +398,11 @@ abstract class BaseFileManager extends BaseSubManager {
 		final List<PutFile> putFileRequests = new ArrayList<>();
 		for (SdlFile file : files) {
 			if (file.isStaticIcon()) {
-				Log.w(TAG, "Static icons don't need to be uploaded");
+				Log.w(TAG, String.format("%s is a static icon and doesn't need to be uploaded", file.getName()));
 				continue;
 			}
 			if (!file.isOverwrite() && hasUploadedFile(file)) {
-				Log.w(TAG, "Files that have already uploaded and have an Overwrite property set to false will not be re-Upload");
+				Log.w(TAG, String.format("%s has already been uploaded and the overwrite property is set to false. It will not be uploaded again", file.getName()));
 				continue;
 			}
 			putFileRequests.add(createPutFile(file));

--- a/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
@@ -329,7 +329,7 @@ abstract class BaseFileManager extends BaseSubManager {
 			listener.onComplete(true);
 			return;
 		}
-		if (!file.isOverwrite() && hasUploadedFile(file)) {
+		if (!file.getOverwrite() && hasUploadedFile(file)) {
 			Log.w(TAG, String.format("%s has already been uploaded and the overwrite property is set to false. It will not be uploaded again", file.getName()));
 			listener.onComplete(true);
 			return;
@@ -401,7 +401,7 @@ abstract class BaseFileManager extends BaseSubManager {
 				Log.w(TAG, String.format("%s is a static icon and doesn't need to be uploaded", file.getName()));
 				continue;
 			}
-			if (!file.isOverwrite() && hasUploadedFile(file)) {
+			if (!file.getOverwrite() && hasUploadedFile(file)) {
 				Log.w(TAG, String.format("%s has already been uploaded and the overwrite property is set to false. It will not be uploaded again", file.getName()));
 				continue;
 			}

--- a/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
@@ -331,10 +331,10 @@ abstract class BaseFileManager extends BaseSubManager {
 		}
 		// In sdl_ios: HAX: [#827](https://github.com/smartdevicelink/sdl_ios/issues/827) Older versions of Core had a bug where list files would cache incorrectly.
 		// This led to attempted uploads failing due to the system thinking they were already there when they were not.
-		if(!file.isPersistent() && !hasUploadedFile(file)){
+		if (!file.isPersistent() && !hasUploadedFile(file)) {
 			file.setOverwrite(true);
 		}
-		if(!file.isOverwrite() && hasUploadedFile(file)){
+		if (!file.isOverwrite() && hasUploadedFile(file)) {
 			Log.w(TAG, "Files that have already uploaded and have an Overwrite property set to false will now upload re-Upload");
 			listener.onComplete(true);
 			return;

--- a/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
@@ -329,11 +329,6 @@ abstract class BaseFileManager extends BaseSubManager {
 			listener.onComplete(true);
 			return;
 		}
-		// In sdl_ios: HAX: [#827](https://github.com/smartdevicelink/sdl_ios/issues/827) Older versions of Core had a bug where list files would cache incorrectly.
-		// This led to attempted uploads failing due to the system thinking they were already there when they were not.
-		if (!file.isPersistent() && !hasUploadedFile(file)) {
-			file.setOverwrite(true);
-		}
 		if (!file.isOverwrite() && hasUploadedFile(file)) {
 			Log.w(TAG, "Files that have already uploaded and have an Overwrite property set to false will not be re-Upload");
 			listener.onComplete(true);
@@ -405,11 +400,6 @@ abstract class BaseFileManager extends BaseSubManager {
 			if (file.isStaticIcon()) {
 				Log.w(TAG, "Static icons don't need to be uploaded");
 				continue;
-			}
-			// In sdl_ios: HAX: [#827](https://github.com/smartdevicelink/sdl_ios/issues/827) Older versions of Core had a bug where list files would cache incorrectly.
-			// This led to attempted uploads failing due to the system thinking they were already there when they were not.
-			if (!file.isPersistent() && !hasUploadedFile(file)) {
-				file.setOverwrite(true);
 			}
 			if (!file.isOverwrite() && hasUploadedFile(file)) {
 				Log.w(TAG, "Files that have already uploaded and have an Overwrite property set to false will not be re-Upload");

--- a/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
@@ -329,6 +329,16 @@ abstract class BaseFileManager extends BaseSubManager {
 			listener.onComplete(true);
 			return;
 		}
+		// In sdl_ios: HAX: [#827](https://github.com/smartdevicelink/sdl_ios/issues/827) Older versions of Core had a bug where list files would cache incorrectly.
+		// This led to attempted uploads failing due to the system thinking they were already there when they were not.
+		if(!file.isPersistent() && !hasUploadedFile(file)){
+			file.setOverwrite(true);
+		}
+		if(!file.isOverwrite() && hasUploadedFile(file)){
+			Log.w(TAG, "Files that have already uploaded and have an Overwrite property set to false will now upload re-Upload");
+			listener.onComplete(true);
+			return;
+		}
 		PutFile putFile = createPutFile(file);
 		putFile.setOnRPCResponseListener(new OnRPCResponseListener() {
 			@Override

--- a/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
@@ -335,7 +335,7 @@ abstract class BaseFileManager extends BaseSubManager {
 			file.setOverwrite(true);
 		}
 		if (!file.isOverwrite() && hasUploadedFile(file)) {
-			Log.w(TAG, "Files that have already uploaded and have an Overwrite property set to false will now upload re-Upload");
+			Log.w(TAG, "Files that have already uploaded and have an Overwrite property set to false will not be re-Upload");
 			listener.onComplete(true);
 			return;
 		}
@@ -412,7 +412,7 @@ abstract class BaseFileManager extends BaseSubManager {
 				file.setOverwrite(true);
 			}
 			if (!file.isOverwrite() && hasUploadedFile(file)) {
-				Log.w(TAG, "Files that have already uploaded and have an Overwrite property set to false will now upload re-Upload");
+				Log.w(TAG, "Files that have already uploaded and have an Overwrite property set to false will not be re-Upload");
 				continue;
 			}
 			putFileRequests.add(createPutFile(file));

--- a/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
@@ -39,12 +39,14 @@ import com.smartdevicelink.proxy.rpc.enums.StaticIconName;
  * A class representing data to be uploaded to core
  */
 public class SdlFile{
-    private String      fileName;
-    private String      filePath;
-    private byte[]      fileData;
-    private FileType    fileType;
-    private boolean     persistentFile;
-    private boolean     isStaticIcon;
+    private String fileName;
+    private String filePath;
+    private byte[] fileData;
+    private FileType fileType;
+    private boolean persistentFile;
+    private boolean isStaticIcon;
+    // Overwrite property by default is set to true in SdlFile constructors indicating that a file can be overwritten
+    private boolean overwrite = true;
 
     /**
      * Creates a new instance of SdlFile
@@ -184,5 +186,21 @@ public class SdlFile{
      */
     public boolean isStaticIcon() {
         return isStaticIcon;
+    }
+
+    /**
+     * Gets the overwrite property for an SdlFile by default its set to true
+     * @return a boolean value that indicates if a file can be overwritten.
+     */
+    public boolean isOverwrite() {
+        return overwrite;
+    }
+
+    /**
+     * Sets the overwrite property for an SdlFile by default its set to true
+     * @param overwrite a boolean value that indicates if a file can be overwritten
+     */
+    public void setOverwrite(boolean overwrite) {
+        this.overwrite = overwrite;
     }
 }

--- a/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
@@ -192,7 +192,7 @@ public class SdlFile{
      * Gets the overwrite property for an SdlFile by default its set to true
      * @return a boolean value that indicates if a file can be overwritten.
      */
-    public boolean isOverwrite() {
+    public boolean getOverwrite() {
         return overwrite;
     }
 


### PR DESCRIPTION
Fixes #1302 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
Added unit test to test file not overwriting itself in BaseFileManager.uploadfiles as well as BaseFileManager.uploadFiles

#### Core Tests
Tested using manticore.

### Summary
Added overwrite property to SdlFile in Android and JavaSE, added logic to baseFileManager.java to handle the overwrite property when uploading files.

Overwrite property is always set to true, in next major release to align with IOS we need to change it to false

To test I recommend after uploading one file to set the SdlFIle's overwrite property to false and upload it the second time in the completion listener's onComplete of the first upload to verify that the file has uploaded before it tries to upload it again. Ex:

```
		SdlFile livio = new SdlFile("livio", FileType.GRAPHIC_PNG, R.drawable.sdl, false);

		sdlManager.getFileManager().uploadFile(livio, new CompletionListener() {
			@Override
			public void onComplete(boolean success) {
				SdlFile livio2 = new SdlFile("livio", FileType.GRAPHIC_PNG, R.drawable.sdl, false);
				livio2.setOverwrite(false);
				sdlManager.getFileManager().uploadFile(livio2, new CompletionListener() {
					@Override
					public void onComplete(boolean success) {
					}
				});
			}
		});
```

##### Enhancements
* Added overwrite property to SdlFile

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
