### PR TITLE
Fix ClassCastException when calling RPC getter method returning Float 

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/RPCStructTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/RPCStructTests.java
@@ -155,4 +155,32 @@ public class RPCStructTests extends TestCase {
         testStruct.setValue(invalidKey, TestValues.GENERAL_STRING);
         assertNull(testStruct.getObject(Integer.class, invalidKey));
     }
+
+    public void testGetFloat() {
+        Hashtable <String, Object> map = new Hashtable<>();
+        String key = "test";
+        Double value = 42.00;
+        map.put(key, value);
+        RPCStruct rpcStruct = new RPCStruct(map);
+        try {
+            Float value2 = rpcStruct.getFloat(key);
+            assertTrue(value2 - value < 0.1);
+        } catch (ClassCastException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    public void testGetDouble() {
+        Hashtable <String, Object> map = new Hashtable<>();
+        String key = "test";
+        Integer value = 42;
+        map.put(key, value);
+        RPCStruct rpcStruct = new RPCStruct(map);
+        try {
+            Double value2 = rpcStruct.getDouble(key);
+            assertTrue(value2 - value < 0.1);
+        } catch (ClassCastException e) {
+            fail(e.getMessage());
+        }
+    }
 }

--- a/base/src/main/java/com/smartdevicelink/proxy/RPCStruct.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/RPCStruct.java
@@ -32,6 +32,7 @@
 package com.smartdevicelink.proxy;
 
 import com.smartdevicelink.marshal.JsonRPCMarshaller;
+import com.smartdevicelink.util.SdlDataTypeConverter;
 import com.smartdevicelink.util.Version;
 
 import org.json.JSONException;
@@ -345,11 +346,11 @@ public class RPCStruct {
 	}
 
 	public Double getDouble(String key) {
-		return (Double) store.get(key);
+		return SdlDataTypeConverter.objectToDouble(store.get(key));
 	}
 
 	public Float getFloat(String key) {
-		return (Float) store.get(key);
+		return SdlDataTypeConverter.objectToFloat(store.get(key));
 	}
 
 	public Boolean getBoolean(String key) { return (Boolean) store.get(key); }


### PR DESCRIPTION
Fixes #1407 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Core Tests
Get `tirePressure` using the following code snippet and make sure the value is retrieved correctly without crashing the app
```
GetVehicleData getVehicleData = new GetVehicleData();
getVehicleData.setTirePressure(true);
getVehicleData.setOnRPCResponseListener(new OnRPCResponseListener() {
    @Override
    public void onResponse(int correlationId, RPCResponse response) {
        GetVehicleDataResponse getVehicleDataResponse = (GetVehicleDataResponse) response;
        Log.i(TAG, "tirePressure: " + getVehicleDataResponse.getTirePressure().getLeftFront().getPressure());
    }
});
sdlManager.sendRPC(getVehicleData);
```


Module tested against: Manticore

### Summary
This PR fixes an issue in `RCPStruct` that causes a class cast exception when the app tries to retreive value using `getFloat()` & `getDouble()` methods

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
