### PR TITLE
JavaSE - Add SdlFile constructor that takes URI

### DIFF
--- a/javaSE/src/main/java/com/smartdevicelink/managers/file/FileManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/file/FileManager.java
@@ -36,7 +36,12 @@ import androidx.annotation.NonNull;
 import com.smartdevicelink.managers.file.filetypes.SdlFile;
 import com.smartdevicelink.proxy.interfaces.ISdl;
 import com.smartdevicelink.proxy.rpc.PutFile;
+import com.smartdevicelink.util.DebugTool;
 import com.smartdevicelink.util.FileUtls;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
 
 /**
  * <strong>FileManager</strong> <br>
@@ -94,6 +99,14 @@ public class FileManager extends BaseFileManager {
 			}else{
 				throw new IllegalArgumentException("File at path was empty");
 			}
+		}else if(file.getURI() != null){
+			// Use URI to upload file
+			byte[] data = contentsOfUri(file.getURI());
+			if(data != null){
+				putFile.setFileData(data);
+			}else{
+				throw new IllegalArgumentException("Uri was empty");
+			}
 		}else if(file.getFileData() != null){
 			// Use file data (raw bytes) to upload file
 			putFile.setFileData(file.getFileData());
@@ -110,4 +123,28 @@ public class FileManager extends BaseFileManager {
 		return putFile;
 	}
 
+
+	/**
+	 * Helper method to take Uri and turn it into byte array
+	 * @param uri Uri for desired file
+	 * @return Resulting byte array
+	 */
+	private byte[] contentsOfUri(URI uri){
+		InputStream is = null;
+		try{
+			is = uri.toURL().openStream();
+			return contentsOfInputStream(is);
+		} catch (IOException e){
+			DebugTool.logError(TAG, "Can't read from URI", e);
+			return null;
+		} finally {
+			if (is != null) {
+				try {
+					is.close();
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
+			}
+		}
+	}
 }

--- a/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlArtwork.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlArtwork.java
@@ -38,6 +38,8 @@ import com.smartdevicelink.proxy.rpc.enums.ImageType;
 import com.smartdevicelink.proxy.rpc.enums.StaticIconName;
 import com.smartdevicelink.util.DebugTool;
 
+import java.net.URI;
+
 /**
  * A class that extends SdlFile, representing artwork (JPEG, PNG, or BMP) to be uploaded to core
  */
