### PR TITLE
Add code to handle legacy PTU (v4.12)

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
@@ -478,7 +478,6 @@ abstract class BaseLifecycleManager {
                             }
                         }
 
-                        DebugTool.logWarning(TAG, "Unable to handle OnSystemRequest");
                         break;
                     case ON_APP_INTERFACE_UNREGISTERED:
 

--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
@@ -377,6 +377,11 @@ abstract class BaseLifecycleManager {
         addRpcListener(FunctionID.ON_SYSTEM_REQUEST, rpcListener);
         addRpcListener(FunctionID.ON_APP_INTERFACE_UNREGISTERED, rpcListener);
         addRpcListener(FunctionID.UNREGISTER_APP_INTERFACE, rpcListener);
+
+        /*  These are legacy and are necessary for older systems   */
+        addRpcListener(FunctionID.ON_SYNC_P_DATA, rpcListener);
+        addRpcListener(FunctionID.ON_ENCODED_SYNC_P_DATA, rpcListener);
+
     }
 
     private OnRPCListener rpcListener = new OnRPCListener() {
@@ -418,42 +423,62 @@ abstract class BaseLifecycleManager {
                     case ON_HASH_CHANGE:
                         break;
                     case ON_SYSTEM_REQUEST:
-                        final OnSystemRequest onSystemRequest = (OnSystemRequest) message;
-                        if ((onSystemRequest.getUrl() != null) &&
-                                (((onSystemRequest.getRequestType() == RequestType.PROPRIETARY) && (onSystemRequest.getFileType() == FileType.JSON))
-                                        || ((onSystemRequest.getRequestType() == RequestType.HTTP) && (onSystemRequest.getFileType() == FileType.BINARY)))) {
-                            Thread handleOffboardTransmissionThread = new Thread() {
-                                @Override
-                                public void run() {
-                                    RPCRequest request = PoliciesFetcher.fetchPolicies(onSystemRequest);
-                                    if (request != null && isConnected()) {
-                                        sendRPCMessagePrivate(request, true);
-                                    }
-                                }
-                            };
-                            handleOffboardTransmissionThread.start();
-                        } else if (onSystemRequest.getRequestType() == RequestType.ICON_URL && onSystemRequest.getUrl() != null) {
-                            //Download the icon file and send SystemRequest RPC
-                            Thread handleOffBoardTransmissionThread = new Thread() {
-                                @Override
-                                public void run() {
-                                    final String urlHttps = onSystemRequest.getUrl().replaceFirst("http://", "https://");
-                                    byte[] file = FileUtls.downloadFile(urlHttps);
-                                    if (file != null) {
-                                        SystemRequest systemRequest = new SystemRequest();
-                                        systemRequest.setFileName(onSystemRequest.getUrl());
-                                        systemRequest.setBulkData(file);
-                                        systemRequest.setRequestType(RequestType.ICON_URL);
-                                        if (isConnected()) {
-                                            sendRPCMessagePrivate(systemRequest, true);
-                                        }
-                                    } else {
-                                        DebugTool.logError(TAG, "File was null at: " + urlHttps);
-                                    }
-                                }
-                            };
-                            handleOffBoardTransmissionThread.start();
+                    case ON_ENCODED_SYNC_P_DATA:
+                    case ON_SYNC_P_DATA:
+                        if (functionID.equals(FunctionID.ON_ENCODED_SYNC_P_DATA) || functionID.equals(FunctionID.ON_SYNC_P_DATA)) {
+                            DebugTool.logInfo(TAG, "Received legacy SYNC_P_DATA, handling it as OnSystemRequest");
+                        } else {
+                            DebugTool.logInfo(TAG, "Received OnSystemRequest");
                         }
+
+                        final OnSystemRequest onSystemRequest = (OnSystemRequest) message;
+                        RequestType requestType = onSystemRequest.getRequestType();
+                        FileType fileType = onSystemRequest.getFileType();
+
+                        if (onSystemRequest.getUrl() != null) {
+                            if ((requestType == RequestType.PROPRIETARY && fileType == FileType.JSON)
+                                    || (requestType == RequestType.HTTP && fileType == FileType.BINARY)
+                                    || functionID.equals(FunctionID.ON_ENCODED_SYNC_P_DATA)
+                                    || functionID.equals(FunctionID.ON_SYNC_P_DATA)) {
+                                DebugTool.logInfo(TAG, "List of conditionals has passed");
+                                Thread handleOffboardTransmissionThread = new Thread() {
+                                    @Override
+                                    public void run() {
+                                        DebugTool.logInfo(TAG, "Attempting to fetch policies");
+                                        RPCRequest request = PoliciesFetcher.fetchPolicies(onSystemRequest);
+                                        if (request != null && isConnected()) {
+                                            sendRPCMessagePrivate(request, true);
+                                        }
+                                    }
+                                };
+                                handleOffboardTransmissionThread.start();
+                                return;
+                            } else if (requestType == RequestType.ICON_URL) {
+                                //Download the icon file and send SystemRequest RPC
+                                Thread handleOffBoardTransmissionThread = new Thread() {
+                                    @Override
+                                    public void run() {
+                                        final String urlHttps = onSystemRequest.getUrl().replaceFirst("http://", "https://");
+                                        byte[] file = FileUtls.downloadFile(urlHttps);
+                                        if (file != null) {
+                                            SystemRequest systemRequest = new SystemRequest();
+                                            systemRequest.setFileName(onSystemRequest.getUrl());
+                                            systemRequest.setBulkData(file);
+                                            systemRequest.setRequestType(RequestType.ICON_URL);
+                                            if (isConnected()) {
+                                                sendRPCMessagePrivate(systemRequest, true);
+                                            }
+                                        } else {
+                                            DebugTool.logError(TAG, "File was null at: " + urlHttps);
+                                        }
+                                    }
+                                };
+                                handleOffBoardTransmissionThread.start();
+                                return;
+                            }
+                        }
+
+                        DebugTool.logWarning(TAG, "Unable to handle OnSystemRequest");
                         break;
                     case ON_APP_INTERFACE_UNREGISTERED:
 

--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/RpcConverter.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/RpcConverter.java
@@ -138,9 +138,16 @@ public class RpcConverter {
         if(params != null && params.containsKey(RPCMessage.KEY_FUNCTION_NAME)){
             StringBuilder rpcClassName = new StringBuilder();
             String functionName = (String)params.get(RPCMessage.KEY_FUNCTION_NAME);
-            if(FunctionID.SHOW_CONSTANT_TBT.toString().equals(functionName)) {
-                    functionName = "ShowConstantTbt";
+            if (FunctionID.SHOW_CONSTANT_TBT.toString().equals(functionName)) {
+                functionName = "ShowConstantTbt";
+            } else if (FunctionID.ON_ENCODED_SYNC_P_DATA.toString().equals(functionName)
+                    || FunctionID.ON_SYNC_P_DATA.toString().equals(functionName)) {
+                //This will create an OnSystemRequest instance, but the function id in the RPC
+                //will remain FunctionID.ON_ENCODED_SYNC_P_DATA or FunctionID.ON_SYNC_P_DATA.
+                //This is desired behavior.
+                functionName = FunctionID.ON_SYSTEM_REQUEST.toString();
             }
+
             rpcClassName.append(RPC_PACKAGE);
             rpcClassName.append (functionName);
 

--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/RpcConverter.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/RpcConverter.java
@@ -146,6 +146,12 @@ public class RpcConverter {
                 //will remain FunctionID.ON_ENCODED_SYNC_P_DATA or FunctionID.ON_SYNC_P_DATA.
                 //This is desired behavior.
                 functionName = FunctionID.ON_SYSTEM_REQUEST.toString();
+            } else if (FunctionID.ENCODED_SYNC_P_DATA.toString().equals(functionName)
+                    || FunctionID.SYNC_P_DATA.toString().equals(functionName)) {
+                //This will create an SystemRequest instance, but the function id in the RPC
+                //will remain FunctionID.ENCODED_SYNC_P_DATA or FunctionID.SYNC_P_DATA.
+                //This is desired behavior.
+                functionName = FunctionID.SYSTEM_REQUEST.toString();
             }
 
             rpcClassName.append(RPC_PACKAGE);


### PR DESCRIPTION
Fixes part of #1541 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android


### Summary
- Added code to the RPC converter to handle legacy RPCs that no longer have classes associated with them
- Added logic to process the legacy PTU RPCs as newer, still supported RPC classes

### Changelog

##### Bug Fixes
* Fixes issue where policy table updates wouldn't occur on older systems


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
