### PR TITLE
Add map to track which transports started a service

### DIFF
--- a/base/src/main/java/com/smartdevicelink/protocol/SdlProtocolBase.java
+++ b/base/src/main/java/com/smartdevicelink/protocol/SdlProtocolBase.java
@@ -830,7 +830,6 @@ public class SdlProtocolBase {
     }
 
     public void endService(SessionType serviceType, byte sessionID) {
-        serviceOnTransport.put(serviceType, false);
         if (serviceType.equals(SessionType.RPC)) { //RPC session will close all other sessions so we want to make sure we use the correct EndProtocolSession method
             endSession(sessionID);
         } else {

--- a/base/src/main/java/com/smartdevicelink/protocol/SdlProtocolBase.java
+++ b/base/src/main/java/com/smartdevicelink/protocol/SdlProtocolBase.java
@@ -213,6 +213,7 @@ public class SdlProtocolBase {
         messageID = 0;
         headerSize = V1_HEADER_SIZE;
         this.activeTransports.clear();
+        this.serviceOnTransport.clear();
         this.mtus.clear();
         mtus.put(SessionType.RPC, (long) (V1_V2_MTU_SIZE - headerSize));
         this.secondaryTransportParams = null;
@@ -1199,12 +1200,14 @@ public class SdlProtocolBase {
                 if (serviceOnTransport.get(SessionType.NAV) != null && serviceOnTransport.get(SessionType.NAV)) {
                     iSdlProtocol.onServiceError(null, SessionType.NAV, iSdlProtocol.getSessionId(), "Transport disconnected");
                     activeTransports.remove(SessionType.NAV);
+                    serviceOnTransport.remove(SessionType.NAV);
                 }
             }
             if (getTransportForSession(SessionType.PCM) != null && disconnectedTransport.equals(getTransportForSession(SessionType.PCM))) {
                 if (serviceOnTransport.get(SessionType.PCM) != null && serviceOnTransport.get(SessionType.PCM)) {
                     iSdlProtocol.onServiceError(null, SessionType.PCM, iSdlProtocol.getSessionId(), "Transport disconnected");
                     activeTransports.remove(SessionType.PCM);
+                    serviceOnTransport.remove(SessionType.PCM);
                 }
             }
 
@@ -1262,6 +1265,7 @@ public class SdlProtocolBase {
                 requestedSession = false;
 
                 activeTransports.clear();
+                serviceOnTransport.clear();
 
                 iSdlProtocol.onTransportDisconnected(info, primaryTransportAvailable, transportConfig);
 

--- a/base/src/main/java/com/smartdevicelink/protocol/SdlProtocolBase.java
+++ b/base/src/main/java/com/smartdevicelink/protocol/SdlProtocolBase.java
@@ -103,7 +103,7 @@ public class SdlProtocolBase {
     private final Hashtable<Byte, Object> _messageLocks = new Hashtable<>();
     private final HashMap<SessionType, Long> mtus = new HashMap<>();
     private final HashMap<SessionType, TransportRecord> activeTransports = new HashMap<>();
-    private final HashMap<SessionType, Boolean> serviceOnTransport = new HashMap<>();
+    private final HashMap<SessionType, Boolean> serviceStartedOnTransport = new HashMap<>();
     private final Map<TransportType, List<ISecondaryTransportListener>> secondaryTransportListeners = new HashMap<>();
 
 
@@ -213,7 +213,7 @@ public class SdlProtocolBase {
         messageID = 0;
         headerSize = V1_HEADER_SIZE;
         this.activeTransports.clear();
-        this.serviceOnTransport.clear();
+        this.serviceStartedOnTransport.clear();
         this.mtus.clear();
         mtus.put(SessionType.RPC, (long) (V1_V2_MTU_SIZE - headerSize));
         this.secondaryTransportParams = null;
@@ -710,7 +710,7 @@ public class SdlProtocolBase {
 
     public void startService(SessionType serviceType, byte sessionID, boolean isEncrypted) {
         final SdlPacket header = SdlPacketFactory.createStartSession(serviceType, 0x00, (byte) protocolVersion.getMajor(), sessionID, isEncrypted);
-        serviceOnTransport.put(serviceType, true);
+        serviceStartedOnTransport.put(serviceType, true);
         if (SessionType.RPC.equals(serviceType)) {
             if (connectedPrimaryTransport != null) {
                 header.setTransportRecord(connectedPrimaryTransport);
@@ -1196,17 +1196,17 @@ public class SdlProtocolBase {
             //a single transport record per transport.
             //TransportType type = disconnectedTransport.getType();
             if (getTransportForSession(SessionType.NAV) != null && disconnectedTransport.equals(getTransportForSession(SessionType.NAV))) {
-                if (serviceOnTransport.get(SessionType.NAV) != null && serviceOnTransport.get(SessionType.NAV)) {
+                if (serviceStartedOnTransport.get(SessionType.NAV) != null && serviceStartedOnTransport.get(SessionType.NAV)) {
                     iSdlProtocol.onServiceError(null, SessionType.NAV, iSdlProtocol.getSessionId(), "Transport disconnected");
                     activeTransports.remove(SessionType.NAV);
-                    serviceOnTransport.remove(SessionType.NAV);
+                    serviceStartedOnTransport.remove(SessionType.NAV);
                 }
             }
             if (getTransportForSession(SessionType.PCM) != null && disconnectedTransport.equals(getTransportForSession(SessionType.PCM))) {
-                if (serviceOnTransport.get(SessionType.PCM) != null && serviceOnTransport.get(SessionType.PCM)) {
+                if (serviceStartedOnTransport.get(SessionType.PCM) != null && serviceStartedOnTransport.get(SessionType.PCM)) {
                     iSdlProtocol.onServiceError(null, SessionType.PCM, iSdlProtocol.getSessionId(), "Transport disconnected");
                     activeTransports.remove(SessionType.PCM);
-                    serviceOnTransport.remove(SessionType.PCM);
+                    serviceStartedOnTransport.remove(SessionType.PCM);
                 }
             }
 
@@ -1264,7 +1264,7 @@ public class SdlProtocolBase {
                 requestedSession = false;
 
                 activeTransports.clear();
-                serviceOnTransport.clear();
+                serviceStartedOnTransport.clear();
 
                 iSdlProtocol.onTransportDisconnected(info, primaryTransportAvailable, transportConfig);
 

--- a/base/src/main/java/com/smartdevicelink/protocol/SdlProtocolBase.java
+++ b/base/src/main/java/com/smartdevicelink/protocol/SdlProtocolBase.java
@@ -1196,13 +1196,13 @@ public class SdlProtocolBase {
             //a single transport record per transport.
             //TransportType type = disconnectedTransport.getType();
             if (getTransportForSession(SessionType.NAV) != null && disconnectedTransport.equals(getTransportForSession(SessionType.NAV))) {
-                if (serviceOnTransport.get(SessionType.NAV)) {
+                if (serviceOnTransport.get(SessionType.NAV) != null && serviceOnTransport.get(SessionType.NAV)) {
                     iSdlProtocol.onServiceError(null, SessionType.NAV, iSdlProtocol.getSessionId(), "Transport disconnected");
                     activeTransports.remove(SessionType.NAV);
                 }
             }
             if (getTransportForSession(SessionType.PCM) != null && disconnectedTransport.equals(getTransportForSession(SessionType.PCM))) {
-                if (serviceOnTransport.get(SessionType.PCM)) {
+                if (serviceOnTransport.get(SessionType.PCM) != null && serviceOnTransport.get(SessionType.PCM)) {
                     iSdlProtocol.onServiceError(null, SessionType.PCM, iSdlProtocol.getSessionId(), "Transport disconnected");
                     activeTransports.remove(SessionType.PCM);
                 }


### PR DESCRIPTION
Fixes #1574 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Core Tests
Security should be set up to see the errors. So it is better to test with test suite.

modify the testSuite so that you can call `sdlManager.dispose()` I added it to `appInfo` menu item

Test 1)
Connect your testSuite to core and open the application on core.
Now that the SDL service is started you can call `sdlManager.dispose()` and in the logs you should no longer observer the following log messages:
```
E/BaseEncryptionLifecycleManager: RC_5.0.0: onServiceError, session Type: NAV, reason: Transport disconnected
E/BaseEncryptionLifecycleManager: RC_5.0.0: onServiceError, session Type: PCM, reason: Transport disconnected
```

Test 2)
Make sure you set the test suite to type Navigation.
Connect your testSuite to core and open the application on core.
Once the app is connected and open start the video streaming test in the test suite.
While the video is streaming you can call `sdlManager.dispose()` the app may crash as this is not the proper way clean up the managers but you can now verify in the logs that just the following log is printed
```
E/BaseEncryptionLifecycleManager: RC_5.0.0: onServiceError, session Type: NAV, reason: Transport disconnected
```

Test 3)
Make sure you set the test suite to type Navigation.
Connect your testSuite to core and open the application on core.
Once the app is connected and open start the audio streaming test in the test suite.
While the audio is streaming you can call `sdlManager.dispose()` the app may crash as this is not the proper way clean up the managers but you can now verify in the logs that just the following log is printed
```
E/BaseEncryptionLifecycleManager: RC_5.0.0: onServiceError, session Type: PCM, reason: Transport disconnected
```

### Summary
This PR will add a hashmap to the `SdlProtocolBase` which will be used to track whether there is an active service or not on a given SessionType. This will be used to make sure we are appropriatly logging errors, currently we are logging errors for SessionTypes even when there is no active service for that SessionType.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
