### PR TITLE
Add hashId to sdlmanager builder

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/BaseSdlManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/BaseSdlManager.java
@@ -83,7 +83,7 @@ abstract class BaseSdlManager {
     static final String TAG = "BaseSubManager";
     final Object STATE_LOCK = new Object();
     int state = -1;
-    String appId, appName, shortAppName;
+    String appId, appName, shortAppName, hashId;
     boolean isMediaApp;
     Language hmiLanguage;
     Language language;
@@ -333,6 +333,7 @@ abstract class BaseSdlManager {
         appConfig.setAppID(appId);
         appConfig.setMinimumProtocolVersion(minimumProtocolVersion);
         appConfig.setMinimumRPCVersion(minimumRPCVersion);
+        appConfig.setHashId(hashId);
 
         lifecycleManager = new LifecycleManager(appConfig, transport, lifecycleListener);
         _internalInterface = lifecycleManager.getInternalInterface((SdlManager) BaseSdlManager.this);
@@ -630,6 +631,16 @@ abstract class BaseSdlManager {
         }
 
         /**
+         * Sets the Resumption Hash ID
+         *
+         * @param hashId String representation of the Hash ID Used to resume the application
+         */
+        public Builder setHashId(final String hashId) {
+            sdlManager.hashId = hashId;
+            return this;
+        }
+
+        /**
          * Sets the Application Name
          *
          * @param appName String that will be associated as the app's name
@@ -715,6 +726,7 @@ abstract class BaseSdlManager {
             sdlManager.appIcon = sdlArtwork;
             return this;
         }
+
 
         /**
          * Sets the vector of AppHMIType <br>

--- a/base/src/main/java/com/smartdevicelink/managers/BaseSdlManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/BaseSdlManager.java
@@ -727,7 +727,6 @@ abstract class BaseSdlManager {
             return this;
         }
 
-
         /**
          * Sets the vector of AppHMIType <br>
          * <strong>Note: This should be an ordered list from most -> least relevant</strong>

--- a/base/src/main/java/com/smartdevicelink/managers/BaseSdlManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/BaseSdlManager.java
@@ -83,7 +83,7 @@ abstract class BaseSdlManager {
     static final String TAG = "BaseSubManager";
     final Object STATE_LOCK = new Object();
     int state = -1;
-    String appId, appName, shortAppName, hashId;
+    String appId, appName, shortAppName, resumeHash;
     boolean isMediaApp;
     Language hmiLanguage;
     Language language;
@@ -333,7 +333,7 @@ abstract class BaseSdlManager {
         appConfig.setAppID(appId);
         appConfig.setMinimumProtocolVersion(minimumProtocolVersion);
         appConfig.setMinimumRPCVersion(minimumRPCVersion);
-        appConfig.setHashId(hashId);
+        appConfig.setResumeHash(resumeHash);
 
         lifecycleManager = new LifecycleManager(appConfig, transport, lifecycleListener);
         _internalInterface = lifecycleManager.getInternalInterface((SdlManager) BaseSdlManager.this);
@@ -633,10 +633,10 @@ abstract class BaseSdlManager {
         /**
          * Sets the Resumption Hash ID
          *
-         * @param hashId String representation of the Hash ID Used to resume the application
+         * @param resumeHash String representation of the Hash ID Used to resume the application
          */
-        public Builder setHashId(final String hashId) {
-            sdlManager.hashId = hashId;
+        public Builder setResumeHash(final String resumeHash) {
+            sdlManager.resumeHash = resumeHash;
             return this;
         }
 

--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
@@ -1186,7 +1186,7 @@ abstract class BaseLifecycleManager {
     }
 
     public static class AppConfig {
-        private String appID, appName, ngnMediaScreenAppName, hashId;
+        private String appID, appName, ngnMediaScreenAppName, resumeHash;
         private Vector<TTSChunk> ttsName;
         private Vector<String> vrSynonyms;
         private boolean isMediaApp = false;
@@ -1287,12 +1287,12 @@ abstract class BaseLifecycleManager {
             this.appType = appType;
         }
 
-        public String getHashId() {
-            return this.hashId;
+        public String getResumeHash() {
+            return this.resumeHash;
         }
 
-        public void setHashId(String hashId) {
-            this.hashId = hashId;
+        public void setResumeHash(String resumeHash) {
+            this.resumeHash = resumeHash;
         }
 
         public TemplateColorScheme getDayColorScheme() {
@@ -1513,7 +1513,7 @@ abstract class BaseLifecycleManager {
                     rai.setAppHMIType(appConfig.getAppType());
                     rai.setDayColorScheme(appConfig.getDayColorScheme());
                     rai.setNightColorScheme(appConfig.getNightColorScheme());
-                    rai.setHashID(appConfig.getHashId());
+                    rai.setHashID(appConfig.getResumeHash());
 
                     //Add device/system info in the future
 

--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
@@ -1186,7 +1186,7 @@ abstract class BaseLifecycleManager {
     }
 
     public static class AppConfig {
-        private String appID, appName, ngnMediaScreenAppName;
+        private String appID, appName, ngnMediaScreenAppName, hashId;
         private Vector<TTSChunk> ttsName;
         private Vector<String> vrSynonyms;
         private boolean isMediaApp = false;
@@ -1285,6 +1285,14 @@ abstract class BaseLifecycleManager {
 
         public void setAppType(Vector<AppHMIType> appType) {
             this.appType = appType;
+        }
+
+        public String getHashId() {
+            return this.hashId;
+        }
+
+        public void setHashId(String hashId) {
+            this.hashId = hashId;
         }
 
         public TemplateColorScheme getDayColorScheme() {
@@ -1505,9 +1513,8 @@ abstract class BaseLifecycleManager {
                     rai.setAppHMIType(appConfig.getAppType());
                     rai.setDayColorScheme(appConfig.getDayColorScheme());
                     rai.setNightColorScheme(appConfig.getNightColorScheme());
-
+                    rai.setHashID(appConfig.getHashId());
                     //Add device/system info in the future
-                    //TODO attach previous hash id
 
                     sendRPCMessagePrivate(rai, true);
                 } else {

--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
@@ -1514,6 +1514,7 @@ abstract class BaseLifecycleManager {
                     rai.setDayColorScheme(appConfig.getDayColorScheme());
                     rai.setNightColorScheme(appConfig.getNightColorScheme());
                     rai.setHashID(appConfig.getHashId());
+
                     //Add device/system info in the future
 
                     sendRPCMessagePrivate(rai, true);


### PR DESCRIPTION
Fixes #1400 

This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [X] I have tested Android, and Java SE

#### Core Tests
1. In the SdlService add a OnHashChange listener and store the hashId in sharedPreferences when notified
2. Set Menu items in the SdlService
3. Run your app against core and verify that a hashId has been stored and that the menu items are available.
4. In SdlService call sdlManager.setHashId with the hashId set in your shared preferences.
5. Comment out the call to setMenus() in the SdlService.
6. Rerun the application, and make sure the RegisterAppInterfaceResponse is successful and that the menu items are still available

### Summary
This PR will add the option to set the HashId via the sdlManager builder. This will enable the developer the set the resumption HashId if needed for their application. The SdlManager will pass the hashid to the lifecyclemanager through the appconfig where it will be used to set the hashId for the RegisterAppInterface.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
