### PR TITLE
Choice Set Error

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/PreloadChoicesOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/PreloadChoicesOperation.java
@@ -73,6 +73,7 @@ class PreloadChoicesOperation extends Task {
 	private CompletionListener completionListener;
 	private boolean isRunning;
 	private boolean isVROptional;
+	private boolean choiceError = false;
 
 	PreloadChoicesOperation(ISdl internalInterface, FileManager fileManager, String displayName, WindowCapability defaultMainWindowCapability,
 								   Boolean isVROptional, HashSet<ChoiceCell> cellsToPreload, CompletionListener listener){
@@ -164,16 +165,15 @@ class PreloadChoicesOperation extends Task {
 				public void onFinished() {
 					isRunning = false;
 					DebugTool.logInfo(TAG, "Finished pre loading choice cells");
-					completionListener.onComplete(true);
-
+					completionListener.onComplete(!choiceError);
+					choiceError = false;
 					PreloadChoicesOperation.super.onFinished();
 				}
 
 				@Override
 				public void onError(int correlationId, Result resultCode, String info) {
 					DebugTool.logError(TAG, "There was an error uploading a choice cell: "+ info + " resultCode: " + resultCode);
-
-					PreloadChoicesOperation.super.onFinished();
+					choiceError = true;
 				}
 
 				@Override


### PR DESCRIPTION
Fixes #1336 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Core Tests
Tested against Sync 3.0 and manticore

### Summary
In ``PreloadChoicesOperation.preloadCells`` For every request sent in the list the OnMultipleRequestListener onResponse or onError will be called depending on if the request was successful or a failure, then onFinished() gets called after the list is complete. 

With the current implementation ```PreloadChoicesOperation.super.onFinished();``` will get called in the onError and onFinished as well as the completion listener will always get notified as a success. If one failed to a GENERIC_ERROR, this could lead to you being notified that preloading is a success and when you go to present a choiceSet you will get an "INVALID_ID, null" error.

To test in ``BaseLifeCycleManager`` I added a boolean value called ``everyOther`` to the class and modified ``private void sendRPCs(List<? extends RPCMessage> messages, final OnMultipleRequestListener listener)`` onResponse  part of listener to simulate every other choiceCell failing to upload. Example Code:
 ```
                        request.setOnRPCResponseListener(new OnRPCResponseListener() {
                            @Override
                            public void onResponse(int correlationId, RPCResponse response) {
                                if(response instanceof CreateInteractionChoiceSetResponse && everyOther){
                                    everyOther = false;
                                    Result resultCode = Result.GENERIC_ERROR;
                                    String info = "Testing";
                                    super.onError(correlationId, resultCode, info);
                                    if (devOnRPCResponseListener != null) {
                                        devOnRPCResponseListener.onError(correlationId, resultCode, info);
                                    }
                                    if (listener.getSingleRpcResponseListener() != null) {
                                        listener.getSingleRpcResponseListener().onError(correlationId, resultCode, info);
                                    }
                                } else {
                                    everyOther = true;
                                    if (devOnRPCResponseListener != null) {
                                        devOnRPCResponseListener.onResponse(correlationId, response);
                                    }
                                    if (listener.getSingleRpcResponseListener() != null) {
                                        listener.getSingleRpcResponseListener().onResponse(correlationId, response);
                                    }
                                }

                            }
                            @Override
                            public void onError(int correlationId, Result resultCode, String info) {
                                super.onError(correlationId, resultCode, info);
                                if (devOnRPCResponseListener != null) {
                                    devOnRPCResponseListener.onError(correlationId, resultCode, info);
                                }
                                if (listener.getSingleRpcResponseListener() != null) {
                                    listener.getSingleRpcResponseListener().onError(correlationId, resultCode, info);
                                }
                            }
                        });
         
```

### Changelog
##### Bug Fixes
* All changes were made in PreloadChoicesOperation

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
