### PR TITLE
Bugfix/issue 1377 parcelable

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlPacket.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlPacket.java
@@ -3,11 +3,8 @@ package com.smartdevicelink.protocol;
 import android.os.Parcel;
 import android.os.Parcelable;
 
-import com.livio.BSON.BsonEncoder;
 import com.smartdevicelink.transport.utl.TransportRecord;
 import com.smartdevicelink.util.DebugTool;
-
-import java.util.HashMap;
 
 public class SdlPacket extends BaseSdlPacket implements Parcelable {
     private static final int EXTRA_PARCEL_DATA_LENGTH 			= 24;
@@ -115,25 +112,4 @@ public class SdlPacket extends BaseSdlPacket implements Parcelable {
         }
 
     };
-
-    public void putTag(String tag, Object data){
-        if(bsonPayload == null){
-            bsonPayload = new HashMap<>();
-        }
-        bsonPayload.put(tag, data);
-    }
-
-    public Object getTag(String tag){
-        if(payload == null){
-            return null;
-        }else if(bsonPayload == null || bsonPayload.isEmpty()){
-            bsonPayload = BsonEncoder.decodeFromBytes(payload);
-        }
-
-        if(bsonPayload == null){
-            return null;
-        }
-
-        return bsonPayload.get(tag);
-    }
 }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlPacket.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlPacket.java
