### PR TITLE
Revert "Bugfix/issue_1343 foreground permissions exception"

### DIFF
--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
@@ -7,7 +7,6 @@ import android.util.Log;
 
 import com.smartdevicelink.transport.SdlBroadcastReceiver;
 import com.smartdevicelink.transport.SdlRouterService;
-import com.smartdevicelink.util.AndroidTools;
 
 public class SdlReceiver  extends SdlBroadcastReceiver {
 	private static final String TAG = "SdlBroadcastReciever";
@@ -21,7 +20,7 @@ public class SdlReceiver  extends SdlBroadcastReceiver {
 		// This will prevent apps in the background from crashing when they try to start SdlService
 		// Because Android O doesn't allow background apps to start background services
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-			AndroidTools.safeStartForegroundService(context, intent);
+			context.startForegroundService(intent);
 		} else {
 			context.startService(intent);
 		}

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -255,7 +255,7 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 								serviceIntent.putExtra(FOREGROUND_EXTRA, true);
 								DebugTool.logInfo("Attempting to startForegroundService - " + System.currentTimeMillis());
 								setForegroundExceptionHandler(); //Prevent ANR in case the OS takes too long to start the service
-								AndroidTools.safeStartForegroundService(context, serviceIntent);
+								context.startForegroundService(serviceIntent);
 
 							}
 							//Make sure to send this out for old apps to close down
@@ -383,7 +383,7 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 				intent.putExtra(FOREGROUND_EXTRA, true);
 				DebugTool.logInfo("Attempting to startForegroundService - " + System.currentTimeMillis());
 				setForegroundExceptionHandler(); //Prevent ANR in case the OS takes too long to start the service
-				AndroidTools.safeStartForegroundService(context, intent);
+				context.startForegroundService(intent);
 			}else {
 				context.startService(intent);
 			}

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -69,6 +69,7 @@ import android.os.Parcel;
 import android.os.ParcelFileDescriptor;
 import android.os.Parcelable;
 import android.os.RemoteException;
+import android.service.notification.StatusBarNotification;
 import android.support.annotation.NonNull;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
@@ -1150,7 +1151,7 @@ public class SdlRouterService extends Service{
 						startService(serviceIntent);
 					}else{
 						try{
-							AndroidTools.safeStartForegroundService(this, serviceIntent);
+							startForegroundService(serviceIntent);
 						}catch (Exception e){
 							Log.e(TAG, "Unable to start next SDL router service. " + e.getMessage());
 						}
@@ -1483,7 +1484,6 @@ public class SdlRouterService extends Service{
 				}
 				return;
 			}
-
 			safeStartForeground(FOREGROUND_SERVICE_ID, notification);
 			isForeground = true;
 
@@ -1508,7 +1508,7 @@ public class SdlRouterService extends Service{
 								.setContentText("Service Running");
 				notification = builder.build();
 			}
-			this.startForeground(id, notification);
+			startForeground(id, notification);
 			DebugTool.logInfo("Entered the foreground - " + System.currentTimeMillis());
 		}catch (Exception e){
 			DebugTool.logError("Unable to start service in foreground", e);
@@ -1539,6 +1539,7 @@ public class SdlRouterService extends Service{
 			}
 		}
 	}
+
 
 	/**
 	 * Creates a notification message to attach to the foreground service notification.

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterStatusProvider.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterStatusProvider.java
@@ -134,7 +134,8 @@ public class SdlRouterStatusProvider {
 		}else {
 			bindingIntent.putExtra(FOREGROUND_EXTRA, true);
 			SdlBroadcastReceiver.setForegroundExceptionHandler(); //Prevent ANR in case the OS takes too long to start the service
-			AndroidTools.safeStartForegroundService(context, bindingIntent);
+			context.startForegroundService(bindingIntent);
+
 		}
 		bindingIntent.setAction( TransportConstants.BIND_REQUEST_TYPE_STATUS);
 		return context.bindService(bindingIntent, routerConnection, Context.BIND_AUTO_CREATE);

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/USBAccessoryAttachmentActivity.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/USBAccessoryAttachmentActivity.java
@@ -179,7 +179,7 @@ public class USBAccessoryAttachmentActivity extends Activity {
                             startedService = context.startService(serviceIntent);
                         }else {
                             serviceIntent.putExtra(FOREGROUND_EXTRA, true);
-                            startedService = AndroidTools.safeStartForegroundService(context, serviceIntent);
+                            startedService = context.startForegroundService(serviceIntent);
                         }
 
                         if(startedService == null){

--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
@@ -32,12 +32,10 @@
 
 package com.smartdevicelink.util;
 
-import android.Manifest;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
@@ -46,8 +44,6 @@ import android.content.pm.ServiceInfo;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.BatteryManager;
-import android.os.Build;
-import android.support.annotation.RequiresApi;
 
 import com.smartdevicelink.transport.TransportConstants;
 
@@ -62,7 +58,6 @@ import java.util.HashMap;
 import java.util.List;
 
 public class AndroidTools {
-
 	/**
 	 * Check to see if a component is exported
 	 * @param context object used to retrieve the package manager
@@ -195,30 +190,5 @@ public class AndroidTools {
 		Bitmap result = BitmapFactory.decodeStream(bis);
 		bis.close();
 		return result;
-	}
-
-	/**
-	 * This is a wrapper around the startForegroundService method. In the
-	 * event that the user is on Android 28+ it will check the FOREGROUND_SERVICE permissions
-	 * before trying to call startForegroundService.
-	 * @param context a context instance
-	 * @param intent the foreground service intent
-	 * @return a ComponentName, an identifier for the started service, will return null is service
-	 * was unable to start
-	 */
-	@RequiresApi(api = Build.VERSION_CODES.O)
-	public static ComponentName safeStartForegroundService(Context context, Intent intent) {
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-			boolean inDebugMode = (0 != (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE));
-			boolean permissionGranted = PackageManager.PERMISSION_GRANTED == context.checkPermission(Manifest.permission.FOREGROUND_SERVICE, android.os.Process.myPid(), android.os.Process.myUid());
-			if (inDebugMode || permissionGranted) {
-				return context.startForegroundService(intent);
-			} else {
-				DebugTool.logError("App is missing FOREGROUND_SERVICE Permission. Sdl will not work.");
-			}
-		} else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-			return context.startForegroundService(intent);
-		}
-		return null;
 	}
 }


### PR DESCRIPTION
Reverts smartdevicelink/sdl_java_suite#1347

These changes prevent the excpetion from happing in prodcution. however:
- The solution should try and make SDL work in production by using the next RS
- We should think about what happens when the app that starts the RS has the permission but the app that hosts it doesn't