### PR TITLE
Set user agent in downloadFile()

### DIFF
--- a/base/src/main/java/com/smartdevicelink/util/FileUtls.java
+++ b/base/src/main/java/com/smartdevicelink/util/FileUtls.java
@@ -32,6 +32,7 @@
 package com.smartdevicelink.util;
 
 import androidx.annotation.NonNull;
+import com.smartdevicelink.BuildConfig;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -85,6 +86,7 @@ public class FileUtls {
         try {
             URL url = new URL(urlStr);
             URLConnection connection = url.openConnection();
+            connection.setRequestProperty("User-Agent", "SmartDeviceLink/" + BuildConfig.VERSION_NAME);
             InputStream inputStream = connection.getInputStream();
             ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 


### PR DESCRIPTION
Fixes #1513 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Java SE

#### Core Tests
Follow the reproduction steps in the issue description to reproduce the bug

Core version : 7.0.0 / Generic HMI

### Summary
This PR sets the user agent for the HTTP request in `downloadFile()` API so the request doesn't get rejected by the server 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
