### PR TITLE
Remove reference to baseAndroid from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,6 @@ from within the project (JavaSE or JavaEE) and a JAR should be generated in the 
 #### base Folder
 The base folder contains the source set that is shared between all of the compilable projects. This folder does not contain a compilable project. 
 
-#### baseAndroid Folder
-The baseAndroid folder contains symbolic links to files and folders from the base folder. This has been included since the Java Suite refactor is a minor version release and the base folder contains breaking changes for the Android project. This folder does not contain a compilable project. 
-
 #### android Folder 
 The android folder contains the SDL Android library as well as the sample project for Android. Both of those are compilable projects. 
 


### PR DESCRIPTION
This PR is **[not ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Summary
Now that the library no longer has symlinked directories (baseAndroid) the README has been updated to reflect that change.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
