### PR TITLE
Fix an issue in switching to backup transport

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/session/SdlSession.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/session/SdlSession.java
@@ -98,9 +98,7 @@ public class SdlSession extends BaseSdlSession {
         }
 
         // If requiresAudioSupport is false, or a supported audio output device is available
-        boolean isAudioOutputAvailable = mediaStreamingStatus != null && mediaStreamingStatus.isAudioOutputAvailable();
-        return !requiresAudioSupport || isAudioOutputAvailable;
-
+        return !requiresAudioSupport || (mediaStreamingStatus != null && mediaStreamingStatus.isAudioOutputAvailable());
     }
 
 


### PR DESCRIPTION
This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Core Tests
To smoke test the fix, use an SDL app that uses multiplex as transport then:
1- Connect the app to TDK via Bluetooth 
2- Connect a USB cable and wait for USB to fully connect
3- Disconnect Bluetooth from the phone
4- Make sure that the app registers again via USB

Core version / branch / commit hash / module tested against: Ford SYNC 3.4

### Summary
This PR reverts one of the changes that were done in this commit https://github.com/smartdevicelink/sdl_java_suite/commit/f2ca3db47bb8b4381f3086db44dc0f7f82ae5183 that causes `mediaStreamingStatus.isAudioOutputAvailable()` to always get called when `isAudioRequirementMet()` is called. The extra  `mediaStreamingStatus.isAudioOutputAvailable()` call is making the app send `EndService` when transport disconnects which causes the backup transport not to work when the primary transport disconnects.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
