### PR TITLE
Target SDK 29 and add foregroundServiceType param

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -25,7 +25,7 @@ jobs:
         script: ./android/gradlew -p ./android :sdl_android:connectedCheck
         
     - name: Hello Sdl Android Tests
-      run: ./android/gradlew -p ./android :hello_sdl_android:build
+      run: ./android/gradlew -p ./android/hello_sdl_android test
       
     - name: Sdl JavaSE Tests
       run: ./javaSE/gradlew -p ./javaSE test

--- a/android/hello_sdl_android/build.gradle
+++ b/android/hello_sdl_android/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId "com.sdl.hellosdlandroid"
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/android/hello_sdl_android/build.gradle
+++ b/android/hello_sdl_android/build.gradle
@@ -5,7 +5,7 @@ android {
     defaultConfig {
         applicationId "com.sdl.hellosdlandroid"
         minSdkVersion 14
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/android/hello_sdl_android/src/main/AndroidManifest.xml
+++ b/android/hello_sdl_android/src/main/AndroidManifest.xml
@@ -39,12 +39,15 @@
                 android:resource="@xml/accessory_filter" />
         </activity>
 
-        <service android:name="com.sdl.hellosdlandroid.SdlService" >
+        <service
+            android:name="com.sdl.hellosdlandroid.SdlService"
+            android:foregroundServiceType="connectedDevice">
         </service>
         <service
             android:name=".SdlRouterService"
             android:exported="true"
-            android:process="com.smartdevicelink.router">
+            android:process="com.smartdevicelink.router"
+            android:foregroundServiceType="connectedDevice">
             <intent-filter>
                 <action android:name="com.smartdevicelink.router.service"/>
             </intent-filter>

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlService.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlService.java
@@ -256,7 +256,7 @@ public class SdlService extends Service {
 	 * Send some voice commands
 	 */
 	private void setVoiceCommands(){
-		List<String>
+
 		List<String> list1 = Collections.singletonList("Command One");
 		List<String> list2 = Collections.singletonList("Command two");
 

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlService.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlService.java
@@ -256,7 +256,7 @@ public class SdlService extends Service {
 	 * Send some voice commands
 	 */
 	private void setVoiceCommands(){
-
+		List<String>
 		List<String> list1 = Collections.singletonList("Command One");
 		List<String> list2 = Collections.singletonList("Command two");
 


### PR DESCRIPTION
Fixes #1374 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [X] I have tested Android

#### Core Tests
Ensured HelloSdl is able to run against Core and Manticore using the proposed changes. Also ensured HelloSdl is able to run against Core and Manticore using Android R.

### Summary
This change will set Hello SDL to target Android SDK 29. It will also set the foregroundServiceType to connectedDevice for the SdlService and SdlRouterService in the AndroidManifest File.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)