### PR TITLE
Add Override Equals method to softButtonObject

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
@@ -925,4 +925,60 @@ public class FileManagerTests extends AndroidTestCase2 {
 		});
 		verify(internalInterface, times(1)).sendRequests(any(List.class), any(OnMultipleRequestListener.class));
 	}
+
+	/**
+	 * 	Test custom overridden SdlFile equals method
+	 */
+	public void testSdlFileEquals() {
+		// Case 1: object is null, assertFalse
+		SdlFile artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, true);
+		SdlFile artwork2 = null;
+		assertFalse(artwork1.equals(artwork2));
+
+		// Case 2 SoftButtonObjects are the same, assertTrue
+		assertTrue(artwork1.equals(artwork1));
+
+		// Case 3: object is not an instance of SoftButtonObject, assertFalse
+		assertFalse(artwork1.equals("Test"));
+
+		// Case 4: different StaticIcon status, assertFalse
+		artwork1.setStaticIcon(true);
+		artwork2 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, true);
+		artwork2.setStaticIcon(false);
+		assertFalse(artwork1.equals(artwork2));
+
+		// Case 5: different Persistent status, assertFalse
+		artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
+		artwork2 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, true);
+		assertFalse(artwork1.equals(artwork2));
+
+		// Case 6: different name, assertFalse
+		artwork2 = new SdlFile("image2", FileType.GRAPHIC_PNG, 1, false);
+		assertFalse(artwork1.equals(artwork2));
+
+		// Case 7: different Uri
+		Uri uri1 = Uri.parse("testUri1");
+		Uri uri2 = Uri.parse("testUri2");
+		artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, uri1, false);
+		artwork2 = new SdlFile("image1", FileType.GRAPHIC_PNG, uri2, false);
+		assertFalse(artwork1.equals(artwork2));
+
+		// Case 8: different FileData
+		artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
+		artwork2 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
+		byte[] GENERAL_BYTE_ARRAY2 = new byte[2];
+		artwork1.setFileData(Test.GENERAL_BYTE_ARRAY);
+		artwork2.setFileData(GENERAL_BYTE_ARRAY2);
+		assertFalse(artwork1.equals(artwork2));
+
+		// Case 9 different FileType, assertFalse
+		artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
+		artwork2 = new SdlFile("image1", FileType.AUDIO_WAVE, 1, false);
+		assertFalse(artwork1.equals(artwork2));
+
+		// Case 10: they are equal, assertTrue
+		artwork1 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
+		artwork2 = new SdlFile("image1", FileType.GRAPHIC_PNG, 1, false);
+		assertTrue(artwork1.equals(artwork2));
+	}
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -305,4 +305,36 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
         assertEquals("SoftButtonObject id doesn't match the expected value", 100, sbo4.getButtonId());
         assertEquals("SoftButtonObject id doesn't match the expected value", 103, sbo5.getButtonId());
     }
+
+    /**
+     * Test custom overridden softButtonState equals method
+     */
+    public void testSoftButtonStateEquals() {
+        assertFalse(softButtonState1.equals(softButtonState2));
+        SdlArtwork artwork1 = new SdlArtwork("image1", FileType.GRAPHIC_PNG, 1, true);
+        SdlArtwork artwork2 = new SdlArtwork("image2", FileType.GRAPHIC_PNG, 1, true);
+
+        // Case 1: object is null, assertFalse
+        softButtonState1 = new SoftButtonState("object1-state1", "o1s1", artwork1);
+        softButtonState2 = null;
+        assertFalse(softButtonState1.equals(softButtonState2));
+
+        // Case 2 SoftButtonObjects are the same, assertTrue
+        assertTrue(softButtonState1.equals(softButtonState1));
+
+        // Case 3: object is not an instance of SoftButtonState, assertFalse
+        assertFalse(softButtonState1.equals(artwork1));
+
+        // Case 4: different artwork, assertFalse
+        softButtonState2 = new SoftButtonState("object1-state1", "o1s1", artwork2);
+        assertFalse(softButtonState1.equals(softButtonState2));
+
+        // Case 5: different name, assertFalse
+        softButtonState2 = new SoftButtonState("object1-state1 different name", "o1s1", artwork1);
+        assertFalse(softButtonState1.equals(softButtonState2));
+
+        // Case 6 they are equal, assertTrue
+        softButtonState2 = new SoftButtonState("object1-state1", "o1s1", artwork1);
+        assertTrue(softButtonState1.equals(softButtonState2));
+    }
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -372,21 +372,6 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
         softButtonObject1 = new SoftButtonObject("hi", softButtonStateList, "Hi", null);
         softButtonObject2 = new SoftButtonObject("hi", softButtonStateList, "Hi2", null);
         assertFalse(softButtonObject1.equals(softButtonObject2));
