### PR TITLE
Fix inconsistency with HMICapabilities API names 

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/TestValues.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/TestValues.java
@@ -425,6 +425,8 @@ public class TestValues {
     public static final LightControlData GENERAL_LIGHTCONTROLDATA = new LightControlData();
     public static final HMISettingsControlData GENERAL_HMISETTINGSCONTROLDATA = new HMISettingsControlData();
     public static final DynamicUpdateCapabilities GENERAL_DYNAMICUPDATECAPABILITIES = new DynamicUpdateCapabilities();
+    public static final WindowState GENERAL_WINDOWSTATE = new WindowState();
+
 
     public static final VehicleDataResult GENERAL_OEM_CUSTOM_VEHICLE_DATA = new VehicleDataResult();
     public static final TemplateConfiguration GENERAL_TEMPLATE_CONFIGURATION = new TemplateConfiguration();

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/HMICapabilitiesTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/HMICapabilitiesTests.java
@@ -24,7 +24,7 @@ public class HMICapabilitiesTests extends TestCase {
         msg.setNavigationAvilable(TestValues.GENERAL_BOOLEAN);
         msg.setPhoneCallAvilable(TestValues.GENERAL_BOOLEAN);
         msg.setVideoStreamingAvailable(TestValues.GENERAL_BOOLEAN);
-        msg.setDriverDistraction(TestValues.GENERAL_BOOLEAN);
+        msg.setDriverDistractionAvailable(TestValues.GENERAL_BOOLEAN);
     }
 
     /**

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/HMICapabilities.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/HMICapabilities.java
@@ -172,11 +172,11 @@ public class HMICapabilities extends RPCStruct {
     /**
      * Sets the driverDistraction.
      *
-     * @param driverDistraction Availability of driver distraction capability. True: Available, False: Not Available
+     * @param available Availability of driver distraction capability. True: Available, False: Not Available
      * @since SmartDeviceLink 7.0.0
      */
-    public HMICapabilities setDriverDistraction(Boolean driverDistraction) {
-        setValue(KEY_DRIVER_DISTRACTION, driverDistraction);
+    public HMICapabilities setDriverDistractionAvailable(Boolean available) {
+        setValue(KEY_DRIVER_DISTRACTION, available);
         return this;
     }
 


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Summary
This PR updates the name for HMICapabilities.setDriverDistraction() to setDriverDistractionAvailable() to align with the other APIs in that class.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
