### PR TITLE
Bugfix/issue 1282

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/video/VideoStreamManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/video/VideoStreamManagerTests.java
@@ -19,8 +19,11 @@ import com.smartdevicelink.proxy.interfaces.OnSystemCapabilityListener;
 import com.smartdevicelink.proxy.rpc.ImageResolution;
 import com.smartdevicelink.proxy.rpc.OnHMIStatus;
 import com.smartdevicelink.proxy.rpc.OnTouchEvent;
+import com.smartdevicelink.proxy.rpc.RegisterAppInterface;
+import com.smartdevicelink.proxy.rpc.RegisterAppInterfaceResponse;
 import com.smartdevicelink.proxy.rpc.TouchCoord;
 import com.smartdevicelink.proxy.rpc.TouchEvent;
+import com.smartdevicelink.proxy.rpc.VehicleType;
 import com.smartdevicelink.proxy.rpc.enums.HMILevel;
 import com.smartdevicelink.proxy.rpc.enums.SystemCapabilityType;
 import com.smartdevicelink.proxy.rpc.enums.TouchType;
@@ -99,6 +102,12 @@ public class VideoStreamManagerTests extends AndroidTestCase2 {
 		ISdl internalInterface = mock(ISdl.class);
 		when(internalInterface.getProtocolVersion()).thenReturn(new Version(5,1,0));
 
+		RegisterAppInterfaceResponse mockRegisterAppInterfaceResponse = new RegisterAppInterfaceResponse();
+		VehicleType mockVehicleType = new VehicleType();
+		mockVehicleType.setMake("Ford");
+		mockRegisterAppInterfaceResponse.setVehicleType(mockVehicleType);
+		when(internalInterface.getRegisterAppInterfaceResponse()).thenReturn(mockRegisterAppInterfaceResponse);
+
 		Answer<Void> onAddServiceListener = new Answer<Void>() {
 			@Override
 			public Void answer(InvocationOnMock invocation) {
@@ -126,6 +135,13 @@ public class VideoStreamManagerTests extends AndroidTestCase2 {
 		final ISdl internalInterface = mock(ISdl.class);
 
 		when(internalInterface.getProtocolVersion()).thenReturn((new Version(5,0,0)));
+
+		RegisterAppInterfaceResponse mockRegisterAppInterfaceResponse = new RegisterAppInterfaceResponse();
+		VehicleType mockVehicleType = new VehicleType();
+		mockVehicleType.setMake("Ford");
+		mockRegisterAppInterfaceResponse.setVehicleType(mockVehicleType);
+		when(internalInterface.getRegisterAppInterfaceResponse()).thenReturn(mockRegisterAppInterfaceResponse);
+
 		when(internalInterface.isCapabilitySupported(SystemCapabilityType.VIDEO_STREAMING)).thenReturn(true);
 
 		final VideoStreamManager videoStreamManager = new VideoStreamManager(internalInterface);
@@ -142,6 +158,12 @@ public class VideoStreamManagerTests extends AndroidTestCase2 {
 
 	public void testRemoteDisplayStream(){
 		ISdl internalInterface = mock(ISdl.class);
+
+		RegisterAppInterfaceResponse mockRegisterAppInterfaceResponse = new RegisterAppInterfaceResponse();
+		VehicleType mockVehicleType = new VehicleType();
+		mockVehicleType.setMake("Ford");
+		mockRegisterAppInterfaceResponse.setVehicleType(mockVehicleType);
+		when(internalInterface.getRegisterAppInterfaceResponse()).thenReturn(mockRegisterAppInterfaceResponse);
 
 		final Set<Object> listenerSet = new HashSet<>();
 
@@ -252,6 +274,13 @@ public class VideoStreamManagerTests extends AndroidTestCase2 {
 
 	public void testConvertTouchEvent() {
 		ISdl internalInterface = mock(ISdl.class);
+
+		RegisterAppInterfaceResponse mockRegisterAppInterfaceResponse = new RegisterAppInterfaceResponse();
+		VehicleType mockVehicleType = new VehicleType();
+		mockVehicleType.setMake("Ford");
+		mockRegisterAppInterfaceResponse.setVehicleType(mockVehicleType);
+		when(internalInterface.getRegisterAppInterfaceResponse()).thenReturn(mockRegisterAppInterfaceResponse);
+
 		VideoStreamManager videoStreamManager = new VideoStreamManager(internalInterface);
 		List<MotionEvent> motionEventList;
 		long e1TS = 1558124390L, e2TS = 1558125390L, e3TS = 1558126390L;
@@ -466,6 +495,12 @@ public class VideoStreamManagerTests extends AndroidTestCase2 {
 
     private void assertMotionEventWithScale(int width, int height, float scale) {
         ISdl internalInterface = mock(ISdl.class);
+
+		RegisterAppInterfaceResponse mockRegisterAppInterfaceResponse = new RegisterAppInterfaceResponse();
+		VehicleType mockVehicleType = new VehicleType();
+		mockVehicleType.setMake("Ford");
+		mockRegisterAppInterfaceResponse.setVehicleType(mockVehicleType);
+		when(internalInterface.getRegisterAppInterfaceResponse()).thenReturn(mockRegisterAppInterfaceResponse);
 
         // Preferred Resolution capability
         ImageResolution resolution = new ImageResolution(width, height);

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SystemCapabilityManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SystemCapabilityManagerTests.java
@@ -951,6 +951,9 @@ public class SystemCapabilityManagerTests extends AndroidTestCase2 {
 		public void getCapability(SystemCapabilityType systemCapabilityType, OnSystemCapabilityListener scListener) { }
 
 		@Override
+		public RegisterAppInterfaceResponse getRegisterAppInterfaceResponse(){return null;}
+
+		@Override
 		public SdlMsgVersion getSdlMsgVersion(){
 			return null;
 		}

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/streaming/video/VideoStreamingParametersTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/streaming/video/VideoStreamingParametersTest.java
@@ -81,6 +81,66 @@ public class VideoStreamingParametersTest extends AndroidTestCase2 {
         assertEquals(380, height);
     }
 
+    public void testUpdateScale_1_0_Ford_Resolution_800_354() {
+        preferredResolution = new ImageResolution(800, 354);
+
+        capability.setScale(1.0);
+        capability.setPreferredResolution(preferredResolution);
+
+        params.update(capability, "Ford");
+
+        int width = params.getResolution().getResolutionWidth();
+        int height = params.getResolution().getResolutionHeight();
+
+        assertEquals(800, width);
+        assertEquals(354, height);
+    }
+
+    public void testUpdateScale_1_3_Lincoln_Resolution_600_900() {
+        preferredResolution = new ImageResolution(600, 900);
+
+        capability.setScale(1.0);
+        capability.setPreferredResolution(preferredResolution);
+
+        params.update(capability, "Lincoln");
+
+        int width = params.getResolution().getResolutionWidth();
+        int height = params.getResolution().getResolutionHeight();
+
+        assertEquals(450, width);
+        assertEquals(676, height);
+    }
+
+    public void testUpdateScale_1_3_Ford_Resolution_900_600() {
+        preferredResolution = new ImageResolution(900, 600);
+
+        capability.setScale(1.0);
+        capability.setPreferredResolution(preferredResolution);
+
+        params.update(capability, "Ford");
+
+        int width = params.getResolution().getResolutionWidth();
+        int height = params.getResolution().getResolutionHeight();
+
+        assertEquals(676, width);
+        assertEquals(450, height);
+    }
+
+    public void testUpdateScale_1_0_Toyota_Resolution_900_600() {
+        preferredResolution = new ImageResolution(900, 600);
+
+        capability.setScale(1.0);
+        capability.setPreferredResolution(preferredResolution);
+
+        params.update(capability, "Toyota");
+
+        int width = params.getResolution().getResolutionWidth();
+        int height = params.getResolution().getResolutionHeight();
+
+        assertEquals(900, width);
+        assertEquals(600, height);
+    }
+
     public void testUpdateCapabilityFormat(){
         VideoStreamingCapability capability = new VideoStreamingCapability();
         capability.setMaxBitrate(10000);

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -867,6 +867,11 @@ public class SdlManager extends BaseSdlManager{
 		}
 
 		@Override
+		public RegisterAppInterfaceResponse getRegisterAppInterfaceResponse() {
+			return proxy.getRegisterAppInterfaceResponse();
+		}
+
+		@Override
 		public boolean isCapabilitySupported(SystemCapabilityType systemCapabilityType){
 			return proxy.isCapabilitySupported(systemCapabilityType);
 		}

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -60,6 +60,7 @@ import com.smartdevicelink.proxy.rpc.OnHMIStatus;
 import com.smartdevicelink.proxy.rpc.OnTouchEvent;
 import com.smartdevicelink.proxy.rpc.TouchCoord;
 import com.smartdevicelink.proxy.rpc.TouchEvent;
+import com.smartdevicelink.proxy.rpc.VehicleType;
 import com.smartdevicelink.proxy.rpc.VideoStreamingCapability;
 import com.smartdevicelink.proxy.rpc.enums.HMILevel;
 import com.smartdevicelink.proxy.rpc.enums.PredefinedWindows;
@@ -95,7 +96,7 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 	private IVideoStreamListener streamListener;
 	private boolean isTransportAvailable = false;
 	private boolean hasStarted;
-	private String vehicleMake;
+	private String vehicleMake = null;
 
 	// INTERNAL INTERFACES
 
@@ -180,7 +181,9 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 	public VideoStreamManager(ISdl internalInterface){
 		super(internalInterface);
 
-		vehicleMake = internalInterface.getRegisterAppInterfaceResponse().getVehicleType().getMake();
+		if(internalInterface.getRegisterAppInterfaceResponse().getVehicleType() != null) {
+			vehicleMake = internalInterface.getRegisterAppInterfaceResponse().getVehicleType().getMake();
+		}
 		virtualDisplayEncoder = new VirtualDisplayEncoder();
 		hmiLevel = HMILevel.HMI_NONE;
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -95,6 +95,7 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 	private IVideoStreamListener streamListener;
 	private boolean isTransportAvailable = false;
 	private boolean hasStarted;
+	private String vehicleMake;
 
 	// INTERNAL INTERFACES
 
@@ -176,10 +177,10 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 	};
 
 	// MANAGER APIs
-
 	public VideoStreamManager(ISdl internalInterface){
 		super(internalInterface);
 
+		vehicleMake = internalInterface.getRegisterAppInterfaceResponse().getVehicleType().getMake();
 		virtualDisplayEncoder = new VirtualDisplayEncoder();
 		hmiLevel = HMILevel.HMI_NONE;
 
@@ -218,7 +219,7 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 				@Override
 				public void onCapabilityRetrieved(Object capability) {
 					VideoStreamingParameters params = new VideoStreamingParameters();
-					params.update((VideoStreamingCapability)capability);	//Streaming parameters are ready time to stream
+					params.update((VideoStreamingCapability)capability, vehicleMake);	//Streaming parameters are ready time to stream
 					VideoStreamManager.this.parameters = params;
 
 					checkState();
@@ -270,7 +271,7 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 					@Override
 					public void onCapabilityRetrieved(Object capability) {
 						VideoStreamingParameters params = new VideoStreamingParameters();
-						params.update((VideoStreamingCapability)capability);	//Streaming parameters are ready time to stream
+						params.update((VideoStreamingCapability)capability, vehicleMake);	//Streaming parameters are ready time to stream
 						startStreaming(params, encrypted);
 					}
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -445,6 +445,11 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		}
 
 		@Override
+		public RegisterAppInterfaceResponse getRegisterAppInterfaceResponse() {
+			return SdlProxyBase.this.getRegisterAppInterfaceResponse();
+		}
+
+		@Override
 		public void getCapability(SystemCapabilityType systemCapabilityType, OnSystemCapabilityListener scListener) {
 			SdlProxyBase.this.getCapability(systemCapabilityType, scListener);
 		}

--- a/base/src/main/java/com/smartdevicelink/proxy/interfaces/ISdl.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/interfaces/ISdl.java
@@ -6,6 +6,7 @@ import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.protocol.enums.SessionType;
 import com.smartdevicelink.proxy.RPCMessage;
 import com.smartdevicelink.proxy.RPCRequest;
+import com.smartdevicelink.proxy.rpc.RegisterAppInterfaceResponse;
 import com.smartdevicelink.proxy.rpc.SdlMsgVersion;
 import com.smartdevicelink.proxy.rpc.enums.SystemCapabilityType;
 import com.smartdevicelink.proxy.rpc.listeners.OnMultipleRequestListener;
@@ -217,6 +218,12 @@ public interface ISdl {
      *                   will be called immediately
      */
     void getCapability(SystemCapabilityType systemCapabilityType, OnSystemCapabilityListener scListener);
+
+    /**
+     * Get RegisterAppInterfaceResponse
+     * @return the RegisterAppInterfaceResponse if available, null if not
+     */
+    RegisterAppInterfaceResponse getRegisterAppInterfaceResponse();
 
     /**
      * Check if capability is supported

--- a/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
+++ b/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
@@ -142,8 +142,10 @@ public class VideoStreamingParameters {
         ImageResolution resolution = capability.getPreferredResolution();
         if(resolution!=null){
 
-            if((vehicleMake.contains("Ford") || vehicleMake.contains("Lincoln")) && ((resolution.getResolutionHeight()!=null && resolution.getResolutionHeight() > 800) || (resolution.getResolutionWidth() !=null && resolution.getResolutionWidth() > 800))) {
-                scale = 1.0 / 0.75;
+            if (vehicleMake != null) {
+                if ((vehicleMake.contains("Ford") || vehicleMake.contains("Lincoln")) && ((resolution.getResolutionHeight() != null && resolution.getResolutionHeight() > 800) || (resolution.getResolutionWidth() != null && resolution.getResolutionWidth() > 800))) {
+                    scale = 1.0 / 0.75;
+                }
             }
 
             if(resolution.getResolutionHeight()!=null && resolution.getResolutionHeight() > 0){ this.resolution.setResolutionHeight((int)(resolution.getResolutionHeight() / scale)); }

--- a/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
+++ b/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
@@ -134,6 +134,48 @@ public class VideoStreamingParameters {
      * @see com.smartdevicelink.proxy.SystemCapabilityManager
      * @see VideoStreamingCapability
      */
+    public void update(VideoStreamingCapability capability, String vehicleMake){
+        if(capability.getMaxBitrate()!=null){ this.bitrate = capability.getMaxBitrate() * 1000; } // NOTE: the unit of maxBitrate in getSystemCapability is kbps.
+        double scale = DEFAULT_SCALE;
+        if(capability.getScale() != null) { scale = capability.getScale(); }
+        ImageResolution resolution = capability.getPreferredResolution();
+        if(resolution!=null){
+
+            if((vehicleMake.contains("Ford") || vehicleMake.contains("Lincoln")) && ((resolution.getResolutionHeight()!=null && resolution.getResolutionHeight() > 800) || (resolution.getResolutionWidth() !=null && resolution.getResolutionWidth() > 800))) {
+                scale = 1.0 / 0.75;
+            }
+
+            if(resolution.getResolutionHeight()!=null && resolution.getResolutionHeight() > 0){ this.resolution.setResolutionHeight((int)(resolution.getResolutionHeight() / scale)); }
+            if(resolution.getResolutionWidth()!=null && resolution.getResolutionWidth() > 0){ this.resolution.setResolutionWidth((int)(resolution.getResolutionWidth() / scale)); }
+        }
+
+        // This should be the last call as it will return out once a suitable format is found
+        final List<VideoStreamingFormat> formats = capability.getSupportedFormats();
+        if(formats != null && formats.size()>0){
+            for(VideoStreamingFormat format : formats){
+                for(int i = 0; i < CURRENTLY_SUPPORTED_FORMATS.length; i ++){
+                    if(CURRENTLY_SUPPORTED_FORMATS[i].equals(format) ){
+                        this.format = format;
+                        return;
+                    }
+                }
+            }
+            DebugTool.logWarning("The VideoStreamingFormat has not been updated because none of the provided formats are supported.");
+
+            //TODO In the future we should set format to null, but might be a breaking change
+            // For now, format will remain whatever was set prior to this update
+        }
+
+    }
+
+    /**
+     * Update the values contained in the capability that should have been returned through the SystemCapabilityManager.
+     * This update will use the most preferred streaming format from the module.
+     * @param capability the video streaming capability returned from the SystemCapabilityManager
+     * @see com.smartdevicelink.proxy.SystemCapabilityManager
+     * @see VideoStreamingCapability
+     */
+    @Deprecated
     public void update(VideoStreamingCapability capability){
         if(capability.getMaxBitrate()!=null){ this.bitrate = capability.getMaxBitrate() * 1000; } // NOTE: the unit of maxBitrate in getSystemCapability is kbps.
         double scale = DEFAULT_SCALE;

--- a/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
+++ b/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
@@ -131,6 +131,7 @@ public class VideoStreamingParameters {
      * Update the values contained in the capability that should have been returned through the SystemCapabilityManager.
      * This update will use the most preferred streaming format from the module.
      * @param capability the video streaming capability returned from the SystemCapabilityManager
+     * @param vehicleMake the vehicle make from the RegisterAppInterfaceResponse
      * @see com.smartdevicelink.proxy.SystemCapabilityManager
      * @see VideoStreamingCapability
      */

--- a/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -1146,6 +1146,11 @@ public class LifecycleManager extends BaseLifecycleManager {
         }
 
         @Override
+        public RegisterAppInterfaceResponse getRegisterAppInterfaceResponse() {
+            return raiResponse;
+        }
+
+        @Override
         public boolean isCapabilitySupported(SystemCapabilityType systemCapabilityType) {
             return LifecycleManager.this.systemCapabilityManager.isCapabilitySupported(systemCapabilityType);
         }


### PR DESCRIPTION
Fixes #1282 

This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
- Tested to ensure video streaming still behaves as expected on SYNC 3
- Need Ford to test to ensure issue is resolved on High Res Ford/Lincoln 

#### Unit Tests
Added unit tests to ensure scaling is set appropriately for high and low red displays as well as Ford/Lincoln vs other vehicle makes

### Summary
ISdl now has a getRegisterAppInterfaceResponse Method so we can access the response in the manager classes, this allows us to pass the vehicle make to the VideoStreamingParameters.

This required a change to the VideoStreamingParameters.update API, The original api has been depricated and the updated API has been implemented
