### PR TITLE
Deprecate internal RPCs

### DIFF
--- a/base/src/main/java/com/smartdevicelink/protocol/enums/FunctionID.java
+++ b/base/src/main/java/com/smartdevicelink/protocol/enums/FunctionID.java
@@ -133,9 +133,13 @@ public enum FunctionID{
     ON_SYSTEM_CAPABILITY_UPDATED(32787, "OnSystemCapabilityUpdated"),
 
     // MOCKED FUNCTIONS (NOT SENT FROM HEAD-UNIT)
+    @Deprecated
     ON_LOCK_SCREEN_STATUS(-1, "OnLockScreenStatus"),
+    @Deprecated
     ON_SDL_CHOICE_CHOSEN(-1, "OnSdlChoiceChosen"),
+    @Deprecated
     ON_STREAM_RPC(-1, "OnStreamRPC"),
+    @Deprecated
     STREAM_RPC(-1, "StreamRPC"),
 
     ;

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/OnLockScreenStatus.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/OnLockScreenStatus.java
@@ -46,6 +46,7 @@ import static com.smartdevicelink.proxy.rpc.OnHMIStatus.KEY_HMI_LEVEL;
  * 
  *
  */
+@Deprecated
 public class OnLockScreenStatus extends RPCNotification {
 	public static final String KEY_DRIVER_DISTRACTION = "driverDistraction";
 	public static final String KEY_SHOW_LOCK_SCREEN = "showLockScreen";

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/OnSdlChoiceChosen.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/OnSdlChoiceChosen.java
@@ -38,7 +38,6 @@ import com.smartdevicelink.proxy.rpc.enums.TriggerSource;
 import java.util.Hashtable;
 import java.util.List;
 
-@Deprecated
 public class OnSdlChoiceChosen extends RPCNotification {
 	public static final String KEY_SDL_CHOICE = "sdlChoice";
 	public static final String KEY_TRIGGER_SOURCE = "triggerSource";

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/OnSdlChoiceChosen.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/OnSdlChoiceChosen.java
@@ -38,6 +38,7 @@ import com.smartdevicelink.proxy.rpc.enums.TriggerSource;
 import java.util.Hashtable;
 import java.util.List;
 
+@Deprecated
 public class OnSdlChoiceChosen extends RPCNotification {
 	public static final String KEY_SDL_CHOICE = "sdlChoice";
 	public static final String KEY_TRIGGER_SOURCE = "triggerSource";

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/OnStreamRPC.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/OnStreamRPC.java
@@ -34,6 +34,7 @@ package com.smartdevicelink.proxy.rpc;
 import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.proxy.RPCNotification;
 
+@Deprecated
 public class OnStreamRPC extends RPCNotification {
 	public static final String KEY_FILENAME = "fileName";
 	public static final String KEY_BYTESCOMPLETE = "bytesComplete";

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/StreamRPCResponse.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/StreamRPCResponse.java
@@ -36,6 +36,7 @@ import com.smartdevicelink.proxy.RPCResponse;
 
 import java.util.Hashtable;
 
+@Deprecated
 public class StreamRPCResponse extends RPCResponse {
 	public static final String KEY_FILENAME = "fileName";
 	public static final String KEY_FILESIZE = "fileSize";


### PR DESCRIPTION
Fixes #14

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Summary
This PR deprecates the following RPCs as they are only used internally and they are not part of the RPC spec:
- `OnLockScreenStatus`
- `OnSdlChoiceChosen`
- `OnStreamRPC`
- `StreamRPCResponse`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
