### PR TITLE
Correct Lockscreen start behavior

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lockscreen/LockScreenManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lockscreen/LockScreenManagerTests.java
@@ -134,7 +134,7 @@ public class LockScreenManagerTests {
         onDriverDistraction.setState(DriverDistractionState.DD_ON);
         onDDListener.onNotified(onDriverDistraction);
         assertTrue(lockScreenManager.enableDismissGesture);
-        assertTrue(lockScreenManager.mIsLockscreenDismissible);
+        assertTrue(lockScreenManager.isLockscreenDismissible);
     }
 
     @Test
@@ -145,7 +145,7 @@ public class LockScreenManagerTests {
         onDriverDistraction.setState(DriverDistractionState.DD_ON);
         onDDListener.onNotified(onDriverDistraction);
         assertFalse(lockScreenManager.enableDismissGesture);
-        assertFalse(lockScreenManager.mIsLockscreenDismissible);
+        assertFalse(lockScreenManager.isLockscreenDismissible);
     }
 
     @Test
@@ -156,7 +156,7 @@ public class LockScreenManagerTests {
         onDriverDistraction.setState(DriverDistractionState.DD_ON);
         onDDListener.onNotified(onDriverDistraction);
         assertTrue(lockScreenManager.enableDismissGesture);
-        assertFalse(lockScreenManager.mIsLockscreenDismissible);
+        assertFalse(lockScreenManager.isLockscreenDismissible);
     }
 
     @Test
