### PR TITLE
Fix JavaDoc comments cutoff after todo in RPC Generator 

### DIFF
--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -72,11 +72,11 @@ class InterfaceProducerCommon(ABC):
     @staticmethod
     def extract_description(d):
         """
-        Evaluate, align and delete @TODO
+        Extract description
         :param d: list with description
         :return: evaluated string
         """
-        return re.sub(r'(\s{2,}|\n|\[@TODO.+)', ' ', ''.join(d)).strip() if d else ''
+        return re.sub(r'(\s{2,}|\n)', ' ', ''.join(d)).strip() if d else ''
 
     @staticmethod
     def extract_values(param):


### PR DESCRIPTION
Fixes #1506

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR fixes an issue in RPC Generator where it cuts off the Javadoc comments after @TODO

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
