### PR TITLE
Fix generated enum value names in RPC generator

### DIFF
--- a/generator/transformers/enums_producer.py
+++ b/generator/transformers/enums_producer.py
@@ -73,7 +73,7 @@ class EnumsProducer(InterfaceProducerCommon):
         return render
 
     def extract_param(self, param: EnumElement, kind):
-        d = {'origin': param.name, 'name': self.key(self.converted(param.name))}
+        d = {'origin': param.name, 'name': self.converted(param.name)}
         if kind == 'custom':
             d['internal'] = '"{}"'.format(param.name)
 


### PR DESCRIPTION
Fixes #1425 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR

#### Unit Tests
To smoke test the PR, use the generator to generate `ImageFieldName` enum and make sure all the values are generated correctly. 

### Summary
This PR fixes an issue in the RPC generator that makes it generate enum values with incorrect capitalization. Please refer to the issue to see an example. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
