### PR TITLE
Fix OnButtonPress's CustomButtonID getter/setter naming

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/notifications/OnButtonPressTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/notifications/OnButtonPressTests.java
@@ -23,7 +23,7 @@ public class OnButtonPressTests extends BaseRpcTests{
 
         msg.setButtonName(Test.GENERAL_BUTTONNAME);
         msg.setButtonPressMode(Test.GENERAL_BUTTONPRESSMODE);
-        msg.setCustomButtonName(Test.GENERAL_INT);
+        msg.setCustomButtonID(Test.GENERAL_INT);
 
         return msg;
     }
@@ -58,7 +58,7 @@ public class OnButtonPressTests extends BaseRpcTests{
 	 */
     public void testRpcValues () { 
     	// Test Values
-        int customName = ( (OnButtonPress) msg ).getCustomButtonName();
+        int customName = ( (OnButtonPress) msg ).getCustomButtonID();
         ButtonName buttonName = ( (OnButtonPress) msg ).getButtonName();
         ButtonPressMode buttonPressMode = ( (OnButtonPress) msg ).getButtonPressMode();
         
@@ -72,7 +72,7 @@ public class OnButtonPressTests extends BaseRpcTests{
         assertNotNull(Test.NOT_NULL, msg);
         testNullBase(msg);
 
-        assertNull(Test.NULL, msg.getCustomButtonName());
+        assertNull(Test.NULL, msg.getCustomButtonID());
         assertNull(Test.NULL, msg.getButtonName());
         assertNull(Test.NULL, msg.getButtonPressMode());
     }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -4585,7 +4585,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					} else if (notification instanceof OnButtonPress) {
 						OnButtonPress onButtonPress = new OnButtonPress();
 						onButtonPress.setButtonPressMode(((OnButtonPress) notification).getButtonPressMode());
-						onButtonPress.setCustomButtonName(((OnButtonPress) notification).getCustomButtonName());
+						onButtonPress.setCustomButtonID(((OnButtonPress) notification).getCustomButtonID());
 						notification2 = onButtonPress;
 					} else {
 						return null;

--- a/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
@@ -171,7 +171,7 @@ abstract class BaseSoftButtonManager extends BaseSubManager {
             public void onNotified(RPCNotification notification) {
                 OnButtonPress onButtonPress = (OnButtonPress) notification;
                 if (onButtonPress!= null && onButtonPress.getButtonName() == ButtonName.CUSTOM_BUTTON) {
-                    Integer buttonId = onButtonPress.getCustomButtonName();
+                    Integer buttonId = onButtonPress.getCustomButtonID();
                     if (getSoftButtonObjects() != null) {
                         for (SoftButtonObject softButtonObject : getSoftButtonObjects()) {
                             if (softButtonObject.getButtonId() == buttonId && softButtonObject.getOnEventListener() != null) {

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/OnButtonPress.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/OnButtonPress.java
@@ -187,6 +187,7 @@ public class OnButtonPress extends RPCNotification {
     public void setCustomButtonName(Integer customButtonID) {
         setParameters(KEY_CUSTOM_BUTTON_ID, customButtonID);
     }
+
     @Deprecated
     /**
      * @deprecated use {@link #getCustomButtonID()} ()} instead.

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/OnButtonPress.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/OnButtonPress.java
@@ -179,10 +179,37 @@ public class OnButtonPress extends RPCNotification {
     public void setButtonPressMode( @NonNull ButtonPressMode buttonPressMode ) {
         setParameters(KEY_BUTTON_PRESS_MODE, buttonPressMode);
     }
+
+    @Deprecated
+    /**
+    * @deprecated use {@link #setCustomButtonID(Integer)} ()} instead.
+    */
     public void setCustomButtonName(Integer customButtonID) {
         setParameters(KEY_CUSTOM_BUTTON_ID, customButtonID);
     }
+    @Deprecated
+    /**
+     * @deprecated use {@link #getCustomButtonID()} ()} instead.
+    */
     public Integer getCustomButtonName() {
     	return getInteger(KEY_CUSTOM_BUTTON_ID);
+    }
+
+    /**
+     * Set CustomButtonID of the button
+     * If ButtonName is "CUSTOM_BUTTON", this references the integer ID passed by a custom button. (e.g. softButton ID)
+     * @param customButtonID CustomButtonID of the button
+     */
+    public void setCustomButtonID(Integer customButtonID) {
+        setParameters(KEY_CUSTOM_BUTTON_ID, customButtonID);
+    }
+
+    /**
+     * Get CustomButtonID of the button
+     * If ButtonName is "CUSTOM_BUTTON", this references the integer ID passed by a custom button. (e.g. softButton ID)
+     * @return CustomButtonID of the button
+     */
+    public Integer getCustomButtonID() {
+        return getInteger(KEY_CUSTOM_BUTTON_ID);
     }
 }


### PR DESCRIPTION
Fixes #547

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

#### Unit Tests
Updated corresponding `OnButtonPress` tests.

### Summary
This PR updates the names of `setCustomButtonName()` & `getCustomButtonName()` in `OnButtonPress` to match the RPC spec.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
