### PR TITLE
Deprecate AudioStreamingLPCMParams enum

### DIFF
--- a/base/src/main/java/com/smartdevicelink/streaming/audio/AudioStreamingLPCMParams.java
+++ b/base/src/main/java/com/smartdevicelink/streaming/audio/AudioStreamingLPCMParams.java
@@ -33,6 +33,7 @@ package com.smartdevicelink.streaming.audio;
 /**
  * A struct to hold LPCM specific audio format information.
  */
+@Deprecated
 public class AudioStreamingLPCMParams extends AudioStreamingParams {
 	/**
 	 * Sample format of linear PCM data.


### PR DESCRIPTION
Fixes #1306 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR deprecates the enum `AudioStreamingLPCMParams` as it is not used anywhere in the library 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
