### PR TITLE
Fix unit test for Hotfix

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/ManagerUtilityTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/ManagerUtilityTests.java
@@ -1,6 +1,6 @@
 package com.smartdevicelink.managers;
 
-import androidx.test.ext.junit.runners.AndroidJUnit4;
+import android.support.test.runner.AndroidJUnit4;
 
 import com.smartdevicelink.proxy.rpc.ImageField;
 import com.smartdevicelink.proxy.rpc.TextField;
@@ -96,13 +96,13 @@ public class ManagerUtilityTests {
 	public void testHasTextFieldOfName() {
 		WindowCapability capability = new WindowCapability();
 		List<TextField> textFieldList = new ArrayList<>();
-		textFieldList.add(new TextField(TextFieldName.mainField1, CharacterSet.UTF_8, 500, 8));
+		textFieldList.add(new TextField(TextFieldName.mainField1, CharacterSet.CID2SET, 500, 8));
 		capability.setTextFields(textFieldList);
 
 		assertTrue(ManagerUtility.WindowCapabilityUtility.hasTextFieldOfName(capability, TextFieldName.mainField1));
 		assertFalse(ManagerUtility.WindowCapabilityUtility.hasTextFieldOfName(capability, TextFieldName.alertText3));
 
-		textFieldList.add(new TextField(TextFieldName.alertText3, CharacterSet.UTF_8, 500, 8));
+		textFieldList.add(new TextField(TextFieldName.alertText3, CharacterSet.CID2SET, 500, 8));
 		capability.setTextFields(textFieldList);
 		assertTrue(ManagerUtility.WindowCapabilityUtility.hasTextFieldOfName(capability, TextFieldName.mainField1));
 		assertTrue(ManagerUtility.WindowCapabilityUtility.hasTextFieldOfName(capability, TextFieldName.alertText3));
@@ -113,7 +113,7 @@ public class ManagerUtilityTests {
 		assertFalse(ManagerUtility.WindowCapabilityUtility.hasTextFieldOfName(capability, TextFieldName.mainField1));
 		assertFalse(ManagerUtility.WindowCapabilityUtility.hasTextFieldOfName(capability, TextFieldName.alertText3));
 
-		textFieldList.add(new TextField(TextFieldName.alertText3, CharacterSet.UTF_8, 500, 8));
+		textFieldList.add(new TextField(TextFieldName.alertText3, CharacterSet.CID2SET, 500, 8));
 		capability.setTextFields(textFieldList);
 		assertFalse(ManagerUtility.WindowCapabilityUtility.hasTextFieldOfName(capability, TextFieldName.mainField1));
 		assertTrue(ManagerUtility.WindowCapabilityUtility.hasTextFieldOfName(capability, TextFieldName.alertText3));
@@ -164,22 +164,22 @@ public class ManagerUtilityTests {
 
 		//Single line
 		List<TextField> singleLineList = new ArrayList<>();
-		singleLineList.add(new TextField(TextFieldName.mainField1, CharacterSet.UTF_8, 500, 8));
+		singleLineList.add(new TextField(TextFieldName.mainField1, CharacterSet.CID2SET, 500, 8));
 		capability.setTextFields(singleLineList);
 		maxNumerOfLines = ManagerUtility.WindowCapabilityUtility.getMaxNumberOfMainFieldLines(capability);
 		assertEquals(1, maxNumerOfLines);
 
-		singleLineList.add(new TextField(TextFieldName.mainField2, CharacterSet.UTF_8, 500, 8));
+		singleLineList.add(new TextField(TextFieldName.mainField2, CharacterSet.CID2SET, 500, 8));
 		capability.setTextFields(singleLineList);
 		maxNumerOfLines = ManagerUtility.WindowCapabilityUtility.getMaxNumberOfMainFieldLines(capability);
 		assertEquals(2, maxNumerOfLines);
 
-		singleLineList.add(new TextField(TextFieldName.mainField3, CharacterSet.UTF_8, 500, 8));
+		singleLineList.add(new TextField(TextFieldName.mainField3, CharacterSet.CID2SET, 500, 8));
 		capability.setTextFields(singleLineList);
 		maxNumerOfLines = ManagerUtility.WindowCapabilityUtility.getMaxNumberOfMainFieldLines(capability);
 		assertEquals(3, maxNumerOfLines);
 
-		singleLineList.add(new TextField(TextFieldName.mainField4, CharacterSet.UTF_8, 500, 8));
+		singleLineList.add(new TextField(TextFieldName.mainField4, CharacterSet.CID2SET, 500, 8));
 		capability.setTextFields(singleLineList);
 		maxNumerOfLines = ManagerUtility.WindowCapabilityUtility.getMaxNumberOfMainFieldLines(capability);
 		assertEquals(4, maxNumerOfLines);
@@ -194,7 +194,7 @@ public class ManagerUtilityTests {
 		maxNumerOfLines = ManagerUtility.WindowCapabilityUtility.getMaxNumberOfMainFieldLines(capability);
 		assertEquals(0, maxNumerOfLines);
 
-		nullList.add(new TextField(TextFieldName.mainField4, CharacterSet.UTF_8, 500, 8));
+		nullList.add(new TextField(TextFieldName.mainField4, CharacterSet.CID2SET, 500, 8));
 		assertNotNull(nullList);
 		capability.setTextFields(nullList);
 		assertNotNull(capability);

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/RPCRequestFactoryTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/RPCRequestFactoryTests.java
@@ -642,7 +642,7 @@ public class RPCRequestFactoryTests extends TestCase {
 		assertNull(TestValues.NULL, testRAI.getAppName());
 		assertNull(TestValues.NULL, testRAI.getTtsName());
 		assertNull(TestValues.NULL, testRAI.getNgnMediaScreenAppName());
-		assertNull(TestValues.NULL, testRAI.getVrSynonyms());
+		assertNull(TestValues.NULL, testRAI.getVrSynonyms().get(0));
 		assertNull(TestValues.NULL, testRAI.getIsMediaApplication());
 		assertNotNull(TestValues.NOT_NULL, testRAI.getLanguageDesired());
 		assertNotNull(TestValues.NOT_NULL, testRAI.getHmiDisplayLanguageDesired());

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/RPCStructTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/RPCStructTests.java
@@ -1,6 +1,6 @@
 package com.smartdevicelink.test.rpc;
 
-import androidx.test.ext.junit.runners.AndroidJUnit4;
+import android.support.test.runner.AndroidJUnit4;
 
 import com.smartdevicelink.proxy.RPCStruct;
 


### PR DESCRIPTION
Fixes #1540

This PR is **read** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

### Summary
`ManagerUtilityTests.java` and `RPCStructTests.java` were apart of the hotFix, but were developed during 5.0. The test needed to be modified slightly to work with 4.12.1. 

### Changelog
- Use `CharacterSet.CID2SET` instead of Using `CharacterSet.UTF_8` in `ManagerUtilityTests.java`
- Use `import android.support.test.runner.AndroidJUnit4` instead of `import androidx.test.ext.junit.runners.AndroidJUnit4` in `ManagerUtilityTests.java` and `RPCStructTests.java`
 - Fix unit test in `RPCRequestFactoryTests.java` in relation to #1473 
### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
