### PR TITLE
Make Rpc setters chainable in RPC generator

### DIFF
--- a/generator/templates/function_template.java
+++ b/generator/templates/function_template.java
@@ -31,7 +31,7 @@
     {%- if p.deprecated is defined and p.deprecated is not none %}
     @Deprecated
     {%- endif %}
-    public void set{{p.title}}({% if p.mandatory %}@NonNull {% endif %}{{p.return_type}} {{p.last}}) {
+    public {{class_name}} set{{p.title}}({% if p.mandatory %}@NonNull {% endif %}{{p.return_type}} {{p.last}}) {
         setParameters({{p.key}}, {{p.last}});
     }
 

--- a/generator/templates/function_template.java
+++ b/generator/templates/function_template.java
@@ -33,6 +33,7 @@
     {%- endif %}
     public {{class_name}} set{{p.title}}({% if p.mandatory %}@NonNull {% endif %}{{p.return_type}} {{p.last}}) {
         setParameters({{p.key}}, {{p.last}});
+        return this;
     }
 
     /**

--- a/generator/templates/struct_template.java
+++ b/generator/templates/struct_template.java
@@ -27,7 +27,7 @@
     {%- if p.deprecated is defined and p.deprecated is not none %}
     @Deprecated
     {%- endif %}
-    public void set{{p.title}}({% if p.mandatory %}@NonNull {% endif %}{{p.return_type}} {{p.last}}) {
+    public {{class_name}} set{{p.title}}({% if p.mandatory %}@NonNull {% endif %}{{p.return_type}} {{p.last}}) {
         setValue({{p.key}}, {{p.last}});
     }
 

--- a/generator/templates/struct_template.java
+++ b/generator/templates/struct_template.java
@@ -29,6 +29,7 @@
     {%- endif %}
     public {{class_name}} set{{p.title}}({% if p.mandatory %}@NonNull {% endif %}{{p.return_type}} {{p.last}}) {
         setValue({{p.key}}, {{p.last}});
+        return this;
     }
 
     /**


### PR DESCRIPTION
Fixes #1463 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
N/A

#### Core Tests
Tested using the RPC Generator to make sure it generated structs and functions correctly, as well as making sure setters and chainable.

### Summary
Edited `function_template.java` and `struct_template.java` to make RPC setters chainable when it generates Rpc's

### Changelog
##### Enhancements
* RPC generator will now make RPC setters chainable

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