@@ -167,7 +167,7 @@ public class LockScreenManagerTests {
         onDriverDistraction.setState(DriverDistractionState.DD_ON);
         onDDListener.onNotified(onDriverDistraction);
         assertFalse(lockScreenManager.enableDismissGesture);
-        assertFalse(lockScreenManager.mIsLockscreenDismissible);
+        assertFalse(lockScreenManager.isLockscreenDismissible);
     }
 
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lockscreen/LockScreenManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lockscreen/LockScreenManagerTests.java
@@ -141,7 +141,7 @@ public class LockScreenManagerTests {
     public void testLockScreenDismissibleWithEnableFalseAndDismissibilityFalse() {
         lockScreenManager.enableDismissGesture = false;
         OnDriverDistraction onDriverDistraction = new OnDriverDistraction();
-        onDriverDistraction.setLockscreenDismissibility(true);
+        onDriverDistraction.setLockscreenDismissibility(false);
         onDriverDistraction.setState(DriverDistractionState.DD_ON);
         onDDListener.onNotified(onDriverDistraction);
         assertFalse(lockScreenManager.enableDismissGesture);
@@ -167,7 +167,7 @@ public class LockScreenManagerTests {
         onDriverDistraction.setState(DriverDistractionState.DD_ON);
         onDDListener.onNotified(onDriverDistraction);
         assertFalse(lockScreenManager.enableDismissGesture);
-        assertFalse(lockScreenManager.isLockscreenDismissible);
+        assertTrue(lockScreenManager.isLockscreenDismissible);
     }
 
 }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
@@ -205,30 +205,37 @@ public class LockScreenManager extends BaseSubManager {
                         boolean previousDismissibleState = isLockscreenDismissible;
                         isLockscreenDismissible = ddState.getLockscreenDismissibility() != null && ddState.getLockscreenDismissibility();
                         DebugTool.logInfo(TAG, "Lock screen dismissible: " + isLockscreenDismissible);
-                        // both of these conditions must be met to be able to dismiss lockscreen
-                        if (isLockscreenDismissible && enableDismissGesture) {
 
-                            // if DisplayMode is set to ALWAYS, it will be shown before the first DD notification.
-                            // If this is our first DD notification and we are in ALWAYS mode, send another intent to
-                            // enable the dismissal. There is a delay added to allow time for the activity
-                            // time to completely start and handle the new intent. There seems to be odd behavior
-                            // in Android when startActivity is called multiple times too quickly.
-                            if (!receivedFirstDDNotification && displayMode == LockScreenConfig.DISPLAY_MODE_ALWAYS) {
-                                new Handler().postDelayed(new Runnable() {
-                                    @Override
-                                    public void run() {
+                        if (displayMode == LockScreenConfig.DISPLAY_MODE_ALWAYS) {
+                            //If the lockscreen is DISPLAY_MODE_ALWAYS, the only thing that matters
+                            // is the dismissible state
+                            if (enableDismissGesture) {
+                                //Check if there was a change to the dismissible state
+                                if (isLockscreenDismissible != previousDismissibleState) {
+                                    // if DisplayMode is set to ALWAYS, it will be shown before the first DD notification.
+                                    // If this is our first DD notification and we are in ALWAYS mode, send another intent to
+                                    // enable the dismissal. There is a delay added to allow time for the activity
+                                    // time to completely start and handle the new intent. There seems to be odd behavior
+                                    // in Android when startActivity is called multiple times too quickly.
+                                    if (!receivedFirstDDNotification) {
+                                        new Handler().postDelayed(new Runnable() {
+                                            @Override
+                                            public void run() {
+                                                launchLockScreenActivity();
+                                            }
+                                        }, 1000);
+                                    } else {
                                         launchLockScreenActivity();
                                     }
-                                }, 1000);
-                                return;
+                                }
                             }
+                            receivedFirstDDNotification = true;
+                            return;
                         }
 
+                        //For all other states the logic will be handled in the launchLockScreenActivity method call
                         if (driverDistStatus) {
                             // launch lock screen
-                            launchLockScreenActivity();
-                        } else if (isLockscreenDismissible != previousDismissibleState && displayMode == LockScreenConfig.DISPLAY_MODE_ALWAYS) {
-                            //Update dismissible state for display mode always
                             launchLockScreenActivity();
                         } else {
                             // close lock screen

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
@@ -325,7 +325,7 @@ public class LockScreenManager extends BaseSubManager {
                     showLockScreenIntent.putExtra(SDLLockScreenActivity.LOCKSCREEN_CUSTOM_VIEW_EXTRA, customView);
                     showLockScreenIntent.putExtra(SDLLockScreenActivity.LOCKSCREEN_DEVICE_LOGO_EXTRA, deviceLogoEnabled);
                     showLockScreenIntent.putExtra(SDLLockScreenActivity.LOCKSCREEN_DEVICE_LOGO_BITMAP, deviceLogo);
-                    showLockScreenIntent.putExtra(SDLLockScreenActivity.KEY_LOCKSCREEN_DISMISSIBLE, isLockscreenDismissible);
+                    showLockScreenIntent.putExtra(SDLLockScreenActivity.KEY_LOCKSCREEN_DISMISSIBLE, isLockscreenDismissible && enableDismissGesture);
                     showLockScreenIntent.putExtra(SDLLockScreenActivity.KEY_LOCKSCREEN_WARNING_MSG, mLockscreenWarningMsg);
 
                     if (lastIntentUsed != null && lastIntentUsed.equals(showLockScreenIntent.toUri(0))) {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
@@ -203,7 +203,7 @@ public class LockScreenManager extends BaseSubManager {
                         driverDistStatus = DriverDistractionState.DD_ON.equals(ddState.getState());
                         mLockscreenWarningMsg = ddState.getLockscreenWarningMessage();
                         boolean previousDismissibleState = isLockscreenDismissible;
-                        if(ddState.getLockscreenDismissibility() == null ) {
+                        if(ddState.getLockscreenDismissibility() != null ) {
                             isLockscreenDismissible = ddState.getLockscreenDismissibility();
                         } //If the param is null, we assume it stays as the previous value
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
@@ -76,7 +76,7 @@ public class LockScreenManager extends BaseSubManager {
     private OnRPCNotificationListener systemRequestListener, ddListener, hmiListener;
     private String deviceIconUrl;
     boolean driverDistStatus;
-    boolean isLockscreenDismissible;
+    boolean isLockscreenDismissible = false;
     boolean enableDismissGesture;
     final boolean lockScreenEnabled;
     final boolean deviceLogoEnabled;
@@ -203,7 +203,10 @@ public class LockScreenManager extends BaseSubManager {
                         driverDistStatus = DriverDistractionState.DD_ON.equals(ddState.getState());
                         mLockscreenWarningMsg = ddState.getLockscreenWarningMessage();
                         boolean previousDismissibleState = isLockscreenDismissible;
-                        isLockscreenDismissible = ddState.getLockscreenDismissibility() != null && ddState.getLockscreenDismissibility();
+                        if(ddState.getLockscreenDismissibility() == null ) {
+                            isLockscreenDismissible = ddState.getLockscreenDismissibility();
+                        } //If the param is null, we assume it stays as the previous value
+
                         DebugTool.logInfo(TAG, "Lock screen dismissible: " + isLockscreenDismissible);
 
                         if (displayMode == LockScreenConfig.DISPLAY_MODE_ALWAYS) {
@@ -299,6 +302,7 @@ public class LockScreenManager extends BaseSubManager {
             }
         };
     }
+
 
     ////
     // LAUNCH LOCK SCREEN LOGIC

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
@@ -202,6 +202,7 @@ public class LockScreenManager extends BaseSubManager {
                         OnDriverDistraction ddState = (OnDriverDistraction) notification;
                         driverDistStatus = DriverDistractionState.DD_ON.equals(ddState.getState());
                         mLockscreenWarningMsg = ddState.getLockscreenWarningMessage();
+                        boolean previousDismissibleState = isLockscreenDismissible;
                         isLockscreenDismissible = ddState.getLockscreenDismissibility() != null && ddState.getLockscreenDismissibility();
                         DebugTool.logInfo(TAG, "Lock screen dismissible: " + isLockscreenDismissible);
                         // both of these conditions must be met to be able to dismiss lockscreen
@@ -225,6 +226,9 @@ public class LockScreenManager extends BaseSubManager {
 
                         if (driverDistStatus) {
                             // launch lock screen
+                            launchLockScreenActivity();
+                        } else if (isLockscreenDismissible != previousDismissibleState && displayMode == LockScreenConfig.DISPLAY_MODE_ALWAYS) {
+                            //Update dismissible state for display mode always
                             launchLockScreenActivity();
                         } else {
                             // close lock screen

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/SDLLockScreenActivity.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/SDLLockScreenActivity.java
@@ -132,7 +132,7 @@ public class SDLLockScreenActivity extends Activity {
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
         setIntent(intent);
-        if (intent != null && intent.getBooleanExtra(KEY_LOCKSCREEN_DISMISSIBLE, false)) {
+        if (intent != null && (mIsDismissible != intent.getBooleanExtra(KEY_LOCKSCREEN_DISMISSIBLE, false))) {
             initializeActivity(intent);
         }
     }


### PR DESCRIPTION
Fixes #1515  

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android


#### Core Tests (Manticore)

Create app with Lockscreen config:

```java
LockScreenConfig lockScreenConfig = new LockScreenConfig();
lockScreenConfig.setDisplayMode(LockScreenConfig.DISPLAY_MODE_ALWAYS);
lockScreenConfig.enableDismissGesture(true);
```

Test 1:

1. Ensure DriverDistraction is OFF on Manticore
2. Deploy app
3. Notice the lockscreen appears
4. Enable DriverDistraction on Manticore
5. Notice there is now the option to swipe away lockscreen
6. Swipe away lockscreen
7. Notice no lockscreen is displayed
8. Turn OFF DriverDistraction on Manticore
9. Notice no lockscreen is displayed

Test 2:

1. Ensure DriverDistraction is ON on Manticore
2. Deploy app
3. Notice the lockscreen appears with option to swipe away
4. Swipe away lockscreen
5. Notice no lockscreen is displayed
6. Turn off DriverDistraction on Manticore
7. Notice no lockscreen is displayed

Test 3:

1. Ensure DriverDistraction is OFF on Core
2. Deploy app
3. Notice the lockscreen appears
4. Enable DriverDistraction on Core with `lockScreenDismissalEnabled= true`
5. Notice there is now the option to swipe away lockscreen
6. Turn OFF DriverDistraction on Core
7. Notice lockscreen is still viewable
8. Enable DriverDistraction on Core with `lockScreenDismissalEnabled= false`
9. Notice there is no longer an option to swipe away lockscreen and swiping does not dismiss lockscreen
10. Repeat steps 4-6


### Summary
- Added a check to prevent multiple startActivity calls with the same intent. There is a race condition when starting an app that instantly connects with Core that causes this.
- Added a delay for a known (second call" to start the lockscreen activity. This is due to the calls to start the activity being too close and the system will simply queue up the intent and restart the activity right after it finishes.
- Refactored logic in lockscreen activity and DD handling to allow updating of lockscreen properly past initial launch.
- Refactored some methods and variables to better adhere to coding style and more descriptive naming.

### Changelog

##### Bug Fixes
* Prevents a duplication startActivity call and therefore the lockscreen is not displayed again after dismissal
* Fix issue where dismissible state goes from Enabled to Disabled

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
