### PR TITLE
Reset taskmaster when LifecycleManager recycles 

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
@@ -162,6 +162,7 @@ abstract class BaseLifecycleManager {
         }
         if (taskmaster != null) {
             taskmaster.shutdown();
+            taskmaster = null;
         }
     }
 
@@ -1110,6 +1111,10 @@ abstract class BaseLifecycleManager {
         }
         if (encryptionLifecycleManager != null) {
             encryptionLifecycleManager.dispose();
+        }
+        if (taskmaster != null) {
+            taskmaster.shutdown();
+            taskmaster = null;
         }
     }
 


### PR DESCRIPTION
Fixes #1518 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Core Tests
to smoke test the PR:
1. Install hello sdl android and make sure it uses multiplex as a transport 
2. Connect the app to TDK via Bluetooth
3. Do not put the app in HMI `FULL`
4. Connect a USB cable and wait for USB to fully connect
5. Disconnect Bluetooth from the phone
6. Put the app in HMI `FULL`
7. Confirm text and graphics are displayed

Core version / branch / commit hash / module tested against: Ford SYNC 3.4

### Summary
This PR fixes an issue that causes the `ScreenManager` queues not to work properly when the app re-registers on backup transport. The reason for the issue was that the taskmaster doesn't reset correctly when proxy recycles.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
