### PR TITLE
Refactor router service's exitForeground logic

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1519,11 +1519,15 @@ public class SdlRouterService extends Service{
 		synchronized (NOTIFICATION_LOCK) {
 			if (isForeground && !isPrimaryTransportConnected()) {	//Ensure that the service is in the foreground and no longer connected to a transport
 				DebugTool.logInfo("SdlRouterService to exit foreground");
-				this.stopForeground(false); //false is used because some phones have issues when trying to clear the notification at the same time
+				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+					this.stopForeground(Service.STOP_FOREGROUND_DETACH);
+				}else{
+					stopForeground(false);
+				}
 				NotificationManager notificationManager = (NotificationManager)getSystemService(Context.NOTIFICATION_SERVICE);
 				if (notificationManager!= null){
 					try {
-						notificationManager.cancel(FOREGROUND_SERVICE_ID);
+						notificationManager.cancelAll();
 						if( Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
 							notificationManager.deleteNotificationChannel(SDL_NOTIFICATION_CHANNEL_ID);
 						}

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1517,26 +1517,17 @@ public class SdlRouterService extends Service{
 	private void exitForeground(){
 		synchronized (NOTIFICATION_LOCK) {
 			if (isForeground && !isPrimaryTransportConnected()) {	//Ensure that the service is in the foreground and no longer connected to a transport
-				this.stopForeground(true);
+				DebugTool.logInfo("SdlRouterService to exit foreground");
+				this.stopForeground(false); //false is used because some phones have issues when trying to clear the notification at the same time
 				NotificationManager notificationManager = (NotificationManager)getSystemService(Context.NOTIFICATION_SERVICE);
-				if (notificationManager!= null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+				if (notificationManager!= null){
 					try {
-						boolean notificationHasDisplayed = false;
-						StatusBarNotification[] notifications = notificationManager.getActiveNotifications();
-						for (StatusBarNotification notification : notifications) {
-							if(notification != null && FOREGROUND_SERVICE_ID == notification.getId()){
-								DebugTool.logInfo("Service notification is being displayed");
-								notificationHasDisplayed = true;
-								break;
-							}
-						}
-						if (notificationHasDisplayed) {
+						notificationManager.cancel(FOREGROUND_SERVICE_ID);
+						if( Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
 							notificationManager.deleteNotificationChannel(SDL_NOTIFICATION_CHANNEL_ID);
 						}
-						//else leave the notification channel alone to avoid deleting it before the
-						//foreground service notification has a chance to be displayed.
-					} catch (Exception e){
-						DebugTool.logError("Issue when deleting notification channel", e);
+					} catch (Exception e) {
+						DebugTool.logError("Issue when removing notification and channel", e);
 					}
 				}
 				isForeground = false;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1344,6 +1344,7 @@ public class SdlRouterService extends Service{
 				// If this is the first time the service has ever connected to this device we want
 				// to ensure we have a record of it
 				setSDLConnectedStatus(address, false);
+				return FOREGROUND_TIMEOUT;
 			}
 		}
 		// If this is a new device or hasn't connected through SDL we want to limit the exposure


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [-] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [-] I have tested Android, Java SE, and Java EE
    - I have only tested with Android as it is the only affected platform for these changes.

#### Testing Procedure

##### Prerequisites:

- Bluetooth adapter should be on.
- Bluetooth headset that does not support SDL should already be paired but not currently connected.
- IVI system that supports SDL should already be paired but not currently connected.
- Create a signing config for the hello_sdl_android app

##### Steps:

1. Install hello_sdl_android with a release build selected (eg multi_sec_offRelease) 
2. Go to Settings -> Apps & notifications (or similar) and select "Hello SDL Android"
3. Fore Stop the app, go to "Storage & Cache" and select "Clear Storage"
4. Go to Settings -> Apps & notifications (or similar) and select "See all # apps"
5. Press the three dot menu icon and select "Reset app preferences"
6. Manually open ""Hello SDL Android"
7. Connect bluetooth device and observe proper behavior.

##### Proper Behavior:

1. If this is the first time the router service is being started for the given bluetooth device, the notification should appear for ~10 seconds. Based on if the device connects or not will determine if the notification is cleared or updated after this time.
2. If the router service has been started for a connection with this bluetooth device previously and had a successful SDL connection established the notification will appear for ~20 seconds.  Based on if the device connects or not will determine if the notification is cleared or updated after this time.
3. If the router service has been started for a connection with this bluetooth device previously and has *NOT* had a successful SDL connection established the notification will not appear. It was previously created and cleared so a notification tracker will pick it up.  If the device does connect using the SDL UUID a notification will appear at that time.

#### Current Results

Phone Model | Android Version | Build | Behavior 1 | Behavior 2 | Behavior 3
--------------|-----------------|------|--------------| - | -
Pixel 2 XL       | 10 | QQ2A.200305.002 | Success | [Awaiting results ] | Success
Pixel 3 XL       | 10 | QQ2A.200305.002 | Success | [Awaiting results ] |Success
Pixel 4 XL       | 10 | QQ2A.200305.003 | Success | [Awaiting results ] | Success
Note 10         | 10 | QP1A.190711.020<br>N970U1UES2BTA1 | Success | [Awaiting results ] | Success
Galaxy S9     | 9 | PPR1.180610.011<br>G960USQS3CSAG| Success | [Awaiting results ] | Success
ZTE Blade <br> Max Z982  | 7.1.1 |  | Success* | [Awaiting results ] | Success*
Samsung Note 8       | 8.0 |  | Success | [Awaiting results ] | Success
LG Stylo 5       | 9 |  | Success | [Awaiting results ] | Success
Nexus 5  | 6.0.1 |  | Success* | [Awaiting results ] | Success*
Nexus 6P  | 7.1.2 |  | Success* | [Awaiting results ] | Success*

*Notification should never be displayed in these cases as they are below the required Android OS version to need the foreground service mechanism. 

### Summary
- Remove previously implemented but not released logic check of using `notificationManager.getActiveNotifications()` to determine if the notification channel needed to be deleted. The behavior of this method was different between debug and release builds. This is not documented in the Android guides. Instead the notification channel will always try to be deleted if the OS version supports it.
- Change `this.stopForeground(true);` to  this.stopForeground(Service.STOP_FOREGROUND_DETACH) for API levels where it is available otherwise `this.stopForeground(false);`. On some devices using a `true` value prevented the notification from being cleared. This is not documented in the Android guides but was easily observable.
- Because of the previous change a call to `notificationManager.cancelAll();` was added. This will manually remove the notification. Some devices required this call along with the notification channel being deleted.

### Changelog

##### Bug Fixes
* Based on testing the new logic handles the majority of corner cases between devices so that the notification is properly cleared when requested to do so.

### Tasks Remaining:
- [x] Fix notification not being cleared when requested.
- [x] Fix issue were router service immediately exits foreground even on first connect with a bluetooth device.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
