### PR TITLE
Deprecate onError for OnRPCResponseListener

### DIFF
--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/listeners/OnRPCResponseListener.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/listeners/OnRPCResponseListener.java
@@ -70,11 +70,16 @@ public abstract class OnRPCResponseListener extends OnRPCListener {
 	public abstract void onResponse(int correlationId, final RPCResponse response);
 	
 	/**
+	 * @deprecated This method has been deprecated in favor of just using the onResponse callback. In the next
+	 * version this method will be removed and all responses successful or not will be returned
+	 * through the onResponse method callback.
+	 *
 	 * Called when there was some sort of error during the original request.
 	 * @param correlationId
 	 * @param resultCode
 	 * @param info
 	 */
+	@Deprecated
 	public void onError(int correlationId, Result resultCode, String info){
 		
 	};


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
Unit tests unchanged at this point as only the method was deprecated. Next release where the method is removed, the tests will need to be updated.

### Summary
-Added the deprecated flag and description to the onError method in the OnRPCResponseListener

### Changelog

##### Enhancements
* Deprecated a confusing callback that can be addressed in the next major version

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
