### PR TITLE
Fix Issue 1465 - NPE in ManagerUtility

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/ManagerUtilityTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/ManagerUtilityTests.java
@@ -1,0 +1,206 @@
+package com.smartdevicelink.managers;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.smartdevicelink.proxy.rpc.ImageField;
+import com.smartdevicelink.proxy.rpc.TextField;
+import com.smartdevicelink.proxy.rpc.WindowCapability;
+import com.smartdevicelink.proxy.rpc.enums.CharacterSet;
+import com.smartdevicelink.proxy.rpc.enums.FileType;
+import com.smartdevicelink.proxy.rpc.enums.ImageFieldName;
+import com.smartdevicelink.proxy.rpc.enums.TextFieldName;
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.assertFalse;
+
+/**
+ * This is a unit test class for the SmartDeviceLink library manager class :
+ * {@link ManagerUtility}
+ */
+@RunWith(AndroidJUnit4.class)
+public class ManagerUtilityTests {
+
+
+	@Before
+	public void setUp() throws Exception{
+
+	}
+
+	// TESTS
+
+	@Test
+	public void testGetAllImageFields(){
+
+		List<ImageField> fields = ManagerUtility.WindowCapabilityUtility.getAllImageFields();
+		assertNotNull(fields);
+		int size = fields.size();
+		assertEquals(ImageFieldName.values().length, size);
+
+		ImageFieldName[] names = ImageFieldName.values();
+
+		boolean found;
+		for (ImageFieldName name : names) {
+			found = false;
+			for(ImageField field : fields) {
+				if(field != null
+						&& field.getName() != null
+						&& field.getName().equals(name)) {
+					found = true;
+					break;
+				}
+			}
+			assertTrue(found);
+		}
+
+	}
+
+	@Test
+	public void testGetAllTextFields(){
+
+		List<TextField> fields = ManagerUtility.WindowCapabilityUtility.getAllTextFields();
+		assertNotNull(fields);
+		int size = fields.size();
+		assertEquals(TextFieldName.values().length, size);
+
+		TextFieldName[] names = TextFieldName.values();
+
+		boolean found;
+		for (TextFieldName name : names) {
+			found = false;
+			for(TextField field : fields) {
+				if(field != null
+						&& field.getName() != null
+						&& field.getName().equals(name)) {
+					found = true;
+					break;
+				}
+			}
+			assertTrue(found);
+		}
+
+	}
+
+	@Test
+	public void testHasTextFieldOfName() {
+		WindowCapability capability = new WindowCapability();
+		List<TextField> textFieldList = new ArrayList<>();
+		textFieldList.add(new TextField(TextFieldName.mainField1, CharacterSet.UTF_8, 500, 8));
+		capability.setTextFields(textFieldList);
+
+		assertTrue(ManagerUtility.WindowCapabilityUtility.hasTextFieldOfName(capability, TextFieldName.mainField1));
+		assertFalse(ManagerUtility.WindowCapabilityUtility.hasTextFieldOfName(capability, TextFieldName.alertText3));
+
+		textFieldList.add(new TextField(TextFieldName.alertText3, CharacterSet.UTF_8, 500, 8));
+		capability.setTextFields(textFieldList);
+		assertTrue(ManagerUtility.WindowCapabilityUtility.hasTextFieldOfName(capability, TextFieldName.mainField1));
+		assertTrue(ManagerUtility.WindowCapabilityUtility.hasTextFieldOfName(capability, TextFieldName.alertText3));
+
+		textFieldList.clear();
+		textFieldList.add(null);
+		capability.setTextFields(textFieldList);
+		assertFalse(ManagerUtility.WindowCapabilityUtility.hasTextFieldOfName(capability, TextFieldName.mainField1));
+		assertFalse(ManagerUtility.WindowCapabilityUtility.hasTextFieldOfName(capability, TextFieldName.alertText3));
+
+		textFieldList.add(new TextField(TextFieldName.alertText3, CharacterSet.UTF_8, 500, 8));
+		capability.setTextFields(textFieldList);
+		assertFalse(ManagerUtility.WindowCapabilityUtility.hasTextFieldOfName(capability, TextFieldName.mainField1));
+		assertTrue(ManagerUtility.WindowCapabilityUtility.hasTextFieldOfName(capability, TextFieldName.alertText3));
+
+	}
+
+	@Test
+	public void testHasImageFieldOfName() {
+
+		WindowCapability capability = new WindowCapability();
+		List<FileType> allImageFileTypes = Arrays.asList(FileType.GRAPHIC_BMP, FileType.GRAPHIC_JPEG, FileType.GRAPHIC_PNG);
+
+		List<ImageField> imageFieldList = new ArrayList<>();
+		imageFieldList.add(new ImageField(ImageFieldName.graphic, allImageFileTypes));
+		capability.setImageFields(imageFieldList);
+
+		assertTrue(ManagerUtility.WindowCapabilityUtility.hasImageFieldOfName(capability, ImageFieldName.graphic));
+		assertFalse(ManagerUtility.WindowCapabilityUtility.hasImageFieldOfName(capability, ImageFieldName.alertIcon));
+
+		imageFieldList.add(new ImageField(ImageFieldName.alertIcon, allImageFileTypes));
+		capability.setImageFields(imageFieldList);
+		assertTrue(ManagerUtility.WindowCapabilityUtility.hasImageFieldOfName(capability, ImageFieldName.graphic));
+		assertTrue(ManagerUtility.WindowCapabilityUtility.hasImageFieldOfName(capability, ImageFieldName.alertIcon));;
+
+		imageFieldList.clear();
+		imageFieldList.add(null);
+		capability.setImageFields(imageFieldList);
+		assertFalse(ManagerUtility.WindowCapabilityUtility.hasImageFieldOfName(capability, ImageFieldName.graphic));
+		assertFalse(ManagerUtility.WindowCapabilityUtility.hasImageFieldOfName(capability, ImageFieldName.alertIcon));
+
+		imageFieldList.add(new ImageField(ImageFieldName.alertIcon, allImageFileTypes));
+		capability.setImageFields(imageFieldList);
+		assertFalse(ManagerUtility.WindowCapabilityUtility.hasImageFieldOfName(capability, ImageFieldName.graphic));
+		assertTrue(ManagerUtility.WindowCapabilityUtility.hasImageFieldOfName(capability, ImageFieldName.alertIcon));
+
+	}
+
+
+	@Test
+	public void testGetMaxNumberOfMainFieldLines() {
+
+		WindowCapability capability = new WindowCapability();
+		capability.setTextFields(ManagerUtility.WindowCapabilityUtility.getAllTextFields());
+
+		int maxNumerOfLines = ManagerUtility.WindowCapabilityUtility.getMaxNumberOfMainFieldLines(capability);
+
+		assertEquals(4, maxNumerOfLines);
+
+		//Single line
+		List<TextField> singleLineList = new ArrayList<>();
+		singleLineList.add(new TextField(TextFieldName.mainField1, CharacterSet.UTF_8, 500, 8));
+		capability.setTextFields(singleLineList);
+		maxNumerOfLines = ManagerUtility.WindowCapabilityUtility.getMaxNumberOfMainFieldLines(capability);
+		assertEquals(1, maxNumerOfLines);
+
+		singleLineList.add(new TextField(TextFieldName.mainField2, CharacterSet.UTF_8, 500, 8));
+		capability.setTextFields(singleLineList);
+		maxNumerOfLines = ManagerUtility.WindowCapabilityUtility.getMaxNumberOfMainFieldLines(capability);
+		assertEquals(2, maxNumerOfLines);
+
+		singleLineList.add(new TextField(TextFieldName.mainField3, CharacterSet.UTF_8, 500, 8));
+		capability.setTextFields(singleLineList);
+		maxNumerOfLines = ManagerUtility.WindowCapabilityUtility.getMaxNumberOfMainFieldLines(capability);
+		assertEquals(3, maxNumerOfLines);
+
+		singleLineList.add(new TextField(TextFieldName.mainField4, CharacterSet.UTF_8, 500, 8));
+		capability.setTextFields(singleLineList);
+		maxNumerOfLines = ManagerUtility.WindowCapabilityUtility.getMaxNumberOfMainFieldLines(capability);
+		assertEquals(4, maxNumerOfLines);
+
+		List<TextField> nullList = new ArrayList<>();
+		nullList.add(null);
+		assertNotNull(nullList);
+		capability.setTextFields(nullList);
+		assertNotNull(capability);
+		assertNotNull(capability.getTextFields()); //Fails
+
+		maxNumerOfLines = ManagerUtility.WindowCapabilityUtility.getMaxNumberOfMainFieldLines(capability);
+		assertEquals(0, maxNumerOfLines);
+
+		nullList.add(new TextField(TextFieldName.mainField4, CharacterSet.UTF_8, 500, 8));
+		assertNotNull(nullList);
+		capability.setTextFields(nullList);
+		assertNotNull(capability);
+		assertNotNull(capability.getTextFields());
+		maxNumerOfLines = ManagerUtility.WindowCapabilityUtility.getMaxNumberOfMainFieldLines(capability);
+		assertEquals(4, maxNumerOfLines);
+
+	}
+}

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/ManagerUtilityTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/ManagerUtilityTests.java
@@ -189,7 +189,7 @@ public class ManagerUtilityTests {
 		assertNotNull(nullList);
 		capability.setTextFields(nullList);
 		assertNotNull(capability);
-		assertNotNull(capability.getTextFields()); //Fails
+		assertNotNull(capability.getTextFields());
 
 		maxNumerOfLines = ManagerUtility.WindowCapabilityUtility.getMaxNumberOfMainFieldLines(capability);
 		assertEquals(0, maxNumerOfLines);

--- a/base/src/main/java/com/smartdevicelink/managers/ManagerUtility.java
+++ b/base/src/main/java/com/smartdevicelink/managers/ManagerUtility.java
@@ -28,14 +28,17 @@ public class ManagerUtility {
          * @param name ImageFieldName representing a name of a given Image field that would be stored in WindowCapability
          * @return true if name exist in WindowCapability else false
          */
-        public static boolean hasImageFieldOfName(WindowCapability windowCapability, ImageFieldName name) {
+        public static boolean hasImageFieldOfName(final WindowCapability windowCapability, final ImageFieldName name) {
             if (windowCapability == null || name == null) {
                 return false;
             }
             if (windowCapability.getImageFields() != null) {
-                for (ImageField field : windowCapability.getImageFields()) {
-                    if (field != null && name.equals(field.getName())) {
-                        return true;
+                List<ImageField> imageFields = windowCapability.getImageFields();
+                if(imageFields != null && imageFields.size() > 0) {
+                    for (ImageField field : imageFields) {
+                        if (field != null && name.equals(field.getName())) {
+                            return true;
+                        }
                     }
                 }
             }
@@ -49,14 +52,17 @@ public class ManagerUtility {
          * @param name TextFieldName representing a name of a given text field that would be stored in WindowCapability
          * @return true if name exist in WindowCapability else false
          */
-        public static boolean hasTextFieldOfName(WindowCapability windowCapability, TextFieldName name) {
+        public static boolean hasTextFieldOfName(final WindowCapability windowCapability, final TextFieldName name) {
             if (windowCapability == null || name == null) {
                 return false;
             }
             if (windowCapability.getTextFields() != null) {
-                for (TextField field : windowCapability.getTextFields()) {
-                    if (field != null && name.equals(field.getName())) {
-                        return true;
+                List<TextField> textFields = windowCapability.getTextFields();
+                if (textFields != null && textFields.size() > 0) {
+                    for (TextField field : textFields) {
+                        if (field != null && name.equals(field.getName())) {
+                            return true;
+                        }
                     }
                 }
             }
@@ -69,24 +75,26 @@ public class ManagerUtility {
          * @param windowCapability WindowCapability representing the capabilities of the desired window
          * @return linesFound Number of textFields found in WindowCapability
          */
-        public static int getMaxNumberOfMainFieldLines(WindowCapability windowCapability) {
+        public static int getMaxNumberOfMainFieldLines(final WindowCapability windowCapability) {
             int highestFound = 0;
             if (windowCapability != null && windowCapability.getTextFields() != null) {
                 for (TextField field : windowCapability.getTextFields()) {
                     int fieldNumber = 0;
-                    switch (field.getName()) {
-                        case mainField1:
-                            fieldNumber = 1;
-                            break;
-                        case mainField2:
-                            fieldNumber = 2;
-                            break;
-                        case mainField3:
-                            fieldNumber = 3;
-                            break;
-                        case mainField4:
-                            fieldNumber = 4;
-                            break;
+                    if(field != null) {
+                        switch (field.getName()) {
+                            case mainField1:
+                                fieldNumber = 1;
+                                break;
+                            case mainField2:
+                                fieldNumber = 2;
+                                break;
+                            case mainField3:
+                                fieldNumber = 3;
+                                break;
+                            case mainField4:
+                                fieldNumber = 4;
+                                break;
+                        }
                     }
                     if (fieldNumber > 0) {
                         highestFound = Math.max(highestFound, fieldNumber);


### PR DESCRIPTION
Fixes #1465 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
- Added unit tests around the utility classes that were modified


### Summary
Added null checks to a couple methods in the `ManagerUtility` class that iterates over lists. While there was a null check for the list itself, it skipped such check on the items stored in the list.

### Changelog

##### Bug Fixes
* Check for null in multiple cases now since null is a valid item in a list


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
