### PR TITLE
Fix missing media track field (v4.12)

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/screen/BaseTextAndGraphicManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/BaseTextAndGraphicManager.java
@@ -628,6 +628,7 @@ abstract class BaseTextAndGraphicManager extends BaseSubManager {
 		newShow.setMainField3(show.getMainField3());
 		newShow.setMainField4(show.getMainField4());
 		newShow.setTemplateTitle(show.getTemplateTitle());
+		newShow.setMediaTrack(show.getMediaTrack());
 
 		return newShow;
 	}


### PR DESCRIPTION

Fixes part of #1541 

This PR is **[ready / not ready]** for review.

### Risk
This PR makes **[no / minor / major]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

### Summary
Added the missing set for media track when extracting text lines from a show request.

### Changelog

##### Bug Fixes
* Media track will now properly be set for all systems that use it

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
