### PR TITLE
Fix onServiceError message in SdlSession

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/session/SdlSession.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/session/SdlSession.java
@@ -187,7 +187,7 @@ public class SdlSession extends BaseSdlSession {
         if (serviceListeners != null && serviceListeners.containsKey(serviceType)) {
             CopyOnWriteArrayList<ISdlServiceListener> listeners = serviceListeners.get(serviceType);
             for (ISdlServiceListener listener : listeners) {
-                listener.onServiceError(this, serviceType, "End " + serviceType.toString() + " Service NACK'ed");
+                listener.onServiceError(this, serviceType, error);
             }
         }
     }

--- a/javaSE/javaSE/src/main/java/com/smartdevicelink/session/SdlSession.java
+++ b/javaSE/javaSE/src/main/java/com/smartdevicelink/session/SdlSession.java
@@ -104,7 +104,7 @@ public class SdlSession extends BaseSdlSession {
         if (serviceListeners != null && serviceListeners.containsKey(sessionType)) {
             CopyOnWriteArrayList<ISdlServiceListener> listeners = serviceListeners.get(sessionType);
             for (ISdlServiceListener listener : listeners) {
-                listener.onServiceError(this, sessionType, "End " + sessionType.toString() + " Service NACK'ed");
+                listener.onServiceError(this, sessionType, error);
             }
         }
     }


### PR DESCRIPTION
Fixes #1520 

This PR is **[ready]** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

Core version / branch / commit hash / module tested against: Ford SYNC 3.4

### Summary
This PR fixes an issue in `OnServiceError()` where it hardcodes an error message instead of passing the correct error message.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
