### PR TITLE
Add missing `Use @link` annotations to some deprecated APIs

### DIFF
--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/OnSystemRequest.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/OnSystemRequest.java
@@ -311,7 +311,7 @@ public class OnSystemRequest extends RPCNotification {
 
     /**
      * @param offset of the data attached
-     * @deprecated as of SmartDeviceLink 4.0
+     * @deprecated as of SmartDeviceLink 4.0. Use {@link #setOffset(Long)} instead.
      */
     public OnSystemRequest setOffset(Integer offset) {
         if (offset == null) {
@@ -377,7 +377,7 @@ public class OnSystemRequest extends RPCNotification {
 
     /**
      * @param length of the data attached
-     * @deprecated as of SmartDeviceLink 4.0
+     * @deprecated as of SmartDeviceLink 4.0. Use {@link #setLength(Long)} instead.
      */
     public OnSystemRequest setLength(Integer length) {
         if (length == null) {

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/PutFile.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/PutFile.java
@@ -268,7 +268,7 @@ public class PutFile extends RPCRequest {
 
     /**
      * @param offset Optional offset in bytes for resuming partial data chunks
-     * @deprecated as of SmartDeviceLink 4.0
+     * @deprecated as of SmartDeviceLink 4.0. Use {@link #setOffset(Long)} instead.
      */
     public PutFile setOffset(Integer offset) {
         if (offset == null) {
@@ -305,7 +305,7 @@ public class PutFile extends RPCRequest {
     /**
      * @param length Optional length in bytes for resuming partial data chunks. If offset is set to 0, then length is
      *               the total length of the file to be downloaded
-     * @deprecated as of SmartDeviceLink 4.0
+     * @deprecated as of SmartDeviceLink 4.0. Use {@link #setLength(Long)} instead.
      */
     public PutFile setLength(Integer length) {
         if (length == null) {

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/TouchEvent.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/TouchEvent.java
@@ -132,7 +132,7 @@ public class TouchEvent extends RPCStruct {
      * Use getTimestamps
      *
      * @return
-     * @deprecated 4.0.2
+     * @deprecated in 4.0.2. Use {@link #getTimestamps()}()} instead.
      */
     @Deprecated
     public List<Long> getTs() {
@@ -170,7 +170,7 @@ public class TouchEvent extends RPCStruct {
      * Use setTimestamps.
      *
      * @param ts
-     * @deprecated 4.0.2
+     * @deprecated in 4.0.2. Use {@link #setTimestamps(List)} instead.
      */
     @Deprecated
     public TouchEvent setTs(List<Long> ts) {
@@ -182,7 +182,7 @@ public class TouchEvent extends RPCStruct {
      * Use getTouchCoordinates
      *
      * @return
-     * @deprecated 4.0.2
+     * @deprecated in 4.0.2. Use {@link #getTouchCoordinates()} instead.
      */
     @Deprecated
     public List<TouchCoord> getC() {
@@ -198,7 +198,7 @@ public class TouchEvent extends RPCStruct {
      * Use setTouchCoordinates
      *
      * @return
-     * @deprecated 4.0.2
+     * @deprecated in 4.0.2. Use {@link #setTouchCoordinates(List)} instead.
      */
     @Deprecated
     public TouchEvent setC(List<TouchCoord> c) {


### PR DESCRIPTION
Fixes #1536

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR adds the missing `Use @link` annotations to some deprecated APIs to clarify what new APIs should be used instead

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
