### PR TITLE
SDL-0152 Driver Distraction: Command List Limitations

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/TestValues.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/TestValues.java
@@ -340,7 +340,7 @@ public class TestValues {
 	public static final AppInterfaceUnregisteredReason GENERAL_APPINTERFACEUNREGISTEREDREASON = AppInterfaceUnregisteredReason.BLUETOOTH_OFF;
 	public static final SystemCapabilityType           GENERAL_SYSTEMCAPABILITYTYPE           = SystemCapabilityType.NAVIGATION;
 	public static final NavigationCapability           GENERAL_NAVIGATIONCAPABILITY           = new NavigationCapability();
-	public static final DriverDistractionCapability	   GENERAL_DRIVERDISTRACTIONCAPABILITY          = new DriverDistractionCapability();
+	public static final DriverDistractionCapability	   GENERAL_DRIVERDISTRACTIONCAPABILITY    = new DriverDistractionCapability();
 	public static final PhoneCapability                GENERAL_PHONECAPABILITY                = new PhoneCapability();
 	public static final RemoteControlCapabilities      GENERAL_REMOTECONTROLCAPABILITIES      = new RemoteControlCapabilities();
 	public static final SystemCapability               GENERAL_SYSTEMCAPABILITY               = new SystemCapability();

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/TestValues.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/TestValues.java
@@ -37,6 +37,7 @@ import com.smartdevicelink.proxy.rpc.DateTime;
 import com.smartdevicelink.proxy.rpc.DeviceInfo;
 import com.smartdevicelink.proxy.rpc.DisplayCapabilities;
 import com.smartdevicelink.proxy.rpc.DisplayCapability;
+import com.smartdevicelink.proxy.rpc.DriverDistractionCapability;
 import com.smartdevicelink.proxy.rpc.EqualizerSettings;
 import com.smartdevicelink.proxy.rpc.Grid;
 import com.smartdevicelink.proxy.rpc.HMICapabilities;
@@ -339,6 +340,7 @@ public class TestValues {
 	public static final AppInterfaceUnregisteredReason GENERAL_APPINTERFACEUNREGISTEREDREASON = AppInterfaceUnregisteredReason.BLUETOOTH_OFF;
 	public static final SystemCapabilityType           GENERAL_SYSTEMCAPABILITYTYPE           = SystemCapabilityType.NAVIGATION;
 	public static final NavigationCapability           GENERAL_NAVIGATIONCAPABILITY           = new NavigationCapability();
+	public static final DriverDistractionCapability	   GENERAL_DRIVERDISTRACTIONCAPABILITY          = new DriverDistractionCapability();
 	public static final PhoneCapability                GENERAL_PHONECAPABILITY                = new PhoneCapability();
 	public static final RemoteControlCapabilities      GENERAL_REMOTECONTROLCAPABILITIES      = new RemoteControlCapabilities();
 	public static final SystemCapability               GENERAL_SYSTEMCAPABILITY               = new SystemCapability();

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/Validator.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/Validator.java
@@ -1319,6 +1319,31 @@ public class Validator{
         return true;
     }
 
+    public static boolean validateDriverDistractionCapability(DriverDistractionCapability driverDistractionCapability1, DriverDistractionCapability driverDistractionCapability2) {
+        if (driverDistractionCapability1 == null) {
+            return (driverDistractionCapability1 == null);
+        }
+        if (driverDistractionCapability2 == null) {
+            return (driverDistractionCapability2 == null);
+        }
+
+        if (driverDistractionCapability1.getMenuLength() != driverDistractionCapability2.getMenuLength()) {
+            log("validateDriverDistractionCapability",
+                    "menuLength " + driverDistractionCapability1.getMenuLength() + " didn't match menuLength " + driverDistractionCapability2.getMenuLength()
+                            + ".");
+            return false;
+        }
+
+        if (driverDistractionCapability1.getSubMenuDepth() != driverDistractionCapability2.getSubMenuDepth()) {
+            log("validateDriverDistractionCapability",
+                    "subMenuDepth " + driverDistractionCapability1.getSubMenuDepth() + " didn't match subMenuDepth " + driverDistractionCapability2.getSubMenuDepth()
+                            + ".");
+            return false;
+        }
+
+        return true;
+    }
+
     public static boolean validatePhoneCapability(PhoneCapability phoneCapability1, PhoneCapability phoneCapability2){
         if(phoneCapability1 == null){
             return ( phoneCapability2 == null );

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/DriverDistractionCapabilityTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/DriverDistractionCapabilityTest.java
@@ -1,0 +1,65 @@
+package com.smartdevicelink.test.rpc.datatypes;
+
+import com.smartdevicelink.proxy.rpc.DriverDistractionCapability;
+import com.smartdevicelink.test.JsonUtils;
+import com.smartdevicelink.test.TestValues;
+import junit.framework.TestCase;
+import org.json.JSONException;
+import org.json.JSONObject;
+import java.util.Iterator;
+
+/**
+ * This is a unit test class for the SmartDeviceLink library project class :
+ * {@link com.smartdevicelink.proxy.rpc.DriverDistractionCapability}
+ */
+public class DriverDistractionCapabilityTest extends TestCase {
+
+    private DriverDistractionCapability msg;
+
+    @Override
+    public void setUp() {
+        msg = new DriverDistractionCapability();
+        msg.setMenuLength(TestValues.GENERAL_INT);
+        msg.setSubMenuDepth(TestValues.GENERAL_INT);
+    }
+
+    /**
+     * Tests the expected values of the RPC message.
+     */
+    public void testRpcValues() {
+        // Test Values
+        int menuLength = msg.getMenuLength();
+        int subMenuDepth = msg.getSubMenuDepth();
+
+        // Valid Tests
+        assertEquals(TestValues.MATCH, TestValues.GENERAL_INT, menuLength);
+        assertEquals(TestValues.MATCH, TestValues.GENERAL_INT, subMenuDepth);
+
+        // Invalid/Null Tests
+        DriverDistractionCapability msg = new DriverDistractionCapability();
+        assertNotNull(TestValues.NOT_NULL, msg);
+
+        assertNull(TestValues.NULL, msg.getMenuLength());
+        assertNull(TestValues.NULL, msg.getSubMenuDepth());
+    }
+
+    public void testJson() {
+        JSONObject reference = new JSONObject();
+
+        try {
+            reference.put(DriverDistractionCapability.KEY_MENU_LENGTH, TestValues.GENERAL_INT);
+            reference.put(DriverDistractionCapability.KEY_SUB_MENU_DEPTH, TestValues.GENERAL_INT);
+
+            JSONObject underTest = msg.serializeJSON();
+            assertEquals(TestValues.MATCH, reference.length(), underTest.length());
+
+            Iterator<?> iterator = reference.keys();
+            while(iterator.hasNext()){
+                String key = (String) iterator.next();
+                assertEquals(TestValues.MATCH, JsonUtils.readObjectFromJsonObject(reference, key), JsonUtils.readObjectFromJsonObject(underTest, key));
+            }
+        } catch (JSONException e) {
+            fail(TestValues.JSON_FAIL);
+        }
+    }
+}

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/HMICapabilitiesTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/HMICapabilitiesTests.java
@@ -49,7 +49,7 @@ public class HMICapabilitiesTests extends TestCase {
 
         assertFalse(msg.isNavigationAvailable());
         assertFalse(msg.isPhoneCallAvailable());
-	    assertFalse(msg.isVideoStreamingAvailable());
+        assertFalse(msg.isVideoStreamingAvailable());
         assertFalse(msg.isDriverDistractionAvailable());
 
     }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/HMICapabilitiesTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/HMICapabilitiesTests.java
@@ -23,8 +23,8 @@ public class HMICapabilitiesTests extends TestCase {
 
         msg.setNavigationAvilable(TestValues.GENERAL_BOOLEAN);
         msg.setPhoneCallAvilable(TestValues.GENERAL_BOOLEAN);
-	    msg.setVideoStreamingAvailable(TestValues.GENERAL_BOOLEAN);
-	    msg.setDriverDistraction(TestValues.GENERAL_BOOLEAN);
+        msg.setVideoStreamingAvailable(TestValues.GENERAL_BOOLEAN);
+        msg.setDriverDistraction(TestValues.GENERAL_BOOLEAN);
     }
 
     /**
@@ -34,8 +34,8 @@ public class HMICapabilitiesTests extends TestCase {
         // Test Values
         Boolean navAvail = msg.isNavigationAvailable();
         Boolean phoneAvail = msg.isPhoneCallAvailable();
-	    Boolean vidStreamAvail = msg.isVideoStreamingAvailable();
-	    Boolean driverDistractionAvail = msg.isDriverDistractionAvailable();
+        Boolean vidStreamAvail = msg.isVideoStreamingAvailable();
+        Boolean driverDistractionAvail = msg.isDriverDistractionAvailable();
 
         // Valid Tests
         assertEquals(TestValues.MATCH, (Boolean) TestValues.GENERAL_BOOLEAN, navAvail);
@@ -60,8 +60,8 @@ public class HMICapabilitiesTests extends TestCase {
         try{
             reference.put(KEY_NAVIGATION, TestValues.GENERAL_BOOLEAN);
             reference.put(HMICapabilities.KEY_PHONE_CALL, TestValues.GENERAL_BOOLEAN);
-	        reference.put(HMICapabilities.KEY_VIDEO_STREAMING, TestValues.GENERAL_BOOLEAN);
-	        reference.put(KEY_DRIVER_DISTRACTION, TestValues.GENERAL_BOOLEAN);
+            reference.put(HMICapabilities.KEY_VIDEO_STREAMING, TestValues.GENERAL_BOOLEAN);
+            reference.put(KEY_DRIVER_DISTRACTION, TestValues.GENERAL_BOOLEAN);
 
             JSONObject underTest = msg.serializeJSON();
             assertEquals(TestValues.MATCH, reference.length(), underTest.length());
@@ -72,9 +72,9 @@ public class HMICapabilitiesTests extends TestCase {
             assertEquals(TestValues.MATCH, JsonUtils.readStringListFromJsonObject(reference, KEY_PHONE_CALL),
                     JsonUtils.readStringListFromJsonObject(underTest, KEY_PHONE_CALL));
 
-	        assertEquals(TestValues.MATCH, JsonUtils.readStringListFromJsonObject(reference, KEY_VIDEO_STREAMING),
+            assertEquals(TestValues.MATCH, JsonUtils.readStringListFromJsonObject(reference, KEY_VIDEO_STREAMING),
 			        JsonUtils.readStringListFromJsonObject(underTest, KEY_VIDEO_STREAMING));
-	        assertEquals(TestValues.MATCH, JsonUtils.readStringFromJsonObject(reference, KEY_DRIVER_DISTRACTION),
+            assertEquals(TestValues.MATCH, JsonUtils.readStringFromJsonObject(reference, KEY_DRIVER_DISTRACTION),
                     JsonUtils.readStringFromJsonObject(underTest, KEY_DRIVER_DISTRACTION));
 
         } catch(JSONException e){

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/HMICapabilitiesTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/HMICapabilitiesTests.java
@@ -9,6 +9,7 @@ import junit.framework.TestCase;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import static com.smartdevicelink.proxy.rpc.HMICapabilities.KEY_DRIVER_DISTRACTION;
 import static com.smartdevicelink.proxy.rpc.HMICapabilities.KEY_NAVIGATION;
 import static com.smartdevicelink.proxy.rpc.HMICapabilities.KEY_PHONE_CALL;
 import static com.smartdevicelink.proxy.rpc.HMICapabilities.KEY_VIDEO_STREAMING;
@@ -23,6 +24,7 @@ public class HMICapabilitiesTests extends TestCase {
         msg.setNavigationAvilable(TestValues.GENERAL_BOOLEAN);
         msg.setPhoneCallAvilable(TestValues.GENERAL_BOOLEAN);
 	    msg.setVideoStreamingAvailable(TestValues.GENERAL_BOOLEAN);
+	    msg.setDriverDistraction(TestValues.GENERAL_BOOLEAN);
     }
 
     /**
@@ -33,11 +35,13 @@ public class HMICapabilitiesTests extends TestCase {
         Boolean navAvail = msg.isNavigationAvailable();
         Boolean phoneAvail = msg.isPhoneCallAvailable();
 	    Boolean vidStreamAvail = msg.isVideoStreamingAvailable();
+	    Boolean driverDistractionAvail = msg.isDriverDistractionAvailable();
 
         // Valid Tests
         assertEquals(TestValues.MATCH, (Boolean) TestValues.GENERAL_BOOLEAN, navAvail);
         assertEquals(TestValues.MATCH, (Boolean) TestValues.GENERAL_BOOLEAN, phoneAvail);
 	    assertEquals(TestValues.MATCH, (Boolean) TestValues.GENERAL_BOOLEAN, vidStreamAvail);
+	    assertEquals(TestValues.MATCH, (Boolean) TestValues.GENERAL_BOOLEAN, driverDistractionAvail);
 
         // Invalid/Null Tests
         HMICapabilities msg = new HMICapabilities();
@@ -46,6 +50,8 @@ public class HMICapabilitiesTests extends TestCase {
         assertFalse(msg.isNavigationAvailable());
         assertFalse(msg.isPhoneCallAvailable());
 	    assertFalse(msg.isVideoStreamingAvailable());
+        assertFalse(msg.isDriverDistractionAvailable());
+
     }
 
     public void testJson(){
@@ -55,6 +61,7 @@ public class HMICapabilitiesTests extends TestCase {
             reference.put(KEY_NAVIGATION, TestValues.GENERAL_BOOLEAN);
             reference.put(HMICapabilities.KEY_PHONE_CALL, TestValues.GENERAL_BOOLEAN);
 	        reference.put(HMICapabilities.KEY_VIDEO_STREAMING, TestValues.GENERAL_BOOLEAN);
+	        reference.put(KEY_DRIVER_DISTRACTION, TestValues.GENERAL_BOOLEAN);
 
             JSONObject underTest = msg.serializeJSON();
             assertEquals(TestValues.MATCH, reference.length(), underTest.length());
@@ -67,6 +74,9 @@ public class HMICapabilitiesTests extends TestCase {
 
 	        assertEquals(TestValues.MATCH, JsonUtils.readStringListFromJsonObject(reference, KEY_VIDEO_STREAMING),
 			        JsonUtils.readStringListFromJsonObject(underTest, KEY_VIDEO_STREAMING));
+	        assertEquals(TestValues.MATCH, JsonUtils.readStringFromJsonObject(reference, KEY_DRIVER_DISTRACTION),
+                    JsonUtils.readStringFromJsonObject(underTest, KEY_DRIVER_DISTRACTION));
+
         } catch(JSONException e){
             fail(TestValues.JSON_FAIL);
         }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/SystemCapabilityTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/SystemCapabilityTests.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import com.smartdevicelink.marshal.JsonRPCMarshaller;
 import com.smartdevicelink.proxy.rpc.AppServicesCapabilities;
 import com.smartdevicelink.proxy.rpc.DisplayCapability;
+import com.smartdevicelink.proxy.rpc.DriverDistractionCapability;
 import com.smartdevicelink.proxy.rpc.NavigationCapability;
 import com.smartdevicelink.proxy.rpc.PhoneCapability;
 import com.smartdevicelink.proxy.rpc.RemoteControlCapabilities;
@@ -42,6 +43,8 @@ public class SystemCapabilityTests extends TestCase {
         msg.setCapabilityForType(SystemCapabilityType.REMOTE_CONTROL, TestValues.GENERAL_REMOTECONTROLCAPABILITIES);
         msg.setCapabilityForType(SystemCapabilityType.APP_SERVICES, TestValues.GENERAL_APP_SERVICE_CAPABILITIES);
         msg.setCapabilityForType(SystemCapabilityType.DISPLAYS, TestValues.GENERAL_DISPLAYCAPABILITY_LIST);
+        msg.setCapabilityForType(SystemCapabilityType.DRIVER_DISTRACTION, TestValues.GENERAL_DRIVERDISTRACTIONCAPABILITY);
+
     }
 
     /**
@@ -55,6 +58,7 @@ public class SystemCapabilityTests extends TestCase {
         RemoteControlCapabilities testRemoteControlCapabilities = (RemoteControlCapabilities) msg.getCapabilityForType(SystemCapabilityType.REMOTE_CONTROL);
         AppServicesCapabilities testAppServicesCapabilities = (AppServicesCapabilities) msg.getCapabilityForType(SystemCapabilityType.APP_SERVICES);
         List<DisplayCapability> displayCapabilities = (List<DisplayCapability>) msg.getCapabilityForType(SystemCapabilityType.DISPLAYS);
+        DriverDistractionCapability testDriverDistractionCapability = (DriverDistractionCapability) msg.getCapabilityForType(SystemCapabilityType.DRIVER_DISTRACTION);
 
         // Valid Tests
         assertEquals(TestValues.MATCH, TestValues.GENERAL_SYSTEMCAPABILITYTYPE, testType);
@@ -62,6 +66,8 @@ public class SystemCapabilityTests extends TestCase {
         assertTrue(TestValues.TRUE, Validator.validatePhoneCapability(TestValues.GENERAL_PHONECAPABILITY, testPhoneCapability));
         assertTrue(TestValues.TRUE, Validator.validateRemoteControlCapabilities(TestValues.GENERAL_REMOTECONTROLCAPABILITIES, testRemoteControlCapabilities));
         assertTrue(TestValues.TRUE, Validator.validateAppServiceCapabilities(TestValues.GENERAL_APP_SERVICE_CAPABILITIES, testAppServicesCapabilities));
+        assertTrue(TestValues.TRUE, Validator.validateDriverDistractionCapability(TestValues.GENERAL_DRIVERDISTRACTIONCAPABILITY, testDriverDistractionCapability));
+
 
         for(int i = 0; i < TestValues.GENERAL_DISPLAYCAPABILITY_LIST.size(); i++){
             assertTrue(TestValues.TRUE, Validator.validateDisplayCapability(TestValues.GENERAL_DISPLAYCAPABILITY_LIST.get(i), displayCapabilities.get(i)));
@@ -77,6 +83,8 @@ public class SystemCapabilityTests extends TestCase {
         assertNull(TestValues.NULL, msg.getCapabilityForType(SystemCapabilityType.REMOTE_CONTROL));
         assertNull(TestValues.NULL, msg.getCapabilityForType(SystemCapabilityType.APP_SERVICES));
         assertNull(TestValues.NULL, msg.getCapabilityForType(SystemCapabilityType.DISPLAYS));
+        assertNull(TestValues.NULL, msg.getCapabilityForType(SystemCapabilityType.DRIVER_DISTRACTION));
+
     }
 
     public void testJson() {
@@ -89,6 +97,7 @@ public class SystemCapabilityTests extends TestCase {
             reference.put(SystemCapability.KEY_REMOTE_CONTROL_CAPABILITY, JsonRPCMarshaller.serializeHashtable(TestValues.GENERAL_REMOTECONTROLCAPABILITIES.getStore()));
             reference.put(SystemCapability.KEY_APP_SERVICES_CAPABILITIES, JsonRPCMarshaller.serializeHashtable(TestValues.GENERAL_APP_SERVICE_CAPABILITIES.getStore()));
             reference.put(SystemCapability.KEY_DISPLAY_CAPABILITIES, TestValues.JSON_DISPLAYCAPABILITY_LIST);
+            reference.put(SystemCapability.KEY_DRIVER_DISTRACTION_CAPABILITY, JsonRPCMarshaller.serializeHashtable(TestValues.GENERAL_DRIVERDISTRACTIONCAPABILITY.getStore()));
 
             JSONObject underTest = msg.serializeJSON();
             assertEquals(TestValues.MATCH, reference.length(), underTest.length());
@@ -133,7 +142,13 @@ public class SystemCapabilityTests extends TestCase {
                         Hashtable<String, Object> hashTest= JsonRPCMarshaller.deserializeJSONObject(underTestArray.getJSONObject(i));
                         assertTrue(TestValues.TRUE, Validator.validateDisplayCapability(new DisplayCapability(hashReference), new DisplayCapability(hashTest)));
                     }
-                } else{
+                } else if (key.equals(SystemCapability.KEY_DRIVER_DISTRACTION_CAPABILITY)) {
+                    JSONObject objectEquals = (JSONObject) JsonUtils.readObjectFromJsonObject(reference, key);
+                    JSONObject testEquals = (JSONObject) JsonUtils.readObjectFromJsonObject(underTest, key);
+                    Hashtable<String, Object> hashReference = JsonRPCMarshaller.deserializeJSONObject(objectEquals);
+                    Hashtable<String, Object> hashTest = JsonRPCMarshaller.deserializeJSONObject(testEquals);
+                    assertTrue(TestValues.TRUE, Validator.validateDriverDistractionCapability(new DriverDistractionCapability(hashReference), new DriverDistractionCapability(hashTest)));
+                } else {
                     assertEquals(TestValues.MATCH, JsonUtils.readObjectFromJsonObject(reference, key), JsonUtils.readObjectFromJsonObject(underTest, key));
                 }
             }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/SystemCapabilityTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/SystemCapabilityTests.java
@@ -6,6 +6,7 @@ import com.smartdevicelink.marshal.JsonRPCMarshaller;
 import com.smartdevicelink.proxy.rpc.AppServicesCapabilities;
 import com.smartdevicelink.proxy.rpc.DisplayCapability;
 import com.smartdevicelink.proxy.rpc.DriverDistractionCapability;
+import com.smartdevicelink.proxy.rpc.HMICapabilities;
 import com.smartdevicelink.proxy.rpc.NavigationCapability;
 import com.smartdevicelink.proxy.rpc.PhoneCapability;
 import com.smartdevicelink.proxy.rpc.RemoteControlCapabilities;
@@ -84,6 +85,11 @@ public class SystemCapabilityTests extends TestCase {
         assertNull(TestValues.NULL, msg.getCapabilityForType(SystemCapabilityType.APP_SERVICES));
         assertNull(TestValues.NULL, msg.getCapabilityForType(SystemCapabilityType.DISPLAYS));
         assertNull(TestValues.NULL, msg.getCapabilityForType(SystemCapabilityType.DRIVER_DISTRACTION));
+
+        // Testing Setting an HMICapability as a SystemCapability
+        HMICapabilities hmiCapabilities = new HMICapabilities();
+        msg.setCapabilityForType(SystemCapabilityType.HMI, hmiCapabilities);
+        assertNull(TestValues.NULL, msg.getCapabilityForType(SystemCapabilityType.HMI));
 
     }
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/SystemCapabilityTypeTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/SystemCapabilityTypeTests.java
@@ -54,6 +54,8 @@ public class SystemCapabilityTypeTests extends TestCase {
 		SystemCapabilityType enumPrerecordedSpeech = SystemCapabilityType.valueForString(example);
 		example = "DISPLAYS";
 		SystemCapabilityType enumDisplays = SystemCapabilityType.valueForString(example);
+		example = "DRIVER_DISTRACTION";
+		SystemCapabilityType enumDriverDistraction = SystemCapabilityType.valueForString(example);
 
 		assertNotNull("NAVIGATION returned null", enumNavigation);
 		assertNotNull("PHONE_CALL returned null", enumPhoneCall);
@@ -73,6 +75,8 @@ public class SystemCapabilityTypeTests extends TestCase {
 		assertNotNull("SEAT_LOCATION return null", enumSeatLocation);
 		assertNotNull("PRERECORDED_SPEECH", enumPrerecordedSpeech);
 		assertNotNull("DISPLAYS", enumDisplays);
+		assertNotNull("DRIVER_DISTRACTION", enumDriverDistraction);
+
 	}
 
 	/**
@@ -128,6 +132,8 @@ public class SystemCapabilityTypeTests extends TestCase {
 		enumTestList.add(SystemCapabilityType.SEAT_LOCATION);
 		enumTestList.add(SystemCapabilityType.PRERECORDED_SPEECH);
 		enumTestList.add(SystemCapabilityType.DISPLAYS);
+		enumTestList.add(SystemCapabilityType.DRIVER_DISTRACTION);
+
 
 		assertTrue("Enum value list does not match enum class list", 
 				enumValueList.containsAll(enumTestList) && enumTestList.containsAll(enumValueList));

--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
@@ -104,7 +104,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 abstract class BaseLifecycleManager {
 
     static final String TAG = "Lifecycle Manager";
-    public static final Version MAX_SUPPORTED_RPC_VERSION = new Version(6, 0, 0);
+    public static final Version MAX_SUPPORTED_RPC_VERSION = new Version(7, 0, 0);
 
     // Protected Correlation IDs
     private final int REGISTER_APP_INTERFACE_CORRELATION_ID = 65529,

--- a/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
@@ -428,7 +428,7 @@ public class SystemCapabilityManager {
 					case SEAT_LOCATION:
 						return hmiCapabilities.isSeatLocationAvailable();
 					case DRIVER_DISTRACTION:
-						return hmiCapabilities.getDriverDistraction();
+						return hmiCapabilities.isDriverDistractionAvailable();
 					default:
 						return false;
 				}

--- a/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
@@ -427,6 +427,8 @@ public class SystemCapabilityManager {
 						return hmiCapabilities.isDisplaysCapabilityAvailable();
 					case SEAT_LOCATION:
 						return hmiCapabilities.isSeatLocationAvailable();
+					case DRIVER_DISTRACTION:
+						return hmiCapabilities.getDriverDistraction();
 					default:
 						return false;
 				}

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/DriverDistractionCapability.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/DriverDistractionCapability.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2017 - 2020, SmartDeviceLink Consortium, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.smartdevicelink.proxy.rpc;
+
+import com.smartdevicelink.proxy.RPCStruct;
+
+import java.util.Hashtable;
+
+/**
+ *
+ * <p><b>Parameter List</b></p>
+ *
+ * <table border="1" rules="all">
+ *  <tr>
+ *      <th>Param Name</th>
+ *      <th>Type</th>
+ *      <th>Description</th>
+ *      <th>Required</th>
+ *      <th>Version Available</th>
+ *  </tr>
+ *  <tr>
+ *      <td>menuLength</td>
+ *      <td>Integer</td>
+ *      <td>The number of items allowed in a Choice Set or Command menu while the driver is distracted</td>
+ *      <td>N</td>
+ *      <td></td>
+ *  </tr>
+ *  <tr>
+ *      <td>subMenuDepth</td>
+ *      <td>Integer</td>
+ *      <td>The depth of submenus allowed when the driver is distracted. e.g. 3 == top level menu ->submenu -> submenu; 1 == top level menu only</td>
+ *      <td>N</td>
+ *      <td></td>
+ *  </tr>
+ * </table>
+ * @since SmartDeviceLink 7.0.0
+ */
+public class DriverDistractionCapability extends RPCStruct {
+    public static final String KEY_MENU_LENGTH = "menuLength";
+    public static final String KEY_SUB_MENU_DEPTH = "subMenuDepth";
+
+    /**
+     * Constructs a new DriverDistractionCapability object
+     */
+    public DriverDistractionCapability() { }
+
+    /**
+     * Constructs a new DriverDistractionCapability object indicated by the Hashtable parameter
+     *
+     * @param hash The Hashtable to use
+     */
+    public DriverDistractionCapability(Hashtable<String, Object> hash) {
+        super(hash);
+    }
+
+    /**
+     * Sets the menuLength.
+     *
+     * @param menuLength The number of items allowed in a Choice Set or Command menu while the driver is distracted
+     */
+    public void setMenuLength(Integer menuLength) {
+        setValue(KEY_MENU_LENGTH, menuLength);
+    }
+
+    /**
+     * Gets the menuLength.
+     *
+     * @return Integer The number of items allowed in a Choice Set or Command menu while the driver is distracted
+     */
+    public Integer getMenuLength() {
+        return getInteger(KEY_MENU_LENGTH);
+    }
+
+    /**
+     * Sets the subMenuDepth.
+     *
+     * @param subMenuDepth The depth of submenus allowed when the driver is distracted. e.g. 3 == top level menu ->
+     * submenu -> submenu; 1 == top level menu only
+     */
+    public void setSubMenuDepth(Integer subMenuDepth) {
+        setValue(KEY_SUB_MENU_DEPTH, subMenuDepth);
+    }
+
+    /**
+     * Gets the subMenuDepth.
+     *
+     * @return Integer The depth of submenus allowed when the driver is distracted. e.g. 3 == top level menu ->
+     * submenu -> submenu; 1 == top level menu only
+     */
+    public Integer getSubMenuDepth() {
+        return getInteger(KEY_SUB_MENU_DEPTH);
+    }
+}

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/HMICapabilities.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/HMICapabilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2019, SmartDeviceLink Consortium, Inc.
+ * Copyright (c) 2017 - 2020, SmartDeviceLink Consortium, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -13,9 +13,9 @@
  * disclaimer in the documentation and/or other materials provided with the
  * distribution.
  *
- * Neither the name of the SmartDeviceLink Consortium, Inc. nor the names of its
- * contributors may be used to endorse or promote products derived from this 
- * software without specific prior written permission.
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -43,6 +43,7 @@ public class HMICapabilities extends RPCStruct{
     public static final String KEY_APP_SERVICES = "appServices";
     public static final String KEY_DISPLAYS = "displays";
     public static final String KEY_SEAT_LOCATION = "seatLocation";
+    public static final String KEY_DRIVER_DISTRACTION = "driverDistraction";
 
 	public HMICapabilities() { }
 	  
@@ -133,5 +134,23 @@ public class HMICapabilities extends RPCStruct{
 	public void setSeatLocationAvailable(Boolean available){
 		setValue(KEY_SEAT_LOCATION, available);
 	}
+    /**
+     * Sets the driverDistraction.
+     *
+     * @param driverDistraction Availability of driver distraction capability. True: Available, False: Not Available
+     * @since SmartDeviceLink 7.0.0
+     */
+    public void setDriverDistraction(Boolean driverDistraction) {
+        setValue(KEY_DRIVER_DISTRACTION, driverDistraction);
+    }
 
+    /**
+     * Gets the driverDistraction.
+     *
+     * @return Boolean Availability of driver distraction capability. True: Available, False: Not Available
+     * @since SmartDeviceLink 7.0.0
+     */
+    public Boolean getDriverDistraction() {
+        return getBoolean(KEY_DRIVER_DISTRACTION);
+    }
 }

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/HMICapabilities.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/HMICapabilities.java
@@ -134,6 +134,7 @@ public class HMICapabilities extends RPCStruct{
 	public void setSeatLocationAvailable(Boolean available){
 		setValue(KEY_SEAT_LOCATION, available);
 	}
+
     /**
      * Sets the driverDistraction.
      *

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/HMICapabilities.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/HMICapabilities.java
@@ -150,7 +150,7 @@ public class HMICapabilities extends RPCStruct{
      * @return Boolean Availability of driver distraction capability. True: Available, False: Not Available
      * @since SmartDeviceLink 7.0.0
      */
-    public Boolean getDriverDistraction() {
+    public Boolean isDriverDistractionAvailable() {
         return getBoolean(KEY_DRIVER_DISTRACTION);
     }
 }

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/HMICapabilities.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/HMICapabilities.java
@@ -150,7 +150,11 @@ public class HMICapabilities extends RPCStruct{
      * @return Boolean Availability of driver distraction capability. True: Available, False: Not Available
      * @since SmartDeviceLink 7.0.0
      */
-    public Boolean isDriverDistractionAvailable() {
-        return getBoolean(KEY_DRIVER_DISTRACTION);
-    }
+	public Boolean isDriverDistractionAvailable() {
+		Object available = getValue(KEY_DRIVER_DISTRACTION);
+		if (available == null) {
+			return false;
+		}
+		return (Boolean) available;
+	}
 }

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/SystemCapability.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/SystemCapability.java
@@ -101,7 +101,7 @@ public class SystemCapability extends RPCStruct {
         } else if (type.equals(SystemCapabilityType.DISPLAYS)) {
             return getObject(DisplayCapability.class, KEY_DISPLAY_CAPABILITIES);
         } else if (type.equals(SystemCapabilityType.DRIVER_DISTRACTION)) {
-            return getObject(DisplayCapabilities.class, KEY_DRIVER_DISTRACTION_CAPABILITY);
+            return getObject(DriverDistractionCapability.class, KEY_DRIVER_DISTRACTION_CAPABILITY);
         } else {
             return null;
         }

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/SystemCapability.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/SystemCapability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2019, SmartDeviceLink Consortium, Inc.
+ * Copyright (c) 2017 - 2020, SmartDeviceLink Consortium, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -13,9 +13,9 @@
  * disclaimer in the documentation and/or other materials provided with the
  * distribution.
  *
- * Neither the name of the SmartDeviceLink Consortium, Inc. nor the names of its
- * contributors may be used to endorse or promote products derived from this 
- * software without specific prior written permission.
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -51,6 +51,8 @@ public class SystemCapability extends RPCStruct {
     public static final String KEY_APP_SERVICES_CAPABILITIES = "appServicesCapabilities";
     public static final String KEY_SEAT_LOCATION_CAPABILITY = "seatLocationCapability";
     public static final String KEY_DISPLAY_CAPABILITIES = "displayCapabilities";
+    public static final String KEY_DRIVER_DISTRACTION_CAPABILITY = "driverDistractionCapability";
+
     public SystemCapability(){}
 
     public SystemCapability(Hashtable<String, Object> hash) {
@@ -98,6 +100,8 @@ public class SystemCapability extends RPCStruct {
             return getObject(SeatLocationCapability.class, KEY_SEAT_LOCATION_CAPABILITY);
         } else if (type.equals(SystemCapabilityType.DISPLAYS)) {
             return getObject(DisplayCapability.class, KEY_DISPLAY_CAPABILITIES);
+        } else if (type.equals(SystemCapabilityType.DRIVER_DISTRACTION)) {
+            return getObject(DisplayCapabilities.class, KEY_DRIVER_DISTRACTION_CAPABILITY);
         } else {
             return null;
         }
@@ -120,6 +124,8 @@ public class SystemCapability extends RPCStruct {
             setValue(KEY_SEAT_LOCATION_CAPABILITY, capability);
         } else if (type.equals(SystemCapabilityType.DISPLAYS)) {
             setValue(KEY_DISPLAY_CAPABILITIES, capability);
+        } else if (type.equals(SystemCapabilityType.DRIVER_DISTRACTION)) {
+            setValue(KEY_DRIVER_DISTRACTION_CAPABILITY, capability);
         } else {
             return;
         }

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/SystemCapabilityType.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/SystemCapabilityType.java
@@ -564,9 +564,9 @@ public enum SystemCapabilityType {
 	 * 		<tr>
 	 * 			<td>DRIVER_DISTRACTION</td>
 	 * 			<td>DriverDistractionCapability</td>
-	 * 			<td>Describes capabilities when the driver is distracted</td>
+	 * 			<td>Returns DRIVER_DISTRACTION</td>
 	 * 			<td align=center>N</td>
-	 * 			<td>@since SmartDeviceLink 7.0.0</td>
+	 * 			<td><strong>Since 7.0</strong> Describes capabilities when the driver is distracted</td>
 	 * 		</tr>
 	 * 	</table>
 	 */

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/SystemCapabilityType.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/SystemCapabilityType.java
@@ -553,7 +553,22 @@ public enum SystemCapabilityType {
 	SEAT_LOCATION (true),
 
 	/**
-	 * @since SmartDeviceLink 7.0.0
+	 * <table border="1" rules="all">
+	 * 		<tr>
+	 * 			<th>Enum Name</th>
+	 * 			<th>Return Type</th>
+	 * 			<th>Description</th>
+	 * 			<th>Requires Async?</th>
+	 * 			<th>Notes</th>
+	 * 		</tr>
+	 * 		<tr>
+	 * 			<td>DRIVER_DISTRACTION</td>
+	 * 			<td>DriverDistractionCapability</td>
+	 * 			<td>Describes capabilities when the driver is distracted</td>
+	 * 			<td align=center>N</td>
+	 * 			<td>@since SmartDeviceLink 7.0.0</td>
+	 * 		</tr>
+	 * 	</table>
 	 */
 	DRIVER_DISTRACTION(true);
 

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/SystemCapabilityType.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/SystemCapabilityType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2019, SmartDeviceLink Consortium, Inc.
+ * Copyright (c) 2017 - 2020, SmartDeviceLink Consortium, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -13,9 +13,9 @@
  * disclaimer in the documentation and/or other materials provided with the
  * distribution.
  *
- * Neither the name of the SmartDeviceLink Consortium, Inc. nor the names of its
- * contributors may be used to endorse or promote products derived from this 
- * software without specific prior written permission.
+ * Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+ * its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -551,6 +551,11 @@ public enum SystemCapabilityType {
 	 * 	</table>
 	 */
 	SEAT_LOCATION (true),
+
+	/**
+	 * @since SmartDeviceLink 7.0.0
+	 */
+	DRIVER_DISTRACTION(true);
 
 	;
 

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/SystemCapabilityType.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/SystemCapabilityType.java
@@ -155,6 +155,13 @@ package com.smartdevicelink.proxy.rpc.enums;
  * 	       <td align=center>N</td>
  * 	       <td>Available Asynchronously, Call is synchronous <strong>after</strong> initial call</strong></td>
  * 	   </tr>
+ * 	   <tr>
+ * 	       <td>DRIVER_DISTRACTION</td>
+ * 	       <d>DriverDistractionCapability</td>
+ * 	       <td>Returns DRIVER_DISTRACTION</td>
+ * 	       <td align=center>N</td>
+ * 	       <td><strong>Since 7.0</strong> Describes capabilities when the driver is distracted</td>
+ * 	   </tr>
  * 	</table>
  *
  */


### PR DESCRIPTION
Fixes #729 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE

#### Unit Tests
Unit tests added for the new RPCs

#### Core Tests
Core branch: smartdevicelink/sdl_core#3447
Rpc_Spec branch: smartdevicelink/rpc_spec#263
Generic_HMI branch: smartdevicelink/generic_hmi#282

### Summary
This PR implements [SDL-0152](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0152-driver-distraction-list-limits.md) to allow the HMI to limit menu structures while driving.

Create an integration branch and test with [Implement SDL-0148 Additional SubMenus](https://github.com/smartdevicelink/sdl_java_suite/pull/1423)

### Changelog
##### Enhancements
* Implements (#962) the ability for an HMI to limit menu structures while driving.

### Tasks Remaining:
- [x] Write unit test
- [x] Test with core Android and JavaSE
- [x] Compare with IOS

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