-
-        // Case 8: SoftButtonObject onEventListener not same, assert false
-        softButtonObject1 = new SoftButtonObject("hi", softButtonStateList, "Hi", testOnEventList1);
-        softButtonObject2 = new SoftButtonObject("hi", softButtonStateList, "Hi", testOnEventList2);
-        assertFalse(softButtonObject1.equals(softButtonObject2));
-
-        // Case 9: onEventListeners not null, everything same, assertTrue
-        softButtonObject1 = new SoftButtonObject("hi", softButtonStateList, "Hi", testOnEventList1);
-        softButtonObject2 = new SoftButtonObject("hi", softButtonStateList, "Hi", testOnEventList1);
-        assertTrue(softButtonObject1.equals(softButtonObject2));
-
-        // Case10: onEventListeners null, everything same, assertTrue
-        softButtonObject1 = new SoftButtonObject("test", softButtonState1, null);
-        softButtonObject2 = new SoftButtonObject("test", softButtonState1, null);
-        assertTrue(softButtonObject1.equals(softButtonObject2));
     }
 
     /**

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -312,7 +312,7 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
     /**
      * Test custom overridden softButtonObject equals method
      */
-    public void testSoftButtonEquals() {
+    public void testSoftButtonObjectEquals() {
         SoftButtonObject softButtonObject1;
         SoftButtonObject softButtonObject2;
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -9,6 +9,8 @@ import com.smartdevicelink.managers.file.filetypes.SdlArtwork;
 import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.proxy.interfaces.ISdl;
 import com.smartdevicelink.proxy.rpc.Image;
+import com.smartdevicelink.proxy.rpc.OnButtonEvent;
+import com.smartdevicelink.proxy.rpc.OnButtonPress;
 import com.smartdevicelink.proxy.rpc.OnHMIStatus;
 import com.smartdevicelink.proxy.rpc.Show;
 import com.smartdevicelink.proxy.rpc.SoftButton;
@@ -25,6 +27,7 @@ import com.smartdevicelink.test.Validator;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -304,6 +307,86 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
         assertEquals("SoftButtonObject id doesn't match the expected value", 102, sbo3.getButtonId());
         assertEquals("SoftButtonObject id doesn't match the expected value", 100, sbo4.getButtonId());
         assertEquals("SoftButtonObject id doesn't match the expected value", 103, sbo5.getButtonId());
+    }
+
+    /**
+     * Test custom overridden softButtonObject equals method
+     */
+    public void testSoftButtonEquals() {
+        SoftButtonObject softButtonObject1;
+        SoftButtonObject softButtonObject2;
+
+        SoftButtonObject.OnEventListener testOnEventList1 = new SoftButtonObject.OnEventListener() {
+            @Override
+            public void onPress(SoftButtonObject softButtonObject, OnButtonPress onButtonPress) {
+            }
+
+            @Override
+            public void onEvent(SoftButtonObject softButtonObject, OnButtonEvent onButtonEvent) {
+            }
+        };
+
+        SoftButtonObject.OnEventListener testOnEventList2 = new SoftButtonObject.OnEventListener() {
+            @Override
+            public void onPress(SoftButtonObject softButtonObject, OnButtonPress onButtonPress) {
+            }
+
+            @Override
+            public void onEvent(SoftButtonObject softButtonObject, OnButtonEvent onButtonEvent) {
+            }
+        };
+
+        // Case 1: object is null, assertFalse
+        softButtonObject1 = new SoftButtonObject("test", softButtonState1, null);
+        softButtonObject2 = null;
+        assertFalse(softButtonObject1.equals(softButtonObject2));
+
+        // Case 2 SoftButtonObjects are the same, assertTrue
+        assertTrue(softButtonObject1.equals(softButtonObject1));
+
+        // Case 3: object is not an instance of SoftButtonObject assertFalse
+        SdlArtwork artwork = new SdlArtwork("image1", FileType.GRAPHIC_PNG, 1, true);
+        assertFalse(softButtonObject1.equals(artwork));
+
+        // Case 4: SoftButtonObjectState List are not same size, assertFalse
+        List<SoftButtonState> softButtonStateList = new ArrayList<>();
+        List<SoftButtonState> softButtonStateList2 = new ArrayList<>();
+        softButtonStateList.add(softButtonState1);
+        softButtonStateList2.add(softButtonState1);
+        softButtonStateList2.add(softButtonState2);
+        softButtonObject1 = new SoftButtonObject("hi", softButtonStateList, "Hi", null);
+        softButtonObject2 = new SoftButtonObject("hi", softButtonStateList2, "Hi", null);
+        assertFalse(softButtonObject1.equals(softButtonObject2));
+
+        // Case 5: SoftButtonStates are not the same, assertFalse
+        softButtonObject1 = new SoftButtonObject("test", softButtonState1, null);
+        softButtonObject2 = new SoftButtonObject("test", softButtonState2, null);
+        assertFalse(softButtonObject1.equals(softButtonObject2));
+
+        // Case 6: SoftButtonObject names are not same, assertFalse
+        softButtonObject1 = new SoftButtonObject("test", softButtonState1, null);
+        softButtonObject2 = new SoftButtonObject("test23123", softButtonState1, null);
+        assertFalse(softButtonObject1.equals(softButtonObject2));
+
+        // Case 7: SoftButtonObject currentStateName not same, assertFalse
+        softButtonObject1 = new SoftButtonObject("hi", softButtonStateList, "Hi", null);
+        softButtonObject2 = new SoftButtonObject("hi", softButtonStateList, "Hi2", null);
+        assertFalse(softButtonObject1.equals(softButtonObject2));
+
+        // Case 8: SoftButtonObject onEventListener not same, assert false
+        softButtonObject1 = new SoftButtonObject("hi", softButtonStateList, "Hi", testOnEventList1);
+        softButtonObject2 = new SoftButtonObject("hi", softButtonStateList, "Hi", testOnEventList2);
+        assertFalse(softButtonObject1.equals(softButtonObject2));
+
+        // Case 9: onEventListeners not null, everything same, assertTrue
+        softButtonObject1 = new SoftButtonObject("hi", softButtonStateList, "Hi", testOnEventList1);
+        softButtonObject2 = new SoftButtonObject("hi", softButtonStateList, "Hi", testOnEventList1);
+        assertTrue(softButtonObject1.equals(softButtonObject2));
+
+        // Case10: onEventListeners null, everything same, assertTrue
+        softButtonObject1 = new SoftButtonObject("test", softButtonState1, null);
+        softButtonObject2 = new SoftButtonObject("test", softButtonState1, null);
+        assertTrue(softButtonObject1.equals(softButtonObject2));
     }
 
     /**

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
@@ -249,9 +249,9 @@ public class SdlFile{
         result += ((getUri() == null) ? 0 : Integer.rotateLeft(getUri().hashCode(), 2));
         result += ((getFileData() == null) ? 0 : Integer.rotateLeft(getFileData().hashCode(), 3));
         result += ((getType() == null) ? 0 : Integer.rotateLeft(getType().hashCode(), 4));
-        result += ((Boolean.valueOf(isStaticIcon) == null) ? 0 : Integer.rotateLeft(Boolean.valueOf(isStaticIcon).hashCode(), 5));
-        result += ((Boolean.valueOf(isPersistent()) == null) ? 0 : Integer.rotateLeft(Boolean.valueOf(isPersistent()).hashCode(), 6));
-        result += ((Integer.valueOf(getResourceId()) == null) ? 0 : Integer.rotateLeft(Integer.valueOf(getResourceId()).hashCode(), 7));
+        result += Integer.rotateLeft(Boolean.valueOf(isStaticIcon()).hashCode(), 5);
+        result += Integer.rotateLeft(Boolean.valueOf(isPersistent()).hashCode(), 6);
+        result += Integer.rotateLeft(Integer.valueOf(getResourceId()).hashCode(), 7);
         return result;
     }
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
@@ -237,4 +237,37 @@ public class SdlFile{
     public void setOverwrite(boolean overwrite) {
         this.overwrite = overwrite;
     }
+
+    /**
+     * Used to compile hashcode for SdlFile for use to compare in overridden equals method
+     * @return Custom hashcode of SdlFile variables
+     */
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result += ((getName() == null) ? 0 : Integer.rotateLeft(getName().hashCode(), 1));
+        result += ((getUri() == null) ? 0 : Integer.rotateLeft(getUri().hashCode(), 2));
+        result += ((getFileData() == null) ? 0 : Integer.rotateLeft(getFileData().hashCode(), 3));
+        result += ((getType() == null) ? 0 : Integer.rotateLeft(getType().hashCode(), 4));
+        result += ((Boolean.valueOf(isStaticIcon) == null) ? 0 : Integer.rotateLeft(Boolean.valueOf(isStaticIcon).hashCode(), 5));
+        result += ((Boolean.valueOf(isPersistent()) == null) ? 0 : Integer.rotateLeft(Boolean.valueOf(isPersistent()).hashCode(), 6));
+        result += ((Integer.valueOf(getResourceId()) == null) ? 0 : Integer.rotateLeft(Integer.valueOf(getResourceId()).hashCode(), 7));
+        return result;
+    }
+
+    /**
+     * Uses our custom hashCode for SdlFile objects
+     * @param o - The object to compare
+     * @return boolean of whether the objects are the same or not
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) return false;
+        // if this is the same memory address, it's the same
+        if (this == o) return true;
+        // if this is not an instance of SdlFile, not the same
+        if (!(o instanceof SdlFile)) return false;
+        // return comparison
+        return hashCode() == o.hashCode();
+    }
 }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -319,8 +319,9 @@ public class SoftButtonObject {
         int result = 1;
         result += ((getName() == null) ? 0 : Integer.rotateLeft(getName().hashCode(), 1));
         result += ((getCurrentStateName() == null) ? 0 : Integer.rotateLeft(getCurrentStateName().hashCode(), 2));
+        result += Integer.rotateLeft(Integer.valueOf(getButtonId()).hashCode(), 3);
         for (int i = 0; i < this.states.size(); i++) {
-            result += ((getStates().get(i) == null) ? 0 : Integer.rotateLeft(getStates().get(i).hashCode(), i + 2));
+            result += ((getStates().get(i) == null) ? 0 : Integer.rotateLeft(getStates().get(i).hashCode(), i + 4));
         }
         return result;
     }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -309,4 +309,35 @@ public class SoftButtonObject {
          */
         void onUpdate();
     }
