### PR TITLE
Fix Issue 1398 - Avoid deadlock from using blocking queues

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/streaming/StreamPacketizer.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/streaming/StreamPacketizer.java
@@ -102,6 +102,8 @@ public class StreamPacketizer extends AbstractPacketizer implements IVideoStream
 			t = null;
 		}
 
+		mOutputQueue.clear();
+
 	}
 
 	public void run() {
@@ -261,6 +263,10 @@ public class StreamPacketizer extends AbstractPacketizer implements IVideoStream
 			throw new ArrayIndexOutOfBoundsException();
 		}
 
+		if (data == null || t == null || t.isInterrupted()) {
+			return;
+		}
+
 		// StreamPacketizer does not need to split a video frame into NAL units
 		ByteBuffer buffer = ByteBuffer.allocate(length);
 		buffer.put(data, offset, length);
@@ -274,7 +280,7 @@ public class StreamPacketizer extends AbstractPacketizer implements IVideoStream
 	}
 
 	private void sendByteBufferData(ByteBuffer data, CompletionListener completionListener) {
-		if (data == null || data.remaining() == 0) {
+		if (data == null || data.remaining() == 0 || t == null || t.isInterrupted()) {
 			return;
 		}
 

--- a/base/src/main/java/com/smartdevicelink/streaming/video/RTPH264Packetizer.java
+++ b/base/src/main/java/com/smartdevicelink/streaming/video/RTPH264Packetizer.java
@@ -36,6 +36,7 @@ import com.smartdevicelink.protocol.enums.SessionType;
 import com.smartdevicelink.proxy.interfaces.IVideoStreamListener;
 import com.smartdevicelink.streaming.AbstractPacketizer;
 import com.smartdevicelink.streaming.IStreamListener;
+import com.smartdevicelink.util.DebugTool;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -61,6 +62,8 @@ import java.util.concurrent.LinkedBlockingQueue;
  * @author Sho Amano
  */
 public class RTPH264Packetizer extends AbstractPacketizer implements IVideoStreamListener, Runnable {
+
+	private static final String TAG = "RTPH264Packetizer";
 
 	// Approximate size of data that mOutputQueue can hold in bytes.
 	// By adding a buffer, we accept underlying transport being stuck for a short time. By setting
@@ -168,6 +171,10 @@ public class RTPH264Packetizer extends AbstractPacketizer implements IVideoStrea
 	public void start() throws IOException {
 		if (mThread != null) {
 			return;
+		}
+
+		if(mOutputQueue != null){
+			mOutputQueue.clear();
 		}
 
 		mThread = new Thread(this);
@@ -293,13 +300,18 @@ public class RTPH264Packetizer extends AbstractPacketizer implements IVideoStrea
 	}
 
 	private boolean outputRTPFrames(ByteBuffer nalUnit, long ptsInUs, boolean isLast) {
+		if((mThread == null || mThread.isInterrupted())) {
+			DebugTool.logError(TAG, "Dropping potential buffer because consumer thread is not alive");
+			return false;
+		}
+
 		if (RTP_HEADER_LEN + nalUnit.remaining() > MAX_RTP_PACKET_SIZE) {
 			// Split into multiple Fragmentation Units ([5.8] in RFC 6184)
 			byte firstByte = nalUnit.get();
 			boolean firstFragment = true;
 			boolean lastFragment = false;
 
-			while (nalUnit.remaining() > 0) {
+			while (nalUnit.remaining() > 0 && mThread != null && !mThread.isInterrupted()) {
 				int payloadLength = MAX_RTP_PACKET_SIZE - (RTP_HEADER_LEN + FU_INDICATOR_LEN + FU_HEADER_LEN);
 				if (nalUnit.remaining() <= payloadLength) {
 					payloadLength = nalUnit.remaining();


### PR DESCRIPTION
Fixes #1398 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
- None added


### Summary

There was a potential race condition where the producer thread (main) would be trying to add data to the shared buffer but was blocked awaiting the consumer thread to take data during a stop() method call. The consumer thread is interrupted and set to null then the queue itself is cleared. This opens up space in the queue and more data is added. If there is currently a buffer being iterated through to create the NAL units the queue can quickly fill up again and cause a deadlock to occur since there is no consumer.

### Changelog

##### Bug Fixes
* Check if the consumer thread is dead before continuing to iterate through a buffer.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
