### PR TITLE
Fix AndroidX imports in RPC generator unit tests

### DIFF
--- a/generator/test/test_functions.py
+++ b/generator/test/test_functions.py
@@ -62,7 +62,7 @@ class TestFunctionsProducer(unittest.TestCase):
         expected['function_id'] = 'GET_VEHICLE_DATA'
         expected['class_name'] = 'GetVehicleDataResponse'
         expected['extends_class'] = 'RPCResponse'
-        expected['imports'] = ['android.support.annotation.NonNull', '',
+        expected['imports'] = ['androidx.annotation.NonNull', '',
                                'com.smartdevicelink.protocol.enums.FunctionID',
                                'com.smartdevicelink.proxy.RPCResponse',
                                'com.smartdevicelink.proxy.rpc.enums.Result',
@@ -86,7 +86,7 @@ class TestFunctionsProducer(unittest.TestCase):
         expected['function_id'] = 'REGISTER_APP_INTERFACE'
         expected['class_name'] = 'RegisterAppInterfaceResponse'
         expected['extends_class'] = 'RPCResponse'
-        expected['imports'] = ['android.support.annotation.NonNull', '',
+        expected['imports'] = ['androidx.annotation.NonNull', '',
                                'com.smartdevicelink.protocol.enums.FunctionID', 'com.smartdevicelink.proxy.RPCResponse',
                                'com.smartdevicelink.proxy.rpc.enums.Language',
                                'com.smartdevicelink.proxy.rpc.enums.Result', '', 'java.util.Hashtable']
@@ -108,7 +108,7 @@ class TestFunctionsProducer(unittest.TestCase):
         expected['function_id'] = 'REGISTER_APP_INTERFACE'
         expected['class_name'] = 'RegisterAppInterface'
         expected['extends_class'] = 'RPCRequest'
-        expected['imports'] = ['android.support.annotation.NonNull', '',
+        expected['imports'] = ['androidx.annotation.NonNull', '',
                                'com.smartdevicelink.protocol.enums.FunctionID',
                                'com.smartdevicelink.proxy.RPCRequest',
                                '', 'java.util.Hashtable', 'java.util.List']
@@ -139,7 +139,7 @@ class TestFunctionsProducer(unittest.TestCase):
         expected['function_id'] = 'PUT_FILE'
         expected['class_name'] = 'PutFile'
         expected['extends_class'] = 'RPCRequest'
-        expected['imports'] = ['android.support.annotation.NonNull', '',
+        expected['imports'] = ['androidx.annotation.NonNull', '',
                                'com.smartdevicelink.protocol.enums.FunctionID', 'com.smartdevicelink.proxy.RPCRequest',
                                'com.smartdevicelink.proxy.rpc.enums.FileType', '', 'java.util.Hashtable']
         expected['description'] = ['Used to']
@@ -163,7 +163,7 @@ class TestFunctionsProducer(unittest.TestCase):
         expected['function_id'] = 'ON_ENCODED_SYNC_PDATA'
         expected['class_name'] = 'OnEncodedSyncPData'
         expected['extends_class'] = 'RPCNotification'
-        expected['imports'] = ['android.support.annotation.NonNull', '',
+        expected['imports'] = ['androidx.annotation.NonNull', '',
                                'com.smartdevicelink.protocol.enums.FunctionID',
                                'com.smartdevicelink.proxy.RPCNotification', '', 'java.util.Hashtable']
         expected['description'] = ['Callback including']
@@ -184,7 +184,7 @@ class TestFunctionsProducer(unittest.TestCase):
         expected['function_id'] = 'DELETE_COMMAND'
         expected['class_name'] = 'DeleteCommand'
         expected['extends_class'] = 'RPCRequest'
-        expected['imports'] = ['android.support.annotation.NonNull', '',
+        expected['imports'] = ['androidx.annotation.NonNull', '',
                                'com.smartdevicelink.protocol.enums.FunctionID', 'com.smartdevicelink.proxy.RPCRequest',
                                '', 'java.util.Hashtable']
         expected['params'] = (
@@ -204,7 +204,7 @@ class TestFunctionsProducer(unittest.TestCase):
         expected['function_id'] = 'ALERT'
         expected['class_name'] = 'Alert'
         expected['extends_class'] = 'RPCRequest'
-        expected['imports'] = ['android.support.annotation.NonNull', '',
+        expected['imports'] = ['androidx.annotation.NonNull', '',
                                'com.smartdevicelink.protocol.enums.FunctionID',
                                'com.smartdevicelink.proxy.RPCRequest', '', 'java.util.Hashtable']
         expected['params'] = (
@@ -225,7 +225,7 @@ class TestFunctionsProducer(unittest.TestCase):
         expected['function_id'] = 'RELEASE_INTERIOR_VEHICLE_DATA_MODULE'
         expected['class_name'] = 'ReleaseInteriorVehicleDataModule'
         expected['extends_class'] = 'RPCRequest'
-        expected['imports'] = ['android.support.annotation.NonNull', '',
+        expected['imports'] = ['androidx.annotation.NonNull', '',
                                'com.smartdevicelink.protocol.enums.FunctionID',
                                'com.smartdevicelink.proxy.RPCRequest', '', 'java.util.Hashtable']
         expected['params'] = (

--- a/generator/test/test_structs.py
+++ b/generator/test/test_structs.py
@@ -40,7 +40,7 @@ class TestStructsProducer(unittest.TestCase):
             'class_name': 'AudioPassThruCapabilities',
             'extends_class': 'RPCStruct',
             'package_name': 'com.smartdevicelink.proxy.rpc',
-            'imports': ['android.support.annotation.NonNull', '', 'com.smartdevicelink.proxy.RPCStruct',
+            'imports': ['androidx.annotation.NonNull', '', 'com.smartdevicelink.proxy.RPCStruct',
                         'com.smartdevicelink.proxy.rpc.enums.SamplingRate',
                         'com.smartdevicelink.util.SdlDataTypeConverter', '', 'java.util.Hashtable'],
             'deprecated': None,
@@ -68,7 +68,7 @@ class TestStructsProducer(unittest.TestCase):
             'class_name': 'CloudAppProperties',
             'extends_class': 'RPCStruct',
             'package_name': 'com.smartdevicelink.proxy.rpc',
-            'imports': ['android.support.annotation.NonNull', '', 'com.smartdevicelink.proxy.RPCStruct', '',
+            'imports': ['androidx.annotation.NonNull', '', 'com.smartdevicelink.proxy.RPCStruct', '',
                         'java.util.Hashtable', 'java.util.List'],
             'deprecated': None,
             'since': None,
@@ -86,7 +86,7 @@ class TestStructsProducer(unittest.TestCase):
         }, description=['\n            Describes different audio type configurations for PerformAudioPassThru.\n     '])
         expected = {
             'package_name': 'com.smartdevicelink.proxy.rpc',
-            'imports': ['android.support.annotation.NonNull', '', 'com.smartdevicelink.proxy.RPCStruct', '',
+            'imports': ['androidx.annotation.NonNull', '', 'com.smartdevicelink.proxy.RPCStruct', '',
                         'java.util.Hashtable'],
             'class_name': 'SoftButton',
             'extends_class': 'RPCStruct',
@@ -107,7 +107,7 @@ class TestStructsProducer(unittest.TestCase):
         })
         expected = {
             'package_name': 'com.smartdevicelink.proxy.rpc',
-            'imports': ['android.support.annotation.NonNull', '', 'com.smartdevicelink.proxy.RPCStruct', '',
+            'imports': ['androidx.annotation.NonNull', '', 'com.smartdevicelink.proxy.RPCStruct', '',
                         'java.util.Hashtable'],
             'class_name': 'OASISAddress',
             'extends_class': 'RPCStruct',
@@ -127,7 +127,7 @@ class TestStructsProducer(unittest.TestCase):
         })
         expected = {
             'package_name': 'com.smartdevicelink.proxy.rpc',
-            'imports': ['android.support.annotation.NonNull', '', 'com.smartdevicelink.proxy.RPCStruct', '',
+            'imports': ['androidx.annotation.NonNull', '', 'com.smartdevicelink.proxy.RPCStruct', '',
                         'java.util.Hashtable'],
             'class_name': 'LocationDetails',
             'extends_class': 'RPCStruct',
@@ -147,7 +147,7 @@ class TestStructsProducer(unittest.TestCase):
         })
         expected = {
             'package_name': 'com.smartdevicelink.proxy.rpc',
-            'imports': ['android.support.annotation.NonNull', '', 'com.smartdevicelink.proxy.RPCStruct', '',
+            'imports': ['androidx.annotation.NonNull', '', 'com.smartdevicelink.proxy.RPCStruct', '',
                         'java.util.Hashtable'],
             'class_name': 'SingleTireStatus',
             'extends_class': 'RPCStruct',


### PR DESCRIPTION
Fixes #1531 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR updates the annotations imports in the RPC generator tests to use the new AndroidX ones.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
