### PR TITLE
Bugfix/issue 1339

### DIFF
--- a/base/src/main/java/com/smartdevicelink/transport/WebSocketServer.java
+++ b/base/src/main/java/com/smartdevicelink/transport/WebSocketServer.java
@@ -80,7 +80,7 @@ public class WebSocketServer extends org.java_websocket.server.WebSocketServer i
     @Override
     public void stop(){
         try {
-            super.stop(500);
+            this.stop(500);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/base/src/main/java/com/smartdevicelink/transport/WebSocketServer.java
+++ b/base/src/main/java/com/smartdevicelink/transport/WebSocketServer.java
@@ -80,7 +80,7 @@ public class WebSocketServer extends org.java_websocket.server.WebSocketServer i
     @Override
     public void stop(){
         try {
-            this.stop(500);
+            super.stop(500);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -90,7 +90,6 @@ import java.util.Vector;
  * 4. Helper methods
  */
 public class SdlManager extends BaseSdlManager{
-
 	private static final String TAG = "SdlManager";
 
 	private SdlArtwork appIcon;
@@ -105,14 +104,12 @@ public class SdlManager extends BaseSdlManager{
 	private FileManager fileManager;
     private ScreenManager screenManager;
 
-
 	// INTERNAL INTERFACE
 	/**
 	 * This is from the LifeCycleManager directly. In the future if there is a reason to be a man in the middle
 	 * the SdlManager could create it's own, however right now it was only a duplication of logic tied to the LCM.
 	 */
 	private ISdl _internalInterface;
-
 
 	// Initialize proxyBridge with anonymous lifecycleListener
 	private final LifecycleManager.LifecycleListener lifecycleListener = new LifecycleManager.LifecycleListener() {
@@ -524,6 +521,14 @@ public class SdlManager extends BaseSdlManager{
 	@SuppressWarnings("unchecked")
 	@Override
 	public void start(){
+
+		Runtime.getRuntime().addShutdownHook(new Thread() {
+			@Override
+			public void run() {
+				dispose();
+			}
+		});
+
 		Log.i(TAG, "start");
 		if (lifecycleManager == null) {
 			if (transport != null

--- a/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -92,6 +92,7 @@ import java.util.Vector;
 public class SdlManager extends BaseSdlManager{
 	private static final String TAG = "SdlManager";
 
+
 	private SdlArtwork appIcon;
 	private SdlManagerListener managerListener;
 	private List<Class<? extends SdlSecurityBase>> sdlSecList;
@@ -104,6 +105,7 @@ public class SdlManager extends BaseSdlManager{
 	private FileManager fileManager;
     private ScreenManager screenManager;
 
+
 	// INTERNAL INTERFACE
 	/**
 	 * This is from the LifeCycleManager directly. In the future if there is a reason to be a man in the middle
@@ -111,6 +113,7 @@ public class SdlManager extends BaseSdlManager{
 	 */
 	private ISdl _internalInterface;
 
+	
 	// Initialize proxyBridge with anonymous lifecycleListener
 	private final LifecycleManager.LifecycleListener lifecycleListener = new LifecycleManager.LifecycleListener() {
 		boolean initStarted = false;

--- a/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -90,8 +90,8 @@ import java.util.Vector;
  * 4. Helper methods
  */
 public class SdlManager extends BaseSdlManager{
-	private static final String TAG = "SdlManager";
 
+	private static final String TAG = "SdlManager";
 
 	private SdlArtwork appIcon;
 	private SdlManagerListener managerListener;
@@ -113,7 +113,7 @@ public class SdlManager extends BaseSdlManager{
 	 */
 	private ISdl _internalInterface;
 
-	
+
 	// Initialize proxyBridge with anonymous lifecycleListener
 	private final LifecycleManager.LifecycleListener lifecycleListener = new LifecycleManager.LifecycleListener() {
 		boolean initStarted = false;


### PR DESCRIPTION
Fixes #1339 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

### Testing Steps
1. Run a JavaSE application connecting to any available port
2. Stop the application
3. Run the JavaSE application trying to connect to the same port
4. The port should be available and the applicaiton should be able to connect

### Summary
This will add a shutdownhook to the start method of SDLManager, when the application is shutdown the hook will then call SDLManager.dispose() which will dispose the PermissionManager, FileManager, ScreenManager, and LifecycleManager. The LifeCycle Manager in turn will eventually call the stop method of the WebSocketServer which will free the Port the WebApp is using

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
