### PR TITLE
Update RPC Generator to generate correct Android X imports

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -430,7 +430,7 @@ Where `[name]` is the value from the `"name"` attribute of `<struct>`.
 ### Constructor with all required parameters, based on `"mandatory"` attribute of the `<param>`
 This constructor requires the import of `NonNull` annotation
 ```java
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 ```
 
 The constructor should include all set of `<param>` with the `"mandatory"` attribute is "true". JavaDoc should include all constructor parameters and the constructor should call all corresponding setters inside itself.
@@ -590,7 +590,7 @@ Output (javadoc comments skipped):
 ```java
 package com.smartdevicelink.proxy.rpc;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.smartdevicelink.proxy.RPCStruct;
 import com.smartdevicelink.proxy.rpc.enums.TemperatureUnit;
@@ -768,7 +768,7 @@ Where `[name]` is the value from the `"name"` attribute of `<function>`.
 ### Constructor with all required parameters, based on `"mandatory"` attribute of the `<param>`
 This constructor requires the import of `NonNull` annotation
 ```java
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 ```
 
 The constructor should include all set of `<param>` with the `"mandatory"` attribute is "true". JavaDoc should include all constructor parameters and the constructor should call all corresponding setters inside itself.
@@ -997,7 +997,7 @@ Output (javadoc comments skipped):
 ```java
 package com.smartdevicelink.proxy.rpc;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.proxy.RPCResponse;
@@ -1039,7 +1039,7 @@ Output (javadoc comments skipped):
 ```java
 package com.smartdevicelink.proxy.rpc;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.proxy.RPCNotification;

--- a/generator/transformers/functions_producer.py
+++ b/generator/transformers/functions_producer.py
@@ -46,7 +46,7 @@ class FunctionsProducer(InterfaceProducerCommon):
             if not class_name.endswith("Response"):
                 class_name += 'Response'
             imports.add('com.smartdevicelink.proxy.rpc.enums.Result')
-            imports.add('android.support.annotation.NonNull')
+            imports.add('androidx.annotation.NonNull')
         elif item.message_type.name == 'request':
             extends_class = self.request_class
         elif item.message_type.name == 'notification':
@@ -87,9 +87,9 @@ class FunctionsProducer(InterfaceProducerCommon):
 
     def sort_imports(self, imports: set):
         sorted_imports = []
-        if 'android.support.annotation.NonNull' in imports:
-            sorted_imports.append('android.support.annotation.NonNull')
-            imports.remove('android.support.annotation.NonNull')
+        if 'androidx.annotation.NonNull' in imports:
+            sorted_imports.append('androidx.annotation.NonNull')
+            imports.remove('androidx.annotation.NonNull')
             sorted_imports.append('')
         sorted_imports.append('com.smartdevicelink.protocol.enums.FunctionID')
         imports.remove('com.smartdevicelink.protocol.enums.FunctionID')
@@ -143,7 +143,7 @@ class FunctionsProducer(InterfaceProducerCommon):
         if tr in self.struct_names:
             imports.add('{}.{}'.format(self.structs_package, tr))
         if param.is_mandatory:
-            imports.add('android.support.annotation.NonNull')
+            imports.add('androidx.annotation.NonNull')
 
         Params = namedtuple('Params', sorted(p))
         return imports, Params(**p)

--- a/generator/transformers/structs_producer.py
+++ b/generator/transformers/structs_producer.py
@@ -76,9 +76,9 @@ class StructsProducer(InterfaceProducerCommon):
 
     def sort_imports(self, imports: set):
         sorted_imports = []
-        if 'android.support.annotation.NonNull' in imports:
-            sorted_imports.append('android.support.annotation.NonNull')
-            imports.remove('android.support.annotation.NonNull')
+        if 'androidx.annotation.NonNull' in imports:
+            sorted_imports.append('androidx.annotation.NonNull')
+            imports.remove('androidx.annotation.NonNull')
             sorted_imports.append('')
         tmp = []
         for i in imports:
@@ -124,7 +124,7 @@ class StructsProducer(InterfaceProducerCommon):
         if tr in self.struct_names:
             imports.add('{}.{}'.format(self.structs_package, tr))
         if param.is_mandatory:
-            imports.add('android.support.annotation.NonNull')
+            imports.add('androidx.annotation.NonNull')
 
         Params = namedtuple('Params', sorted(p))
         return imports, Params(**p)


### PR DESCRIPTION
Fixes #1444 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

#### Unit Tests
- Use the RPC generator to generate all RPCs
- Confirm that the `annotations` imports are correct and they use the Android X library

### Summary
This PR updates the RPC Generator to generate correct Android X imports instead of the old support library imports 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
