### PR TITLE
Fix app reconnection issue after language change 

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -211,14 +211,6 @@ public class SdlManager extends BaseSdlManager {
         }
     }
 
-    @Override
-    void onProxyClosed(SdlDisconnectedReason reason) {
-        Log.i(TAG, "Proxy is closed.");
-        if (reason == null || !reason.equals(SdlDisconnectedReason.LANGUAGE_CHANGE)) {
-            dispose();
-        }
-    }
-
     /**
      * Dispose SdlManager and clean its resources
      * <strong>Note: new instance of SdlManager should be created on every connection. SdlManager cannot be reused after getting disposed.</strong>

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -214,10 +214,6 @@ public class SdlManager extends BaseSdlManager {
     @Override
     void onProxyClosed(SdlDisconnectedReason reason) {
         Log.i(TAG, "Proxy is closed.");
-        if (managerListener != null) {
-            managerListener.onDestroy();
-        }
-
         if (reason == null || !reason.equals(SdlDisconnectedReason.LANGUAGE_CHANGE)) {
             dispose();
         }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -49,7 +49,6 @@ import com.smartdevicelink.managers.permission.PermissionManager;
 import com.smartdevicelink.managers.screen.ScreenManager;
 import com.smartdevicelink.managers.video.VideoStreamManager;
 import com.smartdevicelink.proxy.rpc.enums.AppHMIType;
-import com.smartdevicelink.proxy.rpc.enums.SdlDisconnectedReason;
 import com.smartdevicelink.transport.BaseTransportConfig;
 import com.smartdevicelink.transport.MultiplexTransportConfig;
 import com.smartdevicelink.transport.enums.TransportType;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -112,12 +112,13 @@ public class LifecycleManager extends BaseLifecycleManager {
         }
     }
 
-    private void cycleProxy(SdlDisconnectedReason disconnectedReason) {
+    @Override
+    void cycleProxy(SdlDisconnectedReason disconnectedReason) {
         cleanProxy();
         initializeProxy();
         if (!SdlDisconnectedReason.LEGACY_BLUETOOTH_MODE_ENABLED.equals(disconnectedReason) && !SdlDisconnectedReason.PRIMARY_TRANSPORT_CYCLE_REQUEST.equals(disconnectedReason)) {
             //We don't want to alert higher if we are just cycling for legacy bluetooth
-            onClose("Sdl Proxy Cycled", new SdlException("Sdl Proxy Cycled", SdlExceptionCause.SDL_PROXY_CYCLED));
+            onClose("Sdl Proxy Cycled", new SdlException("Sdl Proxy Cycled", SdlExceptionCause.SDL_PROXY_CYCLED), disconnectedReason);
         }
         try {
             session.startSession();
@@ -160,7 +161,7 @@ public class LifecycleManager extends BaseLifecycleManager {
             Log.d(TAG, "notifying RPC session ended, but potential primary transport available");
             cycleProxy(SdlDisconnectedReason.PRIMARY_TRANSPORT_CYCLE_REQUEST);
         } else {
-            onClose(info, null);
+            onClose(info, null, null);
         }
     }
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -120,10 +120,12 @@ public class LifecycleManager extends BaseLifecycleManager {
             //We don't want to alert higher if we are just cycling for legacy bluetooth
             onClose("Sdl Proxy Cycled", new SdlException("Sdl Proxy Cycled", SdlExceptionCause.SDL_PROXY_CYCLED), disconnectedReason);
         }
-        try {
-            session.startSession();
-        } catch (SdlException e) {
-            e.printStackTrace();
+        if (session != null) {
+            try {
+                session.startSession();
+            } catch (SdlException e) {
+                e.printStackTrace();
+            }
         }
     }
 

--- a/base/src/main/java/com/smartdevicelink/managers/BaseSdlManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/BaseSdlManager.java
@@ -142,7 +142,10 @@ abstract class BaseSdlManager {
 
         @Override
         public void onProxyClosed(LifecycleManager lifeCycleManager, String info, Exception e, SdlDisconnectedReason reason) {
-            BaseSdlManager.this.onProxyClosed(reason);
+            Log.i(TAG, "Proxy is closed.");
+            if (reason == null || !reason.equals(SdlDisconnectedReason.LANGUAGE_CHANGE)) {
+                dispose();
+            }
         }
 
         @Override
@@ -164,8 +167,6 @@ abstract class BaseSdlManager {
 
     // ABSTRACT METHODS
     abstract void retryChangeRegistration();
-
-    abstract void onProxyClosed(SdlDisconnectedReason reason);
 
     abstract void checkState();
 

--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
@@ -326,10 +326,10 @@ abstract class BaseLifecycleManager {
         return currentHMIStatus;
     }
 
-    void onClose(String info, Exception e) {
+    void onClose(String info, Exception e, SdlDisconnectedReason reason) {
         Log.i(TAG, "onClose");
         if (lifecycleListener != null) {
-            lifecycleListener.onProxyClosed((LifecycleManager) this, info, e, null);
+            lifecycleListener.onProxyClosed((LifecycleManager) this, info, e, reason);
         }
     }
 
@@ -446,7 +446,7 @@ abstract class BaseLifecycleManager {
                             cleanProxy();
                         } else {
                             Log.v(TAG, "re-registering for language change");
-                            processLanguageChange();
+                            cycleProxy(SdlDisconnectedReason.LANGUAGE_CHANGE);
                         }
                         break;
                     case UNREGISTER_APP_INTERFACE:
@@ -459,19 +459,6 @@ abstract class BaseLifecycleManager {
 
 
     };
-
-    private void processLanguageChange() {
-        if (session != null) {
-            if (session.getIsConnected()) {
-                session.close();
-            }
-            try {
-                session.startSession();
-            } catch (SdlException e) {
-                e.printStackTrace();
-            }
-        }
-    }
 
     /* *******************************************************************************************************
      ********************************** INTERNAL - RPC LISTENERS !! END !! *********************************
@@ -856,7 +843,7 @@ abstract class BaseLifecycleManager {
     final ISdlConnectionListener sdlConnectionListener = new ISdlConnectionListener() {
         @Override
         public void onTransportDisconnected(String info) {
-            onClose(info, null);
+            onClose(info, null, null);
 
         }
 
@@ -868,7 +855,7 @@ abstract class BaseLifecycleManager {
 
         @Override
         public void onTransportError(String info, Exception e) {
-            onClose(info, e);
+            onClose(info, e, null);
 
         }
 
@@ -1507,6 +1494,9 @@ abstract class BaseLifecycleManager {
                 }
             }
         }
+    }
+
+    void cycleProxy(SdlDisconnectedReason disconnectedReason) {
     }
 
     void onTransportDisconnected(String info, boolean availablePrimary, BaseTransportConfig transportConfig) {

--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
@@ -1496,8 +1496,7 @@ abstract class BaseLifecycleManager {
         }
     }
 
-    void cycleProxy(SdlDisconnectedReason disconnectedReason) {
-    }
+    abstract void cycleProxy(SdlDisconnectedReason disconnectedReason);
 
     void onTransportDisconnected(String info, boolean availablePrimary, BaseTransportConfig transportConfig) {
     }

--- a/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -142,14 +142,6 @@ public class SdlManager extends BaseSdlManager {
     }
 
     @Override
-    void onProxyClosed(SdlDisconnectedReason reason) {
-        Log.i(TAG, "Proxy is closed.");
-        if (managerListener != null) {
-            managerListener.onDestroy(SdlManager.this);
-        }
-    }
-
-    @Override
     public void dispose() {
         if (this.permissionManager != null) {
             this.permissionManager.dispose();

--- a/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -35,6 +35,8 @@ package com.smartdevicelink.managers.lifecycle;
 import android.support.annotation.RestrictTo;
 
 import com.smartdevicelink.SdlConnection.SdlSession;
+import com.smartdevicelink.exception.SdlException;
+import com.smartdevicelink.proxy.rpc.enums.SdlDisconnectedReason;
 import com.smartdevicelink.transport.BaseTransportConfig;
 
 /**
@@ -54,10 +56,24 @@ public class LifecycleManager extends BaseLifecycleManager {
     }
 
     @Override
+    void cycleProxy(SdlDisconnectedReason disconnectedReason) {
+        if (session != null) {
+            if (session.getIsConnected()) {
+                session.close();
+            }
+            try {
+                session.startSession();
+            } catch (SdlException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    @Override
     void onTransportDisconnected(String info, boolean availablePrimary, BaseTransportConfig transportConfig) {
         super.onTransportDisconnected(info, availablePrimary, transportConfig);
         if (!availablePrimary) {
-            onClose(info, null);
+            onClose(info, null, null);
         }
     }
 }

--- a/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -57,10 +57,8 @@ public class LifecycleManager extends BaseLifecycleManager {
 
     @Override
     void cycleProxy(SdlDisconnectedReason disconnectedReason) {
+        cleanProxy();
         if (session != null) {
-            if (session.getIsConnected()) {
-                session.close();
-            }
             try {
                 session.startSession();
             } catch (SdlException e) {


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Core Tests
* Connect app to the head unit
* While the app is connected, change the language on the head unit side
* Make sure that the app unregisters then registers again with the new language

Core version / branch / commit hash / module tested against: Ford Sync 3.2
HMI name / version / branch / commit hash / module tested against: Ford Sync 3.2

### Summary
This PR fixes two issues introduced by this PR #1366:
* Propagate the disconnect reason correctly so the app reconnects after language change
* Fix an issue that causes managerListener.onDestroy to be called twice

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