+
+    /**
+     * Used to compile hashcode for SoftButtonsObjects for use to compare in equals method
+     * @return Custom hashcode of SoftButtonObjects variables
+     */
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result += ((getName() == null) ? 0 : Integer.rotateLeft(getName().hashCode(), 1));
+        result += ((getCurrentStateName() == null) ? 0 : Integer.rotateLeft(getCurrentStateName().hashCode(), 2));
+        for (int i = 0; i < this.states.size(); i++) {
+            result += ((getStates().get(i) == null) ? 0 : Integer.rotateLeft(getStates().get(i).hashCode(), i + 2));
+        }
+        return result;
+    }
+
+    /**
+     * Uses our custom hashCode for SoftButtonObject objects
+     * @param o - The object to compare
+     * @return boolean of whether the objects are the same or not
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) return false;
+        // if this is the same memory address, it's the same
+        if (this == o) return true;
+        // if this is not an instance of SoftButtonObject, not the same
+        if (!(o instanceof SoftButtonObject)) return false;
+        // return comparison
+        return hashCode() == o.hashCode();
+    }
 }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
@@ -158,4 +158,32 @@ public class SoftButtonState {
     public SdlArtwork getArtwork() {
         return artwork;
     }
+
+    /**
+     * Used to compile hashcode for SoftButtonState for use to compare in equals method
+     * @return Custom hashcode of SoftButtonState variables
+     */
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result += ((getName() == null) ? 0 : Integer.rotateLeft(getName().hashCode(), 1));
+        result += ((getArtwork() == null) ? 0 : Integer.rotateLeft(getArtwork().hashCode(),2));
+        return result;
+    }
+
+    /**
+     * Uses our custom hashCode for SoftButtonState objects
+     * @param o - The object to compare
+     * @return boolean of whether the objects are the same or not
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) return false;
+        // if this is the same memory address, it's the same
+        if (this == o) return true;
+        // if this is not an instance of SoftButtonState, not the same
+        if (!(o instanceof SoftButtonState)) return false;
+        // return comparison
+        return hashCode() == o.hashCode();
+    }
 }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/ChoiceCell.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/ChoiceCell.java
@@ -225,7 +225,7 @@ public class ChoiceCell {
         result += ((getSecondaryText() == null) ? 0 : Integer.rotateLeft(getSecondaryText().hashCode(), 2));
         result += ((getTertiaryText() == null) ? 0 : Integer.rotateLeft(getTertiaryText().hashCode(), 3));
         result += ((getArtwork() == null) ? 0 : Integer.rotateLeft(getArtwork().hashCode(), 4));
-        result += ((getSecondaryArtwork() == null || getSecondaryArtwork().getName() == null) ? 0 : Integer.rotateLeft(getSecondaryArtwork().getName().hashCode(), 5));
+        result += ((getSecondaryArtwork() == null) ? 0 : Integer.rotateLeft(getSecondaryArtwork().hashCode(), 5));
         result += ((getVoiceCommands() == null) ? 0 : Integer.rotateLeft(getVoiceCommands().hashCode(), 6));
         return result;
     }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/ChoiceCell.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/ChoiceCell.java
@@ -224,7 +224,7 @@ public class ChoiceCell {
         result += ((getText() == null) ? 0 : Integer.rotateLeft(getText().hashCode(), 1));
         result += ((getSecondaryText() == null) ? 0 : Integer.rotateLeft(getSecondaryText().hashCode(), 2));
         result += ((getTertiaryText() == null) ? 0 : Integer.rotateLeft(getTertiaryText().hashCode(), 3));
-        result += Integer.rotateLeft(getArtwork().hashCode(), 4);
+        result += ((getArtwork() == null) ? 0 : Integer.rotateLeft(getArtwork().hashCode(), 4));
         result += ((getSecondaryArtwork() == null || getSecondaryArtwork().getName() == null) ? 0 : Integer.rotateLeft(getSecondaryArtwork().getName().hashCode(), 5));
         result += ((getVoiceCommands() == null) ? 0 : Integer.rotateLeft(getVoiceCommands().hashCode(), 6));
         return result;

--- a/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/ChoiceCell.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/ChoiceCell.java
@@ -224,7 +224,7 @@ public class ChoiceCell {
         result += ((getText() == null) ? 0 : Integer.rotateLeft(getText().hashCode(), 1));
         result += ((getSecondaryText() == null) ? 0 : Integer.rotateLeft(getSecondaryText().hashCode(), 2));
         result += ((getTertiaryText() == null) ? 0 : Integer.rotateLeft(getTertiaryText().hashCode(), 3));
-        result += ((getArtwork() == null || getArtwork().getName() == null) ? 0 : Integer.rotateLeft(getArtwork().getName().hashCode(), 4));
+        result += Integer.rotateLeft(getArtwork().hashCode(), 4);
         result += ((getSecondaryArtwork() == null || getSecondaryArtwork().getName() == null) ? 0 : Integer.rotateLeft(getSecondaryArtwork().getName().hashCode(), 5));
         result += ((getVoiceCommands() == null) ? 0 : Integer.rotateLeft(getVoiceCommands().hashCode(), 6));
         return result;

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/MenuCell.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/MenuCell.java
@@ -299,7 +299,7 @@ public class MenuCell implements Cloneable{
 	public int hashCode() {
 		int result = 1;
 		result += ((getTitle() == null) ? 0 : Integer.rotateLeft(getTitle().hashCode(), 1));
-		result += Integer.rotateLeft(getIcon().hashCode(), 2);
+		result += ((getIcon() == null) ? 0 : Integer.rotateLeft(getIcon().hashCode(), 2));
 		result += ((getVoiceCommands() == null) ? 0 : Integer.rotateLeft(getVoiceCommands().hashCode(), 3));
 		result += ((getSubCells() == null) ? 0 : Integer.rotateLeft(1, 4));
 		return result;

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/MenuCell.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/MenuCell.java
@@ -299,7 +299,7 @@ public class MenuCell implements Cloneable{
 	public int hashCode() {
 		int result = 1;
 		result += ((getTitle() == null) ? 0 : Integer.rotateLeft(getTitle().hashCode(), 1));
-		result += ((getIcon() == null || getIcon().getName() == null) ? 0 : Integer.rotateLeft(getIcon().getName().hashCode(), 2));
+		result += Integer.rotateLeft(getIcon().hashCode(), 2);
 		result += ((getVoiceCommands() == null) ? 0 : Integer.rotateLeft(getVoiceCommands().hashCode(), 3));
 		result += ((getSubCells() == null) ? 0 : Integer.rotateLeft(1, 4));
 		return result;

--- a/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
@@ -203,4 +203,36 @@ public class SdlFile{
     public void setOverwrite(boolean overwrite) {
         this.overwrite = overwrite;
     }
+
+    /**
+     * Used to compile hashcode for SdlFile for use to compare in equals method
+     * @return Custom hashcode of SdlFile variables
+     */
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result += ((getName() == null) ? 0 : Integer.rotateLeft(getName().hashCode(), 1));
+        result += ((getFilePath() == null) ? 0 : Integer.rotateLeft(getFilePath().hashCode(), 2));
+        result += ((getFileData() == null) ? 0 : Integer.rotateLeft(getFileData().hashCode(), 3));
+        result += ((getType() == null) ? 0 : Integer.rotateLeft(getType().hashCode(), 4));
+        result += ((Boolean.valueOf(isStaticIcon) == null) ? 0 : Integer.rotateLeft(Boolean.valueOf(isStaticIcon).hashCode(), 5));
+        result += ((Boolean.valueOf(isPersistent()) == null) ? 0 : Integer.rotateLeft(Boolean.valueOf(isPersistent()).hashCode(), 6));
+        return result;
+    }
+
+    /**
+     * Uses our custom hashCode for SdlFile objects
+     * @param o - The object to compare
+     * @return boolean of whether the objects are the same or not
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) return false;
+        // if this is the same memory address, it's the same
+        if (this == o) return true;
+        // if this is not an instance of SdlFile, not the same
+        if (!(o instanceof SdlFile)) return false;
+        // return comparison
+        return hashCode() == o.hashCode();
+    }
 }

--- a/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
@@ -215,8 +215,8 @@ public class SdlFile{
         result += ((getFilePath() == null) ? 0 : Integer.rotateLeft(getFilePath().hashCode(), 2));
         result += ((getFileData() == null) ? 0 : Integer.rotateLeft(getFileData().hashCode(), 3));
         result += ((getType() == null) ? 0 : Integer.rotateLeft(getType().hashCode(), 4));
-        result += ((Boolean.valueOf(isStaticIcon) == null) ? 0 : Integer.rotateLeft(Boolean.valueOf(isStaticIcon).hashCode(), 5));
-        result += ((Boolean.valueOf(isPersistent()) == null) ? 0 : Integer.rotateLeft(Boolean.valueOf(isPersistent()).hashCode(), 6));
+        result += Integer.rotateLeft(Boolean.valueOf(isStaticIcon()).hashCode(), 5);
+        result += Integer.rotateLeft(Boolean.valueOf(isPersistent()).hashCode(), 6);
         return result;
     }
 


### PR DESCRIPTION
Fixes # 1257

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [X] I have tested Android, Java SE, and Java EE

#### Unit Tests
Added testSoftButtonEq() and testSoftButtonStateEq() to SoftButtonManagerTests and testSdlFIleEq() to FileManagerTest

#### Core Tests
Tested using manticore

### Summary
Added a method in SdlFile in android and JavaSE, softButtonObjects, and SoftButtonState that overrides their equals methods. The new equals methods compare the objects variables instead of their memory address.


##### Enhancements
*  Added a method in softButtonObjects that overrides its equals method. 
*  Added a method in softButtonState that overrides its equals method. 
*  Added a method in SdlFile that overrides its equals method for android and JavaSE. 

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
