### PR TITLE
Fix loggin issue in DebugTool

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/Log.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/Log.java
@@ -1,19 +1,19 @@
 package com.smartdevicelink.util;
 
 public class Log {
-    public static int i(String tag, String message) {
-        return android.util.Log.i(tag, message);
+    public static void i(String tag, String message) {
+        android.util.Log.i(tag, message);
     }
 
-    public static int w(String tag, String message) {
-        return android.util.Log.w(tag, message);
+    public static void w(String tag, String message) {
+        android.util.Log.w(tag, message);
     }
 
-    public static int e(String tag, String message, Throwable t) {
+    public static void e(String tag, String message, Throwable t) {
         if (t != null) {
-            return android.util.Log.e(tag, message, t);
+            android.util.Log.e(tag, message, t);
         } else {
-            return android.util.Log.e(tag, message);
+            android.util.Log.e(tag, message);
         }
     }
 }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/Log.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/Log.java
@@ -2,21 +2,18 @@ package com.smartdevicelink.util;
 
 public class Log {
     public static int i(String tag, String message) {
-        android.util.Log.i(tag, message);
-        return 10;
+        return android.util.Log.i(tag, message);
     }
 
     public static int w(String tag, String message) {
-        android.util.Log.w(tag, message);
-        return 10;
+        return android.util.Log.w(tag, message);
     }
 
     public static int e(String tag, String message, Throwable t) {
         if (t != null) {
-            android.util.Log.e(tag, message, t);
+            return android.util.Log.e(tag, message, t);
         } else {
-            android.util.Log.e(tag, message);
+            return android.util.Log.e(tag, message);
         }
-        return 10;
     }
 }

--- a/base/src/main/java/com/smartdevicelink/util/NativeLogTool.java
+++ b/base/src/main/java/com/smartdevicelink/util/NativeLogTool.java
@@ -109,7 +109,6 @@ public class NativeLogTool {
 			return false;
 		}
 
-		int bytesWritten = 0;
 		int substrSize = 0;
 		String chunk = null;
 		try {
@@ -118,17 +117,14 @@ public class NativeLogTool {
 				chunk = logMsg.substring(idx, idx + substrSize);
 				switch (ltarg) {
 					case Info:
-						bytesWritten = Log.i(source, chunk);
+						Log.i(source, chunk);
 						break;
 					case Warning:
-						bytesWritten = Log.w(source, chunk);
+						Log.w(source, chunk);
 						break;
 					case Error:
-						bytesWritten = Log.e(source, chunk, null);
+						Log.e(source, chunk, null);
 						break;
-				}
-				if (bytesWritten < chunk.length()) {
-					Log.w(TAG, "Calling Log.w: msg length=" + chunk.length() + ", bytesWritten=" + bytesWritten);
 				}
 			}			
 		} catch (Exception ex) {

--- a/base/src/main/java/com/smartdevicelink/util/NativeLogTool.java
+++ b/base/src/main/java/com/smartdevicelink/util/NativeLogTool.java
@@ -128,7 +128,7 @@ public class NativeLogTool {
 						break;
 				}
 				if (bytesWritten < chunk.length()) {
-					Log.w(TAG, "Calling Log.e: msg length=" + chunk.length() + ", bytesWritten=" + bytesWritten);
+					Log.w(TAG, "Calling Log.w: msg length=" + chunk.length() + ", bytesWritten=" + bytesWritten);
 				}
 			}			
 		} catch (Exception ex) {

--- a/hello_sdl_java/src/main/java/com/smartdevicelink/java/Main.java
+++ b/hello_sdl_java/src/main/java/com/smartdevicelink/java/Main.java
@@ -43,6 +43,9 @@ public class Main {
     static SdlService sdlService;
 
     public static void main(String[] args) {
+        //Enable DebugTool
+        DebugTool.enableDebugTool();
+
         mainThread = Thread.currentThread();
         LOCK = new Object();
         startSdlService();

--- a/javaSE/src/main/java/com/smartdevicelink/util/Log.java
+++ b/javaSE/src/main/java/com/smartdevicelink/util/Log.java
@@ -3,12 +3,12 @@ package com.smartdevicelink.util;
 public class Log {
     public static int i(String tag, String message) {
         System.out.print("\r\nINFO: " + tag + " - " + message);
-        return 10;
+        return 4000;
     }
 
     public static int w(String tag, String message) {
         System.out.print("\r\nWARN: " + tag + " - " + message);
-        return 10;
+        return 4000;
     }
 
     public static int e(String tag, String message, Throwable t) {
@@ -17,6 +17,6 @@ public class Log {
         } else {
             System.out.print("\r\nERROR: " + tag + " - " + message);
         }
-        return 10;
+        return 4000;
     }
 }

--- a/javaSE/src/main/java/com/smartdevicelink/util/Log.java
+++ b/javaSE/src/main/java/com/smartdevicelink/util/Log.java
@@ -1,22 +1,19 @@
 package com.smartdevicelink.util;
 
 public class Log {
-    public static int i(String tag, String message) {
+    public static void i(String tag, String message) {
         System.out.print("\r\nINFO: " + tag + " - " + message);
-        return 4000;
     }
 
-    public static int w(String tag, String message) {
+    public static void w(String tag, String message) {
         System.out.print("\r\nWARN: " + tag + " - " + message);
-        return 4000;
     }
 
-    public static int e(String tag, String message, Throwable t) {
+    public static void e(String tag, String message, Throwable t) {
         if (t != null) {
             System.out.print("\r\nERROR: " + tag + " - " + message + " - " + t.getMessage());
         } else {
             System.out.print("\r\nERROR: " + tag + " - " + message);
         }
-        return 4000;
     }
 }


### PR DESCRIPTION
This PR updates the `Log` methods to return `void` instead of a hardcoded integer value. It also removes the if statement that prints an error message if the returned value is less than the chunk size. Because that will make the `NativeLogTool` prints an error message for every log message:
https://github.com/smartdevicelink/sdl_java_suite/blob/9946777469c0f58a9732cab42669c56850edb761/base/src/main/java/com/smartdevicelink/util/NativeLogTool.java#L133

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
