### PR TITLE
Set default value for overwrite to false in SdlFile

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/filetypes/SdlFileTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/filetypes/SdlFileTests.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
 
 @RunWith(AndroidJUnit4.class)
 public class SdlFileTests {
@@ -60,6 +61,7 @@ public class SdlFileTests {
         assertEquals(sdlFile.getType(), TestValues.GENERAL_FILETYPE);
         sdlFile.setPersistent(TestValues.GENERAL_BOOLEAN);
         assertEquals(sdlFile.isPersistent(), TestValues.GENERAL_BOOLEAN);
+        assertFalse(sdlFile.getOverwrite());
 
         // Case 2 (Setting resourceId)
         sdlFile = new SdlFile();
@@ -73,6 +75,7 @@ public class SdlFileTests {
         assertEquals(sdlFile.getType(), TestValues.GENERAL_FILETYPE);
         sdlFile.setPersistent(TestValues.GENERAL_BOOLEAN);
         assertEquals(sdlFile.isPersistent(), TestValues.GENERAL_BOOLEAN);
+        assertFalse(sdlFile.getOverwrite());
 
         // Case 3 (Setting URI)
         sdlFile = new SdlFile();
@@ -86,6 +89,7 @@ public class SdlFileTests {
         assertEquals(sdlFile.getType(), TestValues.GENERAL_FILETYPE);
         sdlFile.setPersistent(TestValues.GENERAL_BOOLEAN);
         assertEquals(sdlFile.isPersistent(), TestValues.GENERAL_BOOLEAN);
+        assertFalse(sdlFile.getOverwrite());
     }
 
     @Test
@@ -96,6 +100,7 @@ public class SdlFileTests {
         assertEquals(sdlFile1.getType(), TestValues.GENERAL_FILETYPE);
         assertEquals((Integer) sdlFile1.getResourceId(), TestValues.GENERAL_INTEGER);
         assertEquals(sdlFile1.isPersistent(), TestValues.GENERAL_BOOLEAN);
+        assertFalse(sdlFile1.getOverwrite());
 
         // Case2 (Let the library generate a name)
         SdlFile sdlFile2 = new SdlFile(null, TestValues.GENERAL_FILETYPE, TestValues.GENERAL_INTEGER, TestValues.GENERAL_BOOLEAN);
@@ -105,6 +110,7 @@ public class SdlFileTests {
         assertEquals(sdlFile2.getType(), TestValues.GENERAL_FILETYPE);
         assertEquals((Integer) sdlFile2.getResourceId(), TestValues.GENERAL_INTEGER);
         assertEquals(sdlFile2.isPersistent(), TestValues.GENERAL_BOOLEAN);
+        assertFalse(sdlFile2.getOverwrite());
     }
 
     @Test
@@ -115,6 +121,7 @@ public class SdlFileTests {
         assertEquals(sdlFile1.getType(), TestValues.GENERAL_FILETYPE);
         assertEquals(sdlFile1.getFileData(), TestValues.GENERAL_BYTE_ARRAY);
         assertEquals(sdlFile1.isPersistent(), TestValues.GENERAL_BOOLEAN);
+        assertFalse(sdlFile1.getOverwrite());
 
         // Case2 (Let the library generate a name)
         SdlFile sdlFile2 = new SdlFile(null, TestValues.GENERAL_FILETYPE, TestValues.GENERAL_BYTE_ARRAY, TestValues.GENERAL_BOOLEAN);
@@ -124,6 +131,7 @@ public class SdlFileTests {
         assertEquals(sdlFile2.getType(), TestValues.GENERAL_FILETYPE);
         assertEquals(sdlFile2.getFileData(), TestValues.GENERAL_BYTE_ARRAY);
         assertEquals(sdlFile2.isPersistent(), TestValues.GENERAL_BOOLEAN);
+        assertFalse(sdlFile2.getOverwrite());
     }
 
     @Test
@@ -134,6 +142,7 @@ public class SdlFileTests {
         assertEquals(sdlFile1.getType(), TestValues.GENERAL_FILETYPE);
         assertEquals(sdlFile1.getUri(), TestValues.GENERAL_URI);
         assertEquals(sdlFile1.isPersistent(), TestValues.GENERAL_BOOLEAN);
+        assertFalse(sdlFile1.getOverwrite());
 
         // Case2 (Let the library generate a name)
         SdlFile sdlFile2 = new SdlFile(null, TestValues.GENERAL_FILETYPE, TestValues.GENERAL_URI, TestValues.GENERAL_BOOLEAN);
@@ -143,5 +152,6 @@ public class SdlFileTests {
         assertEquals(sdlFile2.getType(), TestValues.GENERAL_FILETYPE);
         assertEquals(sdlFile2.getUri(), TestValues.GENERAL_URI);
         assertEquals(sdlFile2.isPersistent(), TestValues.GENERAL_BOOLEAN);
+        assertFalse(sdlFile2.getOverwrite());
     }
 }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
@@ -53,8 +53,8 @@ public class SdlFile{
     private boolean persistentFile;
     private boolean isStaticIcon;
     private boolean shouldAutoGenerateName;
-    // Overwrite property by default is set to true in SdlFile constructors indicating that a file can be overwritten
-    private boolean overwrite = true;
+    // Overwrite property by default is set to false in SdlFile constructors indicating that a file will not be overwritten
+    private boolean overwrite = false;
 
     /**
      * Creates a new instance of SdlFile
@@ -248,7 +248,7 @@ public class SdlFile{
     }
 
     /**
-     * Gets the overwrite property for an SdlFile by default its set to true
+     * Gets the overwrite property for an SdlFile by default its set to false
      * @return a boolean value that indicates if a file can be overwritten.
      */
     public boolean getOverwrite() {
@@ -256,7 +256,7 @@ public class SdlFile{
     }
 
     /**
-     * Sets the overwrite property for an SdlFile by default its set to true
+     * Sets the overwrite property for an SdlFile by default its set to false
      * @param overwrite a boolean value that indicates if a file can be overwritten
      */
     public void setOverwrite(boolean overwrite) {


### PR DESCRIPTION
Fixes #1451

This PR is **ready** for review.

### Risk
This PR makes **major** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
`SdlFile` unit tests have been updated to assert that the default value for overwrite is `false`

#### Core Tests
- Create a `SdlFile` and don't set the `overwrite` property 
- Upload the file and make sure it gets uploaded the first time
- Try to upload the file again and make sure it doesn't get uploaded the second time

- Create another `SdlFile` and set `overwrite` to `true`
- Upload the file and make sure it gets uploaded the first time
- Try to upload the file again and make sure it gets uploaded the second time

### Summary
This PR Updates the default value for the `overwrite` property in SdlFile to be `false` to match iOS implementation 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
