### PR TITLE
Fix Issue 1473 - Null items as head or empty lists

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/RPCStructTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/RPCStructTests.java
@@ -1,0 +1,48 @@
+package com.smartdevicelink.test.rpc;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.smartdevicelink.proxy.RPCStruct;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static junit.framework.TestCase.assertNotNull;
+
+@RunWith(AndroidJUnit4.class)
+public class RPCStructTests {
+
+    @Test
+    public void testFormatObject() {
+        final String KEY = "LIST";
+        RPCStruct struct = new RPCStruct();
+        List<RPCStruct> structs = new ArrayList<>();
+        struct.setValue(KEY, structs);
+        assertNotNull(struct.getObject(RPCStruct.class, KEY));
+
+        structs.add(new RPCStruct());
+        struct.setValue(KEY, structs);
+        assertNotNull(struct.getObject(RPCStruct.class, KEY));
+
+        structs.clear();
+        structs.add(null);
+        struct.setValue(KEY, structs);
+        assertNotNull(struct.getObject(RPCStruct.class, KEY));
+
+        structs.clear();
+        structs.add(null);
+        structs.add(new RPCStruct());
+        struct.setValue(KEY, structs);
+        assertNotNull(struct.getObject(RPCStruct.class, KEY));
+
+        structs.clear();
+        structs.add(new RPCStruct());
+        structs.add(null);
+        structs.add(new RPCStruct());
+        struct.setValue(KEY, structs);
+        assertNotNull(struct.getObject(RPCStruct.class, KEY));
+    }
+}

--- a/base/src/main/java/com/smartdevicelink/proxy/RPCStruct.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/RPCStruct.java
@@ -275,8 +275,18 @@ public class RPCStruct {
 		} else if (obj instanceof List<?>) {
 			List<?> list = (List<?>) obj;
 			if (list != null && list.size() > 0) {
-				Object item = list.get(0);
-				if (tClass.isInstance(item)) {
+				Object item = null;
+				//Iterate through list to find first non-null object
+				for(Object object: list){
+					if(object != null) {
+						item = object;
+						break;
+					}
+				}
+
+				if (item == null) {
+					return list;
+				} else if (tClass.isInstance(item)) {
 					return list;
 				} else if (item instanceof Hashtable) {
 					List<Object> newList = new ArrayList<Object>();
@@ -307,6 +317,10 @@ public class RPCStruct {
 					}
 					return newList;
 				}
+			} else {
+				//If the list is either null or empty it should be returned. It will keep the same
+				//behavior as it does today with null lists, but empty ones will now also be returned.
+				return list;
 			}
 		}
 		return null;


### PR DESCRIPTION
Fixes #1473 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
- Added a test class for the RPCStruct class. Currently only one test to test the format object for cases of empty lists, null as first value, null in lists, and happy path list.
- All other RPC tests should also be performed to ensure the new behavior doesn't break.


### Summary

Chnages to the RPCStruct.formatObject method
- If list is empty, the method will now return an empty but not null list object instead of a null object
- The method will now attempt to traverse the list to find the first instance of a nonnull value
- If even after traversing the list only null values are found, an instance of the list is returned


##### Bug Fixes
* Empty lists and lists with null objects at the head of the list now return properly


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
