### PR TITLE
Fix Gradle 4.1 compatibility issue

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.0'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Aug 19 13:26:39 EDT 2020
+#Fri Nov 06 10:04:32 EST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/android/sdl_android/build.gradle
+++ b/android/sdl_android/build.gradle
@@ -7,8 +7,9 @@ android {
         targetSdkVersion 29
         versionCode 17
         versionName new File(projectDir.path, ('/../../VERSION')).text.trim()
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+        buildConfigField "String", "VERSION_NAME", '\"' + versionName + '\"'
         resValue "string", "SDL_LIB_VERSION", '\"' + versionName + '\"'
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
         release {

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/util/VersionTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/util/VersionTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.fail;
 
 @RunWith(AndroidJUnit4.class)
 public class VersionTest {
@@ -27,10 +28,8 @@ public class VersionTest {
     public void testConstructorIncorrect() {
         try {
             Version version = new Version("1.2");
-        } catch (Exception e) {
-            assert true;
-        }
-        assert false;
+            fail();
+        } catch (Exception e) {}
     }
 
     @Test


### PR DESCRIPTION
Fixes #1551 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Core Tests
To smoke test the PR: compile Hello Sdl Android, connect to Core, and make sure it connects successfully 

Module tested against: Core 7.0

### Summary
This PR:
- Update Gradle plugin to the current latest version (4.1)
- Add `VERSION_NAME` as a variable in `build.gradle` to force Gradle to add that var the `BuildConfig` so the Android library can use it 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
