### PR TITLE
Trigger OnPermissionChangeListener callback with cached value after adding the listener 

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/permission/PermissionManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/permission/PermissionManagerTests.java
@@ -21,8 +21,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import static com.smartdevicelink.managers.permission.BasePermissionManager.PERMISSION_GROUP_STATUS_DISALLOWED;
+import static com.smartdevicelink.managers.permission.BasePermissionManager.PERMISSION_GROUP_STATUS_UNKNOWN;
 import static com.smartdevicelink.managers.permission.PermissionManager.PERMISSION_GROUP_STATUS_ALLOWED;
 import static com.smartdevicelink.managers.permission.PermissionManager.PERMISSION_GROUP_STATUS_MIXED;
+import static junit.framework.TestCase.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -38,6 +41,7 @@ public class PermissionManagerTests extends AndroidTestCase2 {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
+
 
         // Mock Isdl and its behaviour to use it for PermissionManager testing
         ISdl internalInterface = mock(ISdl.class);
@@ -106,7 +110,7 @@ public class PermissionManagerTests extends AndroidTestCase2 {
             @Override
             public void onPermissionsChange(@NonNull Map<FunctionID, PermissionStatus> allowedPermissions, @NonNull int permissionGroupStatus) {
             // Make sure is the actual result matches the expected one
-            assertEquals(permissionGroupStatus, PERMISSION_GROUP_STATUS_ALLOWED);
+            assertEquals(PERMISSION_GROUP_STATUS_ALLOWED, permissionGroupStatus);
             assertTrue(allowedPermissions.get(FunctionID.SHOW).getIsRPCAllowed());
             assertTrue(allowedPermissions.get(FunctionID.GET_VEHICLE_DATA).getIsRPCAllowed());
             assertTrue(allowedPermissions.get(FunctionID.GET_VEHICLE_DATA).getAllowedParameters().get("rpm"));
@@ -140,13 +144,18 @@ public class PermissionManagerTests extends AndroidTestCase2 {
 
 
         // Make sure the listener is called exactly once
-        assertEquals("Listener was not called or called more/less frequently than expected", listenerCalledCounter, 1);
+        assertEquals("Listener was not called or called more/less frequently than expected", 1, listenerCalledCounter);
     }
 
 
     // Test adding a listener to be called when ANY of the specified permissions become allowed
     public void testListenersAnyAllowed() {
         listenerCalledCounter = 0;
+
+
+        // Emulate Core's behaviour by sending OnHMIStatus notification
+        sendFakeCoreOnHMIStatusNotifications(HMILevel.HMI_NONE);
+
 
         // Test how developers can add listeners through PermissionManager
         List<PermissionElement> permissionElements = new ArrayList<>();
@@ -157,13 +166,19 @@ public class PermissionManagerTests extends AndroidTestCase2 {
             public void onPermissionsChange(@NonNull Map<FunctionID, PermissionStatus> allowedPermissions, @NonNull int permissionGroupStatus) {
                 // Make sure is the actual result matches the expected one
                 if (listenerCalledCounter == 0) { // Listener called for the first time
-                    assertEquals(permissionGroupStatus, PERMISSION_GROUP_STATUS_MIXED);
+                    assertEquals(PERMISSION_GROUP_STATUS_DISALLOWED, permissionGroupStatus);
+                    assertFalse(allowedPermissions.get(FunctionID.SHOW).getIsRPCAllowed());
+                    assertFalse(allowedPermissions.get(FunctionID.GET_VEHICLE_DATA).getIsRPCAllowed());
+                    assertFalse(allowedPermissions.get(FunctionID.GET_VEHICLE_DATA).getAllowedParameters().get("rpm"));
+                    assertFalse(allowedPermissions.get(FunctionID.GET_VEHICLE_DATA).getAllowedParameters().get("airbagStatus"));
+                } else if (listenerCalledCounter == 1) { // Listener called for the first time
+                    assertEquals(PERMISSION_GROUP_STATUS_MIXED, permissionGroupStatus);
                     assertTrue(allowedPermissions.get(FunctionID.SHOW).getIsRPCAllowed());
-                    assertTrue(!allowedPermissions.get(FunctionID.GET_VEHICLE_DATA).getIsRPCAllowed());
-                    assertTrue(!allowedPermissions.get(FunctionID.GET_VEHICLE_DATA).getAllowedParameters().get("rpm"));
-                    assertTrue(!allowedPermissions.get(FunctionID.GET_VEHICLE_DATA).getAllowedParameters().get("airbagStatus"));
-                } else if (listenerCalledCounter == 1) {  // Listener called for the second time
-                    assertEquals(permissionGroupStatus, PERMISSION_GROUP_STATUS_ALLOWED);
+                    assertFalse(allowedPermissions.get(FunctionID.GET_VEHICLE_DATA).getIsRPCAllowed());
+                    assertFalse(allowedPermissions.get(FunctionID.GET_VEHICLE_DATA).getAllowedParameters().get("rpm"));
+                    assertFalse(allowedPermissions.get(FunctionID.GET_VEHICLE_DATA).getAllowedParameters().get("airbagStatus"));
+                } else if (listenerCalledCounter == 2) {  // Listener called for the third time
+                    assertEquals(PERMISSION_GROUP_STATUS_ALLOWED, permissionGroupStatus);
                     assertTrue(allowedPermissions.get(FunctionID.SHOW).getIsRPCAllowed());
                     assertTrue(allowedPermissions.get(FunctionID.GET_VEHICLE_DATA).getIsRPCAllowed());
                     assertTrue(allowedPermissions.get(FunctionID.GET_VEHICLE_DATA).getAllowedParameters().get("rpm"));
@@ -198,6 +213,6 @@ public class PermissionManagerTests extends AndroidTestCase2 {
 
 
         // Make sure the the listener is called exactly twice
-        assertEquals("Listener was not called or called more/less frequently than expected", listenerCalledCounter, 2);
+        assertEquals("Listener was not called or called more/less frequently than expected", 3, listenerCalledCounter);
     }
 }

--- a/base/src/main/java/com/smartdevicelink/managers/permission/BasePermissionManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/permission/BasePermissionManager.java
@@ -402,6 +402,9 @@ abstract class BasePermissionManager extends BaseSubManager{
     public UUID addListener(@NonNull List<PermissionElement> permissionElements, @PermissionGroupType int groupType, @NonNull OnPermissionChangeListener listener){
         PermissionFilter filter = new PermissionFilter(null, permissionElements, groupType, listener);
         filters.add(filter);
+        if (groupType == PERMISSION_GROUP_TYPE_ANY || (groupType == PERMISSION_GROUP_TYPE_ALL_ALLOWED && getGroupStatusOfPermissions(permissionElements) == PERMISSION_GROUP_STATUS_ALLOWED)) {
+            notifyListener(filter);
+        }
         return filter.getIdentifier();
     }
 

--- a/base/src/main/java/com/smartdevicelink/managers/permission/PermissionStatus.java
+++ b/base/src/main/java/com/smartdevicelink/managers/permission/PermissionStatus.java
@@ -96,4 +96,9 @@ public class PermissionStatus {
     protected void setAllowedParameters(Map<String, Boolean> allowedParameters) {
         this.allowedParameters = allowedParameters;
     }
+
+    @Override
+    public String toString() {
+        return "rpcName: " + rpcName + ", allowed: " + isRPCAllowed + ", allowedParameters: " + allowedParameters;
+    }
 }


### PR DESCRIPTION
Fixes #1353

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Updated permission manager unit tests to reflect the new changes.

#### Core Tests
1. Run the app and connect to Manticore
2. Add an `OnPermissionChangeListener` for the `GetWayPoints` RPC
3. Confirm listener is triggered 

### Summary
This PR fixes an issue in `PermissionManager` where it doesn't trigger the listener with the cached value after adding the listener. This means the listener was not getting triggered if the permission change happened before adding the listener. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
