### PR TITLE
Feature/0202 supported character sets

### DIFF
--- a/android/sdl_android/src/androidTest/assets/json/RegisterAppInterface.json
+++ b/android/sdl_android/src/androidTest/assets/json/RegisterAppInterface.json
@@ -163,7 +163,7 @@
           },
           {
             "width":1980,
-            "characterSet":"CID2SET",
+            "characterSet":"UTF_8",
             "rows":960,
             "name":"scrollableMessageBody"
           },

--- a/android/sdl_android/src/androidTest/assets/json/SetDisplayLayout.json
+++ b/android/sdl_android/src/androidTest/assets/json/SetDisplayLayout.json
@@ -73,7 +73,7 @@
           },
           {
             "width":1980,
-            "characterSet":"CID2SET",
+            "characterSet":"UTF_8",
             "rows":960,
             "name":"scrollableMessageBody"
           },

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/CharacterSetTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/CharacterSetTests.java
@@ -26,11 +26,20 @@ public class CharacterSetTests extends TestCase {
 		CharacterSet enumCid1Set = CharacterSet.valueForString(example);
 		example = "CID2SET";
 		CharacterSet enumCid2Set = CharacterSet.valueForString(example);
-		
+		example = "ASCII";
+		CharacterSet enumAsciiSet = CharacterSet.valueForString(example);
+		example = "ISO_8859_1";
+		CharacterSet enumIsoSet = CharacterSet.valueForString(example);
+		example = "UTF_8";
+		CharacterSet enumUtfSet = CharacterSet.valueForString(example);
+
 		assertNotNull("TYPE2SET returned null", enumType2Set);
 		assertNotNull("TYPE5SET returned null", enumType5Set);
 		assertNotNull("CID1SET returned null", enumCid1Set);
 		assertNotNull("CID2SET returned null", enumCid2Set);
+		assertNotNull("ASCII returned null", enumAsciiSet);
+		assertNotNull("ISO_8859_1 returned null", enumIsoSet);
+		assertNotNull("UTF_8 returned null", enumUtfSet);
 	}
 
 	/**

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/CharacterSetTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/CharacterSetTests.java
@@ -72,6 +72,9 @@ public class CharacterSetTests extends TestCase {
 		enumTestList.add(CharacterSet.TYPE5SET);
 		enumTestList.add(CharacterSet.CID1SET);
 		enumTestList.add(CharacterSet.CID2SET);
+		enumTestList.add(CharacterSet.ASCII);
+		enumTestList.add(CharacterSet.ISO_8859_1);
+		enumTestList.add(CharacterSet.UTF_8);
 
 		assertTrue("Enum value list does not match enum class list", 
 				enumValueList.containsAll(enumTestList) && enumTestList.containsAll(enumValueList));

--- a/base/src/main/java/com/smartdevicelink/managers/ManagerUtility.java
+++ b/base/src/main/java/com/smartdevicelink/managers/ManagerUtility.java
@@ -107,7 +107,7 @@ public class ManagerUtility {
         public static List<TextField> getAllTextFields() {
             List<TextField> allTextFields = new ArrayList<>();
             for (TextFieldName name : TextFieldName.values()) {
-                allTextFields.add(new TextField(name, CharacterSet.CID1SET, 500, 8));
+                allTextFields.add(new TextField(name, CharacterSet.UTF_8, 500, 8));
             }
             return allTextFields;
         }

--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
@@ -104,7 +104,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 abstract class BaseLifecycleManager {
 
     static final String TAG = "Lifecycle Manager";
-    public static final Version MAX_SUPPORTED_RPC_VERSION = new Version(6, 0, 0);
+    public static final Version MAX_SUPPORTED_RPC_VERSION = new Version(7, 0, 0);
 
     // Protected Correlation IDs
     private final int REGISTER_APP_INTERFACE_CORRELATION_ID = 65529,

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/TextField.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/TextField.java
@@ -143,7 +143,9 @@ public class TextField extends RPCStruct {
     }
     /**
      * Get the character set that is supported in this field.
-     * @return the character set
+     * @return The set of characters that are supported by this text field.
+     * All text is sent in UTF-8 format, but not all systems may support all of the characters expressed by UTF-8.
+     * All systems will support at least ASCII, but they may support more, either the LATIN-1 character set, or the full UTF-8 character set.
      */    
     public CharacterSet getCharacterSet() {
         return (CharacterSet) getObject(CharacterSet.class, KEY_CHARACTER_SET);

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/TextField.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/TextField.java
@@ -58,7 +58,7 @@ import java.util.Hashtable;
  * 		<tr>
  * 			<td>characterSet</td>
  * 			<td>CharacterSet</td>
- * 			<td>The character set that is supported in this field.	</td>
+ * 			<td>The set of characters that are supported by this text field. All text is sent in UTF-8 format, but not all systems may support all of the characters expressed by UTF-8. All systems will support at least ASCII, but they may support more, either the LATIN-1 character set, or the full UTF-8 character set.	</td>
  * 			<td>SmartDeviceLink 1.0</td>
  * 		</tr>
  * 		<tr>
@@ -114,7 +114,9 @@ public class TextField extends RPCStruct {
 	/**
 	 * Constructs a newly allocated TextField object
 	 * @param name Enumeration identifying the field.
-	 * @param characterSet The character set that is supported in this field.
+	 * @param characterSet The set of characters that are supported by this text field.
+     * All text is sent in UTF-8 format, but not all systems may support all of the characters expressed by UTF-8.
+     * All systems will support at least ASCII, but they may support more, either the LATIN-1 character set, or the full UTF-8 character set.
 	 * @param width The number of characters in one row of this field.
 	 * @param rows The number of rows for this text field.
 	 */
@@ -148,7 +150,9 @@ public class TextField extends RPCStruct {
     }
     /**
      * Set the character set that is supported in this field.
-     * @param characterSet - the character set
+     * @param characterSet - The set of characters that are supported by this text field.
+     * All text is sent in UTF-8 format, but not all systems may support all of the characters expressed by UTF-8.
+     * All systems will support at least ASCII, but they may support more, either the LATIN-1 character set, or the full UTF-8 character set.
      */    
     public void setCharacterSet(@NonNull CharacterSet characterSet ) {
         setValue(KEY_CHARACTER_SET, characterSet);

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/CharacterSet.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/CharacterSet.java
@@ -35,10 +35,47 @@ package com.smartdevicelink.proxy.rpc.enums;
  * @since SmartDeviceLink 1.0
  */
 public enum CharacterSet {
+    /**
+     * @since SmartDeviceLink 7.0.0
+     */
+    @Deprecated
     TYPE2SET,
+    /**
+     * @since SmartDeviceLink 7.0.0
+     */
+    @Deprecated
     TYPE5SET,
+    /**
+     * @since SmartDeviceLink 7.0.0
+     */
+    @Deprecated
     CID1SET,
-    CID2SET;
+    /**
+     * @since SmartDeviceLink 7.0.0
+     */
+    @Deprecated
+    CID2SET,
+    /**
+     * ASCII as defined in https://en.wikipedia.org/wiki/ASCII as defined in codes 0-127.
+     * Non-printable characters such as tabs and back spaces are ignored.
+     *
+     * @since SmartDeviceLink 7.0.0
+     */
+    ASCII,
+    /**
+     * Latin-1, as defined in https://en.wikipedia.org/wiki/ISO/IEC_8859-1
+     *
+     * @since SmartDeviceLink 7.0.0
+     */
+    ISO_8859_1,
+    /**
+     * The UTF-8 character set that uses variable bytes per code point.
+     * See https://en.wikipedia.org/wiki/UTF-8 for more details.
+     * This is the preferred character set.
+     *
+     * @since SmartDeviceLink 7.0.0
+     */
+    UTF_8;
 
     /**
      * Convert String to CharacterSet

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/CharacterSet.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/CharacterSet.java
@@ -36,22 +36,22 @@ package com.smartdevicelink.proxy.rpc.enums;
  */
 public enum CharacterSet {
     /**
-     * @since SmartDeviceLink 7.0.0
+     * @deprecated in SmartDeviceLink 7.0.0
      */
     @Deprecated
     TYPE2SET,
     /**
-     * @since SmartDeviceLink 7.0.0
+     * @deprecated in SmartDeviceLink 7.0.0
      */
     @Deprecated
     TYPE5SET,
     /**
-     * @since SmartDeviceLink 7.0.0
+     * @deprecated in SmartDeviceLink 7.0.0
      */
     @Deprecated
     CID1SET,
     /**
-     * @since SmartDeviceLink 7.0.0
+     * @deprecated in SmartDeviceLink 7.0.0
      */
     @Deprecated
     CID2SET,


### PR DESCRIPTION
Fixes #950 

This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [X] I have tested Android, Java SE, and Java EE

#### Unit Tests
Unit tests have been updated to account for deprecated Character Sets and for new Character Sets

#### Core Tests
Tested against the CharacterSet branches of Core and Sdl_Hmi and ensured TextFields are appearing correctly. Also verified that UTF_8 characters were able to be displayed in the text fields.
https://github.com/smartdevicelink/sdl_hmi/pull/384
https://github.com/smartdevicelink/sdl_core/pull/3454

### Summary
These changes deprecate the old CharacterSet enums(TYPE2SET, TYPE5SET, CID1SET, CID2SET) and adds 3 new enums(ASCII, ISO_8859_1, and UTF_8) and UTF_8 is the new prefered CharacterSet

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
