### PR TITLE
Add check to prevent NPE in ManagerUtility class

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/ManagerUtility.java
+++ b/base/src/main/java/com/smartdevicelink/managers/ManagerUtility.java
@@ -80,7 +80,7 @@ public class ManagerUtility {
             if (windowCapability != null && windowCapability.getTextFields() != null) {
                 for (TextField field : windowCapability.getTextFields()) {
                     int fieldNumber = 0;
-                    if(field != null) {
+                    if(field != null && field.getName() != null) {
                         switch (field.getName()) {
                             case mainField1:
                                 fieldNumber = 1;


### PR DESCRIPTION
Fixes #1495 

This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Core Tests
Tested against Sync 3.0 TDK-X2-U2-150

### Summary
Fix NPE in ManagerUtility.getMaxNumberOfMainFieldLines that occurs on a sync 3.0 tdk

##### Bug Fixes
* Added an null check for TextFields.getName()

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