@@ -1,0 +1,139 @@
+package com.smartdevicelink.protocol;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import com.livio.BSON.BsonEncoder;
+import com.smartdevicelink.transport.utl.TransportRecord;
+import com.smartdevicelink.util.DebugTool;
+
+import java.util.HashMap;
+
+public class SdlPacket extends BaseSdlPacket implements Parcelable {
+    private static final int EXTRA_PARCEL_DATA_LENGTH 			= 24;
+
+    public SdlPacket(int version, boolean encryption, int frameType,
+                         int serviceType, int frameInfo, int sessionId,
+                         int dataSize, int messageId, byte[] payload) {
+        super(version, encryption, frameType, serviceType, frameInfo, sessionId, dataSize, messageId, payload);
+    }
+
+    public SdlPacket(int version, boolean encryption, int frameType,
+                         int serviceType, int frameInfo, int sessionId,
+                         int dataSize, int messageId, byte[] payload, int offset, int bytesToWrite) {
+        super(version, encryption, frameType, serviceType, frameInfo, sessionId, dataSize, messageId, payload, offset, bytesToWrite);
+    }
+
+    protected  SdlPacket() {
+        super();
+    }
+
+    protected SdlPacket(BaseSdlPacket packet) {
+        super(packet);
+    }
+
+    /* ***************************************************************************************************************************************************
+     * ***********************************************************  Parceable Overrides  *****************************************************************
+     *****************************************************************************************************************************************************/
+
+
+
+    //I think this is FIFO...right?
+    public SdlPacket(Parcel p) {
+        this.version = p.readInt();
+        this.encryption = (p.readInt() == 0) ? false : true;
+        this.frameType = p.readInt();
+        this.serviceType = p.readInt();
+        this.frameInfo = p.readInt();
+        this.sessionId = p.readInt();
+        this.dataSize = p.readInt();
+        this.messageId = p.readInt();
+        if(p.readInt() == 1){ //We should have a payload attached
+            payload = new byte[dataSize];
+            p.readByteArray(payload);
+        }
+
+        this.priorityCoefficient = p.readInt();
+
+        if(p.dataAvail() > EXTRA_PARCEL_DATA_LENGTH) {	//See note on constant for why not 0
+            try {
+                messagingVersion = p.readInt();
+                if (messagingVersion >= 2) {
+                    if (p.readInt() == 1) { //We should have a transport type attached
+                        this.transportRecord = (TransportRecord) p.readParcelable(TransportRecord.class.getClassLoader());
+                    }
+                }
+            }catch (RuntimeException e){
+                DebugTool.logError("Error creating packet from parcel", e);
+            }
+        }
+    }
+
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+
+        dest.writeInt(version);
+        dest.writeInt(encryption? 1 : 0);
+        dest.writeInt(frameType);
+        dest.writeInt(serviceType);
+        dest.writeInt(frameInfo);
+        dest.writeInt(sessionId);
+        dest.writeInt(dataSize);
+        dest.writeInt(messageId);
+        dest.writeInt(payload!=null? 1 : 0);
+        if(payload!=null){
+            dest.writeByteArray(payload);
+        }
+        dest.writeInt(priorityCoefficient);
+
+        ///Additions after initial creation
+        if(messagingVersion > 1){
+            dest.writeInt(messagingVersion);
+
+            dest.writeInt(transportRecord!=null? 1 : 0);
+            if(transportRecord != null){
+                dest.writeParcelable(transportRecord,0);
+            }
+        }
+
+    }
+
+    public static final Parcelable.Creator<SdlPacket> CREATOR = new Parcelable.Creator<SdlPacket>() {
+        public SdlPacket createFromParcel(Parcel in) {
+            return new SdlPacket(in);
+        }
+
+        @Override
+        public SdlPacket[] newArray(int size) {
+            return new SdlPacket[size];
+        }
+
+    };
+
+    public void putTag(String tag, Object data){
+        if(bsonPayload == null){
+            bsonPayload = new HashMap<>();
+        }
+        bsonPayload.put(tag, data);
+    }
+
+    public Object getTag(String tag){
+        if(payload == null){
+            return null;
+        }else if(bsonPayload == null || bsonPayload.isEmpty()){
+            bsonPayload = BsonEncoder.decodeFromBytes(payload);
+        }
+
+        if(bsonPayload == null){
+            return null;
+        }
+
+        return bsonPayload.get(tag);
+    }
+}

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/utl/TransportRecord.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/utl/TransportRecord.java
@@ -7,13 +7,12 @@ import com.smartdevicelink.transport.enums.TransportType;
 
 public class TransportRecord extends BaseTransportRecord implements Parcelable {
 
-    private TransportType type;
-    private String address;
-
     public TransportRecord(TransportType transportType, String address) {
         super(transportType, address);
-        this.type = transportType;
-        this.address = address;
+    }
+
+    public TransportRecord(Parcel p) {
+        super(p);
     }
 
     @Override
@@ -36,19 +35,7 @@ public class TransportRecord extends BaseTransportRecord implements Parcelable {
 
     public static final Parcelable.Creator<TransportRecord> CREATOR = new Parcelable.Creator<TransportRecord>() {
         public TransportRecord createFromParcel(Parcel in) {
-            TransportType type = null;
-            String address = "";
-            if (in.readInt() == 1) { //We should have a transport type attached
-                String transportName = in.readString();
-                if(transportName != null){
-                    type = TransportType.valueOf(transportName);
-                }
-            }
-
-            if (in.readInt() == 1) { //We should have a transport address attached
-                address = in.readString();
-            }
-            return new TransportRecord(type, address);
+            return new TransportRecord(in);
         }
 
         @Override

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/utl/TransportRecord.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/utl/TransportRecord.java
@@ -1,0 +1,60 @@
+package com.smartdevicelink.transport.utl;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import com.smartdevicelink.transport.enums.TransportType;
+
+public class TransportRecord extends BaseTransportRecord implements Parcelable {
+
+    private TransportType type;
+    private String address;
+
+    public TransportRecord(TransportType transportType, String address) {
+        super(transportType, address);
+        this.type = transportType;
+        this.address = address;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeInt(type!=null? 1 : 0);
+        if(type != null){
+            dest.writeString(type.name());
+        }
+
+        dest.writeInt(address !=null? 1 : 0);
+        if(address != null){
+            dest.writeString(address);
+        }
+    }
+
+    public static final Parcelable.Creator<TransportRecord> CREATOR = new Parcelable.Creator<TransportRecord>() {
+        public TransportRecord createFromParcel(Parcel in) {
+            TransportType type = null;
+            String address = "";
+            if (in.readInt() == 1) { //We should have a transport type attached
+                String transportName = in.readString();
+                if(transportName != null){
+                    type = TransportType.valueOf(transportName);
+                }
+            }
+
+            if (in.readInt() == 1) { //We should have a transport address attached
+                address = in.readString();
+            }
+            return new TransportRecord(type, address);
+        }
+
+        @Override
+        public TransportRecord[] newArray(int size) {
+            return new TransportRecord[size];
+        }
+
+    };
+}

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/utl/TransportRecord.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/utl/TransportRecord.java
@@ -12,7 +12,16 @@ public class TransportRecord extends BaseTransportRecord implements Parcelable {
     }
 
     public TransportRecord(Parcel p) {
-        super(p);
+        if (p.readInt() == 1) { //We should have a transport type attached
+            String transportName = p.readString();
+            if(transportName != null){
+                this.type = TransportType.valueOf(transportName);
+            }
+        }
+
+        if (p.readInt() == 1) { //We should have a transport address attached
+            address = p.readString();
+        }
     }
 
     @Override

--- a/base/src/main/java/android/os/Parcel.java
+++ b/base/src/main/java/android/os/Parcel.java
@@ -18,6 +18,7 @@
 
 package android.os;
 
+@Deprecated
 public class Parcel {
 
     public void writeInt(int data){

--- a/base/src/main/java/android/os/Parcelable.java
+++ b/base/src/main/java/android/os/Parcelable.java
@@ -17,6 +17,7 @@
  */
 package android.os;
 
+@Deprecated
 public interface Parcelable {
 
     int describeContents();

--- a/base/src/main/java/com/smartdevicelink/protocol/BaseSdlPacket.java
+++ b/base/src/main/java/com/smartdevicelink/protocol/BaseSdlPacket.java
@@ -47,7 +47,7 @@ import java.util.HashMap;
  * Any other binder transactions must include an additional int flag into their bundle or the parsing
  * of this object will fail.
  */
-public class BaseSdlPacket implements Parcelable{
+public class BaseSdlPacket {
 
 	/**
 	 * This is the amount of bytes added to the bundle from the router service for a specific int
@@ -359,92 +359,6 @@ public class BaseSdlPacket implements Parcelable{
 	public void setMessagingVersion(int version){
 		this.messagingVersion = version;
 	}
-	
-	
-	
-	/* ***************************************************************************************************************************************************
-	 * ***********************************************************  Parceable Overrides  *****************************************************************
-	 *****************************************************************************************************************************************************/
-
-
-
-	//I think this is FIFO...right?
-	public BaseSdlPacket(Parcel p) {
-		this.version = p.readInt();
-		this.encryption = (p.readInt() == 0) ? false : true;
-		this.frameType = p.readInt();
-		this.serviceType = p.readInt();
-		this.frameInfo = p.readInt();
-		this.sessionId = p.readInt();
-		this.dataSize = p.readInt();
-		this.messageId = p.readInt();
-		if(p.readInt() == 1){ //We should have a payload attached
-			payload = new byte[dataSize];
-			p.readByteArray(payload);
-		}
-
-		this.priorityCoefficient = p.readInt();
-
-		if(p.dataAvail() > EXTRA_PARCEL_DATA_LENGTH) {	//See note on constant for why not 0
-			try {
-				messagingVersion = p.readInt();
-				if (messagingVersion >= 2) {
-					if (p.readInt() == 1) { //We should have a transport type attached
-						this.transportRecord = (TransportRecord) p.readParcelable(TransportRecord.class.getClassLoader());
-					}
-				}
-			}catch (RuntimeException e){
-				DebugTool.logError("Error creating packet from parcel", e);
-			}
-		}
-	}
-	
-	
-	@Override
-	public int describeContents() {
-		return 0;
-	}
-
-	@Override
-	public void writeToParcel(Parcel dest, int flags) {
-		
-		dest.writeInt(version);
-		dest.writeInt(encryption? 1 : 0);
-		dest.writeInt(frameType);
-		dest.writeInt(serviceType);
-		dest.writeInt(frameInfo);
-		dest.writeInt(sessionId);
-		dest.writeInt(dataSize);
-		dest.writeInt(messageId);
-		dest.writeInt(payload!=null? 1 : 0);
-		if(payload!=null){
-			dest.writeByteArray(payload);
-		}
-		dest.writeInt(priorityCoefficient);
-
-		///Additions after initial creation
-		if(messagingVersion > 1){
-			dest.writeInt(messagingVersion);
-
-			dest.writeInt(transportRecord!=null? 1 : 0);
-			if(transportRecord != null){
-				dest.writeParcelable(transportRecord,0);
-			}
-		}
-
-	}
-	
-	public static final Parcelable.Creator<BaseSdlPacket> CREATOR = new Parcelable.Creator<BaseSdlPacket>() {
-        public BaseSdlPacket createFromParcel(Parcel in) {
-     	   return new BaseSdlPacket(in);
-        }
-
-		@Override
-		public BaseSdlPacket[] newArray(int size) {
-			return new BaseSdlPacket[size];
-		}
-
-    };
 
 	public void putTag(String tag, Object data){
 		if(bsonPayload == null){

--- a/base/src/main/java/com/smartdevicelink/protocol/BaseSdlPacket.java
+++ b/base/src/main/java/com/smartdevicelink/protocol/BaseSdlPacket.java
@@ -47,7 +47,7 @@ import java.util.HashMap;
  * Any other binder transactions must include an additional int flag into their bundle or the parsing
  * of this object will fail.
  */
-public class SdlPacket implements Parcelable{
+public class BaseSdlPacket implements Parcelable{
 
 	/**
 	 * This is the amount of bytes added to the bundle from the router service for a specific int
@@ -122,9 +122,9 @@ public class SdlPacket implements Parcelable{
 	int messagingVersion = 1;
 	TransportRecord transportRecord;
 
-	public SdlPacket(int version, boolean encryption, int frameType,
-			int serviceType, int frameInfo, int sessionId,
-			int dataSize, int messageId, byte[] payload) {
+	public BaseSdlPacket(int version, boolean encryption, int frameType,
+						 int serviceType, int frameInfo, int sessionId,
+						 int dataSize, int messageId, byte[] payload) {
 		this.version = version;
 		this.encryption = encryption;
 		this.frameType = frameType;
@@ -140,9 +140,9 @@ public class SdlPacket implements Parcelable{
 		}
 	}
 
-	public SdlPacket(int version, boolean encryption, int frameType,
-			int serviceType, int frameInfo, int sessionId,
-			int dataSize, int messageId, byte[] payload, int offset,int bytesToWrite) {
+	public BaseSdlPacket(int version, boolean encryption, int frameType,
+						 int serviceType, int frameInfo, int sessionId,
+						 int dataSize, int messageId, byte[] payload, int offset, int bytesToWrite) {
 		this.version = version;
 		this.encryption = encryption;
 		this.frameType = frameType;
@@ -166,7 +166,7 @@ public class SdlPacket implements Parcelable{
 	 * <p>Frame Info
 	 * <p>
 	 */
-	protected SdlPacket(){
+	protected BaseSdlPacket(){
 		//Package only empty constructor
 		this.version = 1;
 		this.encryption = false;
@@ -183,7 +183,7 @@ public class SdlPacket implements Parcelable{
 	 * Creates a new packet based on previous packet definitions. Will not copy payload.
 	 * @param packet an instance of the packet that should be copied.
 	 */
-	protected SdlPacket(SdlPacket packet){
+	protected BaseSdlPacket(BaseSdlPacket packet){
 		this.version = packet.version;
 		this.encryption = packet.encryption;
 		this.frameType = packet.frameType;	
@@ -369,7 +369,7 @@ public class SdlPacket implements Parcelable{
 
 
 	//I think this is FIFO...right?
-	public SdlPacket(Parcel p) {
+	public BaseSdlPacket(Parcel p) {
 		this.version = p.readInt();
 		this.encryption = (p.readInt() == 0) ? false : true;
 		this.frameType = p.readInt();
@@ -434,14 +434,14 @@ public class SdlPacket implements Parcelable{
 
 	}
 	
-	public static final Parcelable.Creator<SdlPacket> CREATOR = new Parcelable.Creator<SdlPacket>() {
-        public SdlPacket createFromParcel(Parcel in) {
-     	   return new SdlPacket(in); 
+	public static final Parcelable.Creator<BaseSdlPacket> CREATOR = new Parcelable.Creator<BaseSdlPacket>() {
+        public BaseSdlPacket createFromParcel(Parcel in) {
+     	   return new BaseSdlPacket(in);
         }
 
 		@Override
-		public SdlPacket[] newArray(int size) {
-			return new SdlPacket[size];
+		public BaseSdlPacket[] newArray(int size) {
+			return new BaseSdlPacket[size];
 		}
 
     };

--- a/base/src/main/java/com/smartdevicelink/protocol/BaseSdlPacket.java
+++ b/base/src/main/java/com/smartdevicelink/protocol/BaseSdlPacket.java
@@ -47,7 +47,7 @@ import java.util.HashMap;
  * Any other binder transactions must include an additional int flag into their bundle or the parsing
  * of this object will fail.
  */
-public class BaseSdlPacket {
+class BaseSdlPacket {
 
 	/**
 	 * This is the amount of bytes added to the bundle from the router service for a specific int
@@ -122,7 +122,7 @@ public class BaseSdlPacket {
 	int messagingVersion = 1;
 	TransportRecord transportRecord;
 
-	public BaseSdlPacket(int version, boolean encryption, int frameType,
+	BaseSdlPacket(int version, boolean encryption, int frameType,
 						 int serviceType, int frameInfo, int sessionId,
 						 int dataSize, int messageId, byte[] payload) {
 		this.version = version;
@@ -140,7 +140,7 @@ public class BaseSdlPacket {
 		}
 	}
 
-	public BaseSdlPacket(int version, boolean encryption, int frameType,
+	BaseSdlPacket(int version, boolean encryption, int frameType,
 						 int serviceType, int frameInfo, int sessionId,
 						 int dataSize, int messageId, byte[] payload, int offset, int bytesToWrite) {
 		this.version = version;

--- a/base/src/main/java/com/smartdevicelink/protocol/BaseSdlPacket.java
+++ b/base/src/main/java/com/smartdevicelink/protocol/BaseSdlPacket.java
@@ -31,13 +31,9 @@
  */
 package com.smartdevicelink.protocol;
 
-import android.os.Parcel;
-import android.os.Parcelable;
-
 import com.livio.BSON.BsonEncoder;
 import com.smartdevicelink.protocol.enums.FrameType;
 import com.smartdevicelink.transport.utl.TransportRecord;
-import com.smartdevicelink.util.DebugTool;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;

--- a/base/src/main/java/com/smartdevicelink/transport/utl/BaseTransportRecord.java
+++ b/base/src/main/java/com/smartdevicelink/transport/utl/BaseTransportRecord.java
@@ -32,13 +32,14 @@
 
 package com.smartdevicelink.transport.utl;
 
-import android.os.Parcel;
 import com.smartdevicelink.transport.enums.TransportType;
 
 class BaseTransportRecord{
 
     protected TransportType type;
     protected String address;
+
+    BaseTransportRecord(){}
 
     BaseTransportRecord(TransportType transportType, String address){
         this.type = transportType;
@@ -77,18 +78,5 @@ class BaseTransportRecord{
         builder.append(" Address: ");
         builder.append(address);
         return builder.toString();
-    }
-
-    BaseTransportRecord(Parcel p) {
-        if (p.readInt() == 1) { //We should have a transport type attached
-            String transportName = p.readString();
-            if(transportName != null){
-                this.type = TransportType.valueOf(transportName);
-            }
-        }
-
-        if (p.readInt() == 1) { //We should have a transport address attached
-            address = p.readString();
-        }
     }
 }

--- a/base/src/main/java/com/smartdevicelink/transport/utl/BaseTransportRecord.java
+++ b/base/src/main/java/com/smartdevicelink/transport/utl/BaseTransportRecord.java
@@ -32,12 +32,9 @@
 
 package com.smartdevicelink.transport.utl;
 
-import android.os.Parcel;
-import android.os.Parcelable;
-
 import com.smartdevicelink.transport.enums.TransportType;
 
-public class BaseTransportRecord implements Parcelable{
+public class BaseTransportRecord{
 
     private TransportType type;
     private String address;
@@ -80,47 +77,4 @@ public class BaseTransportRecord implements Parcelable{
         builder.append(address);
         return builder.toString();
     }
-
-    public BaseTransportRecord(Parcel p){
-        if (p.readInt() == 1) { //We should have a transport type attached
-            String transportName = p.readString();
-            if(transportName != null){
-                this.type = TransportType.valueOf(transportName);
-            }
-        }
-
-        if (p.readInt() == 1) { //We should have a transport address attached
-            address = p.readString();
-        }
-    }
-
-    @Override
-    public int describeContents() {
-        return 0;
-    }
-
-    @Override
-    public void writeToParcel(Parcel dest, int flags) {
-        dest.writeInt(type!=null? 1 : 0);
-        if(type != null){
-            dest.writeString(type.name());
-        }
-
-        dest.writeInt(address !=null? 1 : 0);
-        if(address != null){
-            dest.writeString(address);
-        }
-    }
-
-    public static final Parcelable.Creator<BaseTransportRecord> CREATOR = new Parcelable.Creator<BaseTransportRecord>() {
-        public BaseTransportRecord createFromParcel(Parcel in) {
-            return new BaseTransportRecord(in);
-        }
-
-        @Override
-        public BaseTransportRecord[] newArray(int size) {
-            return new BaseTransportRecord[size];
-        }
-
-    };
 }

--- a/base/src/main/java/com/smartdevicelink/transport/utl/BaseTransportRecord.java
+++ b/base/src/main/java/com/smartdevicelink/transport/utl/BaseTransportRecord.java
@@ -34,12 +34,12 @@ package com.smartdevicelink.transport.utl;
 
 import com.smartdevicelink.transport.enums.TransportType;
 
-public class BaseTransportRecord{
+class BaseTransportRecord{
 
     private TransportType type;
     private String address;
 
-    public BaseTransportRecord(TransportType transportType, String address){
+    BaseTransportRecord(TransportType transportType, String address){
         this.type = transportType;
         this.address = address;
     }

--- a/base/src/main/java/com/smartdevicelink/transport/utl/BaseTransportRecord.java
+++ b/base/src/main/java/com/smartdevicelink/transport/utl/BaseTransportRecord.java
@@ -32,12 +32,13 @@
 
 package com.smartdevicelink.transport.utl;
 
+import android.os.Parcel;
 import com.smartdevicelink.transport.enums.TransportType;
 
 class BaseTransportRecord{
 
-    private TransportType type;
-    private String address;
+    protected TransportType type;
+    protected String address;
 
     BaseTransportRecord(TransportType transportType, String address){
         this.type = transportType;
@@ -76,5 +77,18 @@ class BaseTransportRecord{
         builder.append(" Address: ");
         builder.append(address);
         return builder.toString();
+    }
+
+    BaseTransportRecord(Parcel p) {
+        if (p.readInt() == 1) { //We should have a transport type attached
+            String transportName = p.readString();
+            if(transportName != null){
+                this.type = TransportType.valueOf(transportName);
+            }
+        }
+
+        if (p.readInt() == 1) { //We should have a transport address attached
+            address = p.readString();
+        }
     }
 }

--- a/base/src/main/java/com/smartdevicelink/transport/utl/BaseTransportRecord.java
+++ b/base/src/main/java/com/smartdevicelink/transport/utl/BaseTransportRecord.java
@@ -37,12 +37,12 @@ import android.os.Parcelable;
 
 import com.smartdevicelink.transport.enums.TransportType;
 
-public class TransportRecord implements Parcelable{
+public class BaseTransportRecord implements Parcelable{
 
     private TransportType type;
     private String address;
 
-    public TransportRecord(TransportType transportType, String address){
+    public BaseTransportRecord(TransportType transportType, String address){
         this.type = transportType;
         this.address = address;
     }
@@ -61,8 +61,8 @@ public class TransportRecord implements Parcelable{
             return false;
         }
 
-        if (obj instanceof TransportRecord) {
-            TransportRecord record = (TransportRecord) obj;
+        if (obj instanceof BaseTransportRecord) {
+            BaseTransportRecord record = (BaseTransportRecord) obj;
             return record.type != null && record.type.equals(type)  //Transport type is the same
                     && ((record.address == null && address == null) //Both addresses are null
                     || (record.address != null && record.address.equals(address))); //Or they match
@@ -81,7 +81,7 @@ public class TransportRecord implements Parcelable{
         return builder.toString();
     }
 
-    public TransportRecord(Parcel p){
+    public BaseTransportRecord(Parcel p){
         if (p.readInt() == 1) { //We should have a transport type attached
             String transportName = p.readString();
             if(transportName != null){
@@ -112,14 +112,14 @@ public class TransportRecord implements Parcelable{
         }
     }
 
-    public static final Parcelable.Creator<TransportRecord> CREATOR = new Parcelable.Creator<TransportRecord>() {
-        public TransportRecord createFromParcel(Parcel in) {
-            return new TransportRecord(in);
+    public static final Parcelable.Creator<BaseTransportRecord> CREATOR = new Parcelable.Creator<BaseTransportRecord>() {
+        public BaseTransportRecord createFromParcel(Parcel in) {
+            return new BaseTransportRecord(in);
         }
 
         @Override
-        public TransportRecord[] newArray(int size) {
-            return new TransportRecord[size];
+        public BaseTransportRecord[] newArray(int size) {
+            return new BaseTransportRecord[size];
         }
 
     };

--- a/baseAndroid/src/main/java/com/smartdevicelink/protocol/BaseSdlPacket.java
+++ b/baseAndroid/src/main/java/com/smartdevicelink/protocol/BaseSdlPacket.java
@@ -1,0 +1,1 @@
+../../../../../../../base/src/main/java/com/smartdevicelink/protocol/BaseSdlPacket.java

--- a/baseAndroid/src/main/java/com/smartdevicelink/protocol/SdlPacket.java
+++ b/baseAndroid/src/main/java/com/smartdevicelink/protocol/SdlPacket.java
@@ -1,1 +1,0 @@
-../../../../../../../base/src/main/java/com/smartdevicelink/protocol/SdlPacket.java

--- a/baseAndroid/src/main/java/com/smartdevicelink/transport/utl/BaseTransportRecord.java
+++ b/baseAndroid/src/main/java/com/smartdevicelink/transport/utl/BaseTransportRecord.java
@@ -1,0 +1,1 @@
+../../../../../../../../base/src/main/java/com/smartdevicelink/transport/utl/BaseTransportRecord.java

--- a/baseAndroid/src/main/java/com/smartdevicelink/transport/utl/TransportRecord.java
+++ b/baseAndroid/src/main/java/com/smartdevicelink/transport/utl/TransportRecord.java
@@ -1,1 +1,0 @@
-../../../../../../../../base/src/main/java/com/smartdevicelink/transport/utl/TransportRecord.java

--- a/javaSE/src/main/java/com/smartdevicelink/protocol/SdlPacket.java
+++ b/javaSE/src/main/java/com/smartdevicelink/protocol/SdlPacket.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2017 - 2019, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium, Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.smartdevicelink.protocol;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class SdlPacket extends BaseSdlPacket {
+    private static final int EXTRA_PARCEL_DATA_LENGTH 			= 24;
+
+    public SdlPacket(int version, boolean encryption, int frameType,
+                     int serviceType, int frameInfo, int sessionId,
+                     int dataSize, int messageId, byte[] payload) {
+        super(version, encryption, frameType, serviceType, frameInfo, sessionId, dataSize, messageId, payload);
+    }
+
+    public SdlPacket(int version, boolean encryption, int frameType,
+                     int serviceType, int frameInfo, int sessionId,
+                     int dataSize, int messageId, byte[] payload, int offset, int bytesToWrite) {
+        super(version, encryption, frameType, serviceType, frameInfo, sessionId, dataSize, messageId, payload, offset, bytesToWrite);
+    }
+
+    protected  SdlPacket() {
+        super();
+    }
+
+    protected SdlPacket(BaseSdlPacket packet) {
+        super(packet);
+    }
+
+    @Deprecated
+    public SdlPacket(Parcel p){}
+
+    @Deprecated
+    public int describeContents() {
+        return 0;
+    }
+
+    @Deprecated
+    public void writeToParcel(Parcel dest, int flags) {}
+
+    @Deprecated
+    public static final Parcelable.Creator<SdlPacket> CREATOR = new Parcelable.Creator<SdlPacket>() {
+        public SdlPacket createFromParcel(Parcel in) {
+            return new SdlPacket(in);
+        }
+
+        @Override
+        public SdlPacket[] newArray(int size) {
+            return new SdlPacket[size];
+        }
+
+    };
+}

--- a/javaSE/src/main/java/com/smartdevicelink/protocol/SdlPacket.java
+++ b/javaSE/src/main/java/com/smartdevicelink/protocol/SdlPacket.java
@@ -35,7 +35,6 @@ import android.os.Parcel;
 import android.os.Parcelable;
 
 public class SdlPacket extends BaseSdlPacket {
-    private static final int EXTRA_PARCEL_DATA_LENGTH 			= 24;
 
     public SdlPacket(int version, boolean encryption, int frameType,
                      int serviceType, int frameInfo, int sessionId,

--- a/javaSE/src/main/java/com/smartdevicelink/transport/utl/TransportRecord.java
+++ b/javaSE/src/main/java/com/smartdevicelink/transport/utl/TransportRecord.java
@@ -31,6 +31,8 @@
  */
 package com.smartdevicelink.transport.utl;
 
+import android.os.Parcel;
+import android.os.Parcelable;
 import com.smartdevicelink.transport.enums.TransportType;
 
 public class TransportRecord extends BaseTransportRecord {
@@ -42,4 +44,30 @@ public class TransportRecord extends BaseTransportRecord {
         this.type = transportType;
         this.address = address;
     }
+
+    @Deprecated
+    public TransportRecord(Parcel p) {
+        super(null, "");
+    }
+
+    @Deprecated
+    public int describeContents() {
+        return 0;
+    };
+
+    @Deprecated
+    public void writeToParcel(Parcel dest, int flags) {}
+
+    @Deprecated
+    public static final Parcelable.Creator<TransportRecord> CREATOR = new Parcelable.Creator<TransportRecord>() {
+        public TransportRecord createFromParcel(Parcel in) {
+            return new TransportRecord(in);
+        }
+
+        @Override
+        public TransportRecord[] newArray(int size) {
+            return new TransportRecord[size];
+        }
+
+    };
 }

--- a/javaSE/src/main/java/com/smartdevicelink/transport/utl/TransportRecord.java
+++ b/javaSE/src/main/java/com/smartdevicelink/transport/utl/TransportRecord.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017 - 2019, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium, Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.smartdevicelink.transport.utl;
+
+import com.smartdevicelink.transport.enums.TransportType;
+
+public class TransportRecord extends BaseTransportRecord {
+    private TransportType type;
+    private String address;
+
+    public TransportRecord(TransportType transportType, String address) {
+        super(transportType, address);
+        this.type = transportType;
+        this.address = address;
+    }
+}

--- a/javaSE/src/main/java/com/smartdevicelink/transport/utl/TransportRecord.java
+++ b/javaSE/src/main/java/com/smartdevicelink/transport/utl/TransportRecord.java
@@ -42,9 +42,7 @@ public class TransportRecord extends BaseTransportRecord {
     }
 
     @Deprecated
-    public TransportRecord(Parcel p) {
-        super(p);
-    }
+    public TransportRecord(Parcel p) {}
 
     @Deprecated
     public int describeContents() {

--- a/javaSE/src/main/java/com/smartdevicelink/transport/utl/TransportRecord.java
+++ b/javaSE/src/main/java/com/smartdevicelink/transport/utl/TransportRecord.java
@@ -36,18 +36,14 @@ import android.os.Parcelable;
 import com.smartdevicelink.transport.enums.TransportType;
 
 public class TransportRecord extends BaseTransportRecord {
-    private TransportType type;
-    private String address;
 
     public TransportRecord(TransportType transportType, String address) {
         super(transportType, address);
-        this.type = transportType;
-        this.address = address;
     }
 
     @Deprecated
     public TransportRecord(Parcel p) {
-        super(null, "");
+        super(p);
     }
 
     @Deprecated
@@ -56,7 +52,17 @@ public class TransportRecord extends BaseTransportRecord {
     };
 
     @Deprecated
-    public void writeToParcel(Parcel dest, int flags) {}
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeInt(type!=null? 1 : 0);
+        if(type != null){
+            dest.writeString(type.name());
+        }
+
+        dest.writeInt(address !=null? 1 : 0);
+        if(address != null){
+            dest.writeString(address);
+        }
+    }
 
     @Deprecated
     public static final Parcelable.Creator<TransportRecord> CREATOR = new Parcelable.Creator<TransportRecord>() {


### PR DESCRIPTION
Fixes #[1377]

This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [X] I have tested Android, and Java SE

### Summary
This PR Will:
 - Create SdlPacket and TransportRecord in sdl_android and JavaSE that will extend BaseSdlPacket and BaseTransportRecord respectively
 - Remove Parcelable Methods from BaseSdlPacket and BaseTransportRecord 
 - Deprecate Parcelable Methods in JavaSE SdlPacket and TransportRecord
 - Deprecate base/android/os/Parcel and base/android/os/Parcelable
With these changes we can safely remove base/android/os/Parcel and base/android/os/Parcelable as well as the Parcelable Methods in the JavaSE classes in the next major release

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
