### PR TITLE
Add NPE check to SoftButtonCapabilities onCapabilityRetrieved

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
@@ -136,7 +136,7 @@ abstract class BaseSoftButtonManager extends BaseSubManager {
                     for (WindowCapability windowCapability : mainDisplay.getWindowCapabilities()) {
                         int currentWindowID = windowCapability.getWindowID() != null ? windowCapability.getWindowID() : PredefinedWindows.DEFAULT_WINDOW.getValue();
                         if (currentWindowID == PredefinedWindows.DEFAULT_WINDOW.getValue()) {
-                            if (windowCapability.getSoftButtonCapabilities() != null) {
+                            if (windowCapability.getSoftButtonCapabilities() != null && windowCapability.getSoftButtonCapabilities().size() > 0) {
                                 softButtonCapabilities = windowCapability.getSoftButtonCapabilities().get(0);
                             } else {
                                 softButtonCapabilities = null;

--- a/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
@@ -136,7 +136,11 @@ abstract class BaseSoftButtonManager extends BaseSubManager {
                     for (WindowCapability windowCapability : mainDisplay.getWindowCapabilities()) {
                         int currentWindowID = windowCapability.getWindowID() != null ? windowCapability.getWindowID() : PredefinedWindows.DEFAULT_WINDOW.getValue();
                         if (currentWindowID == PredefinedWindows.DEFAULT_WINDOW.getValue()) {
-                            softButtonCapabilities = windowCapability.getSoftButtonCapabilities().get(0);
+                            if (windowCapability.getSoftButtonCapabilities() != null) {
+                                softButtonCapabilities = windowCapability.getSoftButtonCapabilities().get(0);
+                            } else {
+                                softButtonCapabilities = null;
+                            }
                             break;
                         }
                     }


### PR DESCRIPTION
Fixes #1499 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Core Tests
Tested sending a setDisplayLayout request to core with template DOUBLE_GRAPHIC_WITH_SOFTBUTTONS then changing to GRAPHIC_WITH_TEXT. 

Core version / branch / commit hash / module tested against: Core 6.1
HMI name / version / branch / commit hash / module tested against: Generic_HMI 0.8.1

### Summary
Add null check to BaseSoftButtonManager onCapabilityRetrieved to check if incoming softButtonCapabilities are null or not. If null setting the SoftButton capabilities to null

### Changelog
##### Breaking Changes
* [Breaking change info]

##### Enhancements
* [Enhancement info]

##### Bug Fixes
* Fix NPE from issue #1499 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
