### PR TITLE
Match Deprecations to RPC Spec

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/GlobalPropertyTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/GlobalPropertyTests.java
@@ -32,7 +32,7 @@ public class GlobalPropertyTests extends TestCase {
         GlobalProperty enumMenuIcon = GlobalProperty.valueForString(example);
         example = "KEYBOARDPROPERTIES";
         GlobalProperty enumKeyboardProperties = GlobalProperty.valueForString(example);
-        example = "USERLOCATION";
+        example = "USER_LOCATION";
         GlobalProperty enumUserLocation = GlobalProperty.valueForString(example);
 
         assertNotNull("HELPPROMPT returned null", enumHelpPrompt);
@@ -42,7 +42,7 @@ public class GlobalPropertyTests extends TestCase {
         assertNotNull("MENUNAME returned null", enumMenuName);
         assertNotNull("MENUICON returned null", enumMenuIcon);
         assertNotNull("KEYBOARDPROPERTIES returned null", enumKeyboardProperties);
-        assertNotNull("USERLOCATION returned null", enumUserLocation);
+        assertNotNull("USER_LOCATION returned null", enumUserLocation);
     }
 
     /**
@@ -86,6 +86,7 @@ public class GlobalPropertyTests extends TestCase {
         enumTestList.add(GlobalProperty.MENUICON);
         enumTestList.add(GlobalProperty.KEYBOARDPROPERTIES);
         enumTestList.add(GlobalProperty.USERLOCATION);
+        enumTestList.add(GlobalProperty.USER_LOCATION);
 
         assertTrue("Enum value list does not match enum class list",
                 enumValueList.containsAll(enumTestList) && enumTestList.containsAll(enumValueList));

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/SeatControlData.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/SeatControlData.java
@@ -43,6 +43,7 @@ import java.util.List;
  * Seat control data corresponds to "SEAT" ModuleType.
  */
 public class SeatControlData extends RPCStruct {
+    @Deprecated
     public static final String KEY_ID = "id";
     public static final String KEY_HEATING_ENABLED = "heatingEnabled";
     public static final String KEY_COOLING_ENABLED = "coolingEnabled";
@@ -81,6 +82,7 @@ public class SeatControlData extends RPCStruct {
      *
      * @param id type of SupportedSeat.
      */
+    @Deprecated
     public SeatControlData(@NonNull SupportedSeat id) {
         this();
         setId(id);
@@ -91,6 +93,7 @@ public class SeatControlData extends RPCStruct {
      *
      * @param id
      */
+    @Deprecated
     public SeatControlData setId(@NonNull SupportedSeat id) {
         setValue(KEY_ID, id);
         return this;
@@ -101,6 +104,7 @@ public class SeatControlData extends RPCStruct {
      *
      * @return SupportedSeat.
      */
+    @Deprecated
     public SupportedSeat getId() {
         return (SupportedSeat) getObject(SupportedSeat.class, KEY_ID);
     }

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/SetDisplayLayout.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/SetDisplayLayout.java
@@ -94,6 +94,7 @@ import java.util.Hashtable;
  *
  * @since SmartDeviceLink 2.0
  */
+@Deprecated
 public class SetDisplayLayout extends RPCRequest {
     public static final String KEY_DISPLAY_LAYOUT = "displayLayout";
     public static final String KEY_DAY_COLOR_SCHEME = "dayColorScheme";

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/SetDisplayLayoutResponse.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/SetDisplayLayoutResponse.java
@@ -46,6 +46,7 @@ import java.util.List;
  *
  * @since SmartDeviceLink 2.0
  */
+@Deprecated
 public class SetDisplayLayoutResponse extends RPCResponse {
     public static final String KEY_BUTTON_CAPABILITIES = "buttonCapabilities";
     public static final String KEY_DISPLAY_CAPABILITIES = "displayCapabilities";

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/DisplayType.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/DisplayType.java
@@ -36,7 +36,7 @@ package com.smartdevicelink.proxy.rpc.enums;
  *
  * @since SmartDeviceLink 1.0
  */
-
+@Deprecated
 public enum DisplayType {
     /**
      * Center Information Display.

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/GlobalProperty.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/GlobalProperty.java
@@ -71,10 +71,13 @@ public enum GlobalProperty {
 
     KEYBOARDPROPERTIES,
 
+    @Deprecated
+    USERLOCATION,
+
     /**
      * The user seat location of setGlobalProperties
      */
-    USERLOCATION;
+    USER_LOCATION;
 
     /**
      * Convert String to GlobalProperty


### PR DESCRIPTION
Fixes #1545 

This PR is **[not ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
- [ ] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [ ] I have tested Android, Java SE, and Java EE

### Summary
This PR will deprecate some RPCs to align with the RPC Spec
`GlobalProperty.USERLOCATION` is now deprecated and `GlobalPropert.USER_LOCATION` is now added
`SeatControlData.id` is now deprecated along with associated methods
`DisplayType`, `SetDisplayLayout`, and `SetDisplayLayoutResponse` are now deprecated as well

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
