### PR TITLE
Fix issue in setting MediaTrack in the T&G manager

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperation.java
@@ -497,6 +497,7 @@ class TextAndGraphicUpdateOperation extends Task {
         newShow.setMainField2(show.getMainField2());
         newShow.setMainField3(show.getMainField3());
         newShow.setMainField4(show.getMainField4());
+        newShow.setMediaTrack(show.getMediaTrack());
         newShow.setTemplateTitle(show.getTemplateTitle());
         newShow.setMetadataTags(show.getMetadataTags());
         newShow.setAlignment(show.getAlignment());


### PR DESCRIPTION
Fixes #1541

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Core Tests
To smoke test the PR, use this code snippet and confirm that the media track field is displayed on hmi:
```
sdlManager.getScreenManager().beginTransaction();
sdlManager.getScreenManager().setTextField1("Hi there");
sdlManager.getScreenManager().setMediaTrackTextField("Media Track");
sdlManager.getScreenManager().commit(new CompletionListener() {
    @Override
    public void onComplete(boolean success) {
        Log.i(TAG, "success: " + success);
    }
});
```

Module tested against: SYN 3.4

### Summary
This PR fixes an issue in the T&G manager where it was not setting the MediaTrack field correctly in the show.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