@@ -59,6 +61,17 @@ public class SdlArtwork extends SdlFile implements Cloneable{
      */
     public SdlArtwork(String fileName, @NonNull FileType fileType, String filePath, boolean persistentFile) {
         super(fileName, fileType, filePath, persistentFile);
+    }
+
+    /**
+     * Creates a new instance of SdlArtwork
+     * @param fileName a String value representing the name that will be used to store the file in the head unit. You can pass null if you want the library to auto generate the name
+     * @param fileType a FileType enum value representing the type of the file
+     * @param uri a URI value representing a file's location. Currently, it only supports local files
+     * @param persistentFile a boolean value that indicates if the file is meant to persist between sessions / ignition cycles
+     */
+    public SdlArtwork(String fileName, @NonNull FileType fileType, URI uri, boolean persistentFile) {
+        super(fileName, fileType, uri, persistentFile);
     }
 
     /**

--- a/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
@@ -36,6 +36,7 @@ import androidx.annotation.NonNull;
 import com.smartdevicelink.proxy.rpc.enums.FileType;
 import com.smartdevicelink.proxy.rpc.enums.StaticIconName;
 
+import java.net.URI;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -45,6 +46,7 @@ import java.security.NoSuchAlgorithmException;
 public class SdlFile{
     private String fileName;
     private String filePath;
+    private URI uri;
     private byte[] fileData;
     private FileType fileType;
     private boolean persistentFile;
@@ -69,6 +71,20 @@ public class SdlFile{
         setName(fileName);
         setType(fileType);
         setFilePath(filePath);
+        setPersistent(persistentFile);
+    }
+
+    /**
+     * Creates a new instance of SdlFile
+     * @param fileName a String value representing the name that will be used to store the file in the head unit. You can pass null if you want the library to auto generate the name
+     * @param fileType a FileType enum value representing the type of the file
+     * @param uri a URI value representing a file's location. Currently, it only supports local files
+     * @param persistentFile a boolean value that indicates if the file is meant to persist between sessions / ignition cycles
+     */
+    public SdlFile(String fileName, @NonNull FileType fileType, URI uri, boolean persistentFile){
+        setName(fileName);
+        setType(fileType);
+        setURI(uri);
         setPersistent(persistentFile);
     }
 
@@ -109,6 +125,8 @@ public class SdlFile{
             this.shouldAutoGenerateName = true;
             if (this.getFileData() != null) {
                 this.fileName = generateFileNameFromData(this.getFileData());
+            } else if (this.getURI() != null) {
+                this.fileName = generateFileNameFromUri(this.getURI());
             } else if (this.getFilePath() != null) {
                 this.fileName = generateFileNameFromFilePath(this.getFilePath());
             }
@@ -140,6 +158,25 @@ public class SdlFile{
      */
     public String getFilePath(){
         return this.filePath;
+    }
+
+    /**
+     * Sets the uri of the file
+     * @param uri a URI value representing a file's location. Currently, it only supports local files
+     */
+    public void setURI(URI uri){
+        this.uri = uri;
+        if (shouldAutoGenerateName && uri != null) {
+            this.fileName = generateFileNameFromUri(uri);
+        }
+    }
+
+    /**
+     * Gets the uri of the file
+     * @return a URI value representing a file's location. Currently, it only supports local files
+     */
+    public URI getURI(){
+        return uri;
     }
 
     /**
@@ -262,6 +299,15 @@ public class SdlFile{
     }
 
     /**
+     * Generates a file name from uri by hashing the uri string and returning the last 16 chars
+     * @param uri a URI value representing a file's location
+     * @return a String value representing the name that will be used to store the file in the head unit
+     */
+    private String generateFileNameFromUri(@NonNull URI uri) {
+        return generateFileNameFromData(uri.toString().getBytes());
+    }
+
+    /**
      * Used to compile hashcode for SdlFile for use to compare in equals method
      * @return Custom hashcode of SdlFile variables
      */
@@ -269,11 +315,12 @@ public class SdlFile{
     public int hashCode() {
         int result = 1;
         result += ((getName() == null) ? 0 : Integer.rotateLeft(getName().hashCode(), 1));
-        result += ((getFilePath() == null) ? 0 : Integer.rotateLeft(getFilePath().hashCode(), 2));
-        result += ((getFileData() == null) ? 0 : Integer.rotateLeft(getFileData().hashCode(), 3));
-        result += ((getType() == null) ? 0 : Integer.rotateLeft(getType().hashCode(), 4));
-        result += Integer.rotateLeft(Boolean.valueOf(isStaticIcon()).hashCode(), 5);
-        result += Integer.rotateLeft(Boolean.valueOf(isPersistent()).hashCode(), 6);
+        result += ((getURI() == null) ? 0 : Integer.rotateLeft(getURI().hashCode(), 2));
+        result += ((getFilePath() == null) ? 0 : Integer.rotateLeft(getFilePath().hashCode(), 3));
+        result += ((getFileData() == null) ? 0 : Integer.rotateLeft(getFileData().hashCode(), 4));
+        result += ((getType() == null) ? 0 : Integer.rotateLeft(getType().hashCode(), 5));
+        result += Integer.rotateLeft(Boolean.valueOf(isStaticIcon()).hashCode(), 6);
+        result += Integer.rotateLeft(Boolean.valueOf(isPersistent()).hashCode(), 7);
         return result;
     }
 


### PR DESCRIPTION
Fixes #1469

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested  Java SE

#### Core Tests
This code snippet can be used to test uploading a file using URI:
```
void testSdlFileURI (){
    // Get URI
    File file = new File("<file path>");
    URI uri = file.toURI();

    // Upload file
    final SdlArtwork sdlFile = new SdlArtwork(null, FileType.GRAPHIC_PNG, uri, false);
    sdlFile.setOverwrite(true);
    sdlManager.getFileManager().uploadFile(sdlFile, new CompletionListener() {
        @Override
        public void onComplete(boolean success) {
            if (success) {
                Log.i(TAG,"File Uploaded: " + sdlManager.getFileManager().hasUploadedFile(sdlFile));

                // Send Show
                Show show = new Show();
                show.setMainField1("Hi There");
                Image image = new Image(sdlFile.getName(), ImageType.DYNAMIC);
                show.setGraphic(image);
                show.setOnRPCResponseListener(new OnRPCResponseListener() {
                    @Override
                    public void onResponse(int correlationId, RPCResponse response) {
                        try {
                            Log.i(TAG, "onResponse: " + response.serializeJSON().toString(4));
                        } catch (JSONException e) {
                            e.printStackTrace();
                        }
                    }
                });
                sdlManager.sendRPC(show);
            } else {
                messageLogger.logError(TAG, "Failed to upload file.", true);
            }
        }
    });
}
```

Core version: Core 6.1.0 / Generic HMI

### Summary
This PR Adds `SdlFile` constructor that takes `URI` to the JavaSE library to align with Android 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
