### PR TITLE
Implement SDL 0323: Align video streaming parameters with VideoStreamingCapability

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
@@ -125,9 +125,26 @@ public class VirtualDisplayEncoder {
         return this.streamingParams;
     }
 
+    /**
+     * This method is deprecated; setStreamingParams with having stableFrameRate should be used.
+     */
     @Deprecated
     public void setStreamingParams(int displayDensity, ImageResolution resolution, int frameRate, int bitrate, int interval, VideoStreamingFormat format) {
         this.streamingParams = new VideoStreamingParameters(displayDensity, frameRate, bitrate, interval, resolution, format);
+    }
+
+    /**
+     * setter of every parameter in streamingParams.
+     * @param displayDensity
+     * @param resolution
+     * @param frameRate
+     * @param bitrate
+     * @param interval
+     * @param format
+     * @param stableFramerate
+     */
+    public void setStreamingParams(int displayDensity, ImageResolution resolution, int frameRate, int bitrate, int interval, VideoStreamingFormat format, boolean stableFramerate) {
+        this.streamingParams = new VideoStreamingParameters(displayDensity, frameRate, bitrate, interval, resolution, format, stableFramerate);
     }
 
     @SuppressWarnings("unused")

--- a/android/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
@@ -131,11 +131,6 @@ public class VirtualDisplayEncoder {
     }
 
     @SuppressWarnings("unused")
-    public void setStreamingParams(int displayDensity, ImageResolution resolution, int frameRate, int bitrate, int interval, VideoStreamingFormat format, boolean stableFrameRate) {
-        this.streamingParams = new VideoStreamingParameters(displayDensity, frameRate, bitrate, interval, resolution, format, stableFrameRate);
-    }
-
-    @SuppressWarnings("unused")
     public void setStreamingParams(VideoStreamingParameters streamingParams) {
         this.streamingParams = streamingParams;
     }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -311,8 +311,6 @@ public class VideoStreamManager extends BaseVideoStreamManager {
                         DebugTool.logError(TAG, "Error retrieving video streaming capability: " + info);
                     }
                 }, false);
-            } else {
-                DebugTool.logError(TAG, "Cannot start video streaming because getSystemCapabilityManager is null.");
             }
         } else {
             //We just use default video streaming params

--- a/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
+++ b/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
@@ -83,6 +83,27 @@ public class VideoStreamingParameters {
     }
 
     /**
+     * deprecated constructor of VideoStreamingParameters. This constructor will be removed in the future version.
+     * @param displayDensity
+     * @param frameRate
+     * @param bitrate
+     * @param interval
+     * @param resolution
+     * @param format
+     */
+    @Deprecated
+    public VideoStreamingParameters(int displayDensity, int frameRate, int bitrate, int interval,
+                                    ImageResolution resolution, VideoStreamingFormat format) {
+	    this.displayDensity = displayDensity;
+	    this.frameRate = frameRate;
+	    this.bitrate = bitrate;
+	    this.interval = interval;
+	    this.resolution = resolution;
+	    this.format = format;
+	    this.stableFrameRate = true;
+    }
+
+    /**
      * new constructor of VideoStreamingParameters, which now has stableFrameRate param.
      * @param displayDensity
      * @param frameRate
@@ -92,16 +113,15 @@ public class VideoStreamingParameters {
      * @param format
      * @param stableFrameRate
      */
-    @Deprecated
     public VideoStreamingParameters(int displayDensity, int frameRate, int bitrate, int interval,
-                                    ImageResolution resolution, VideoStreamingFormat format){
-	    this.displayDensity = displayDensity;
-	    this.frameRate = frameRate;
-	    this.bitrate = bitrate;
-	    this.interval = interval;
-	    this.resolution = resolution;
-	    this.format = format;
-	    this.stableFrameRate = true;
+                                    ImageResolution resolution, VideoStreamingFormat format, boolean stableFrameRate) {
+        this.displayDensity = displayDensity;
+        this.frameRate = frameRate;
+        this.bitrate = bitrate;
+        this.interval = interval;
+        this.resolution = resolution;
+        this.format = format;
+        this.stableFrameRate = stableFrameRate;
     }
 
     /**

--- a/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
+++ b/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
@@ -190,6 +190,9 @@ public class VideoStreamingParameters {
         // This should be the last call as it will return out once a suitable format is found
         final List<VideoStreamingFormat> formats = capability.getSupportedFormats();
         if (formats != null && formats.size() > 0) {
+            if (this.format != null && formats.contains(this.format)) {
+                return; // given format is supported, so no need to change.
+            }
             for (VideoStreamingFormat format : formats) {
                 for (VideoStreamingFormat currentlySupportedFormat : currentlySupportedFormats) {
                     if (currentlySupportedFormat.equals(format)) {

--- a/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
+++ b/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
@@ -180,7 +180,9 @@ public class VideoStreamingParameters {
         if (capability.getMaxBitrate() != null) {
             // Taking lower value as per SDL 0323 :
             // https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0323-align-VideoStreamingParameter-with-capability.md
-            this.bitrate = Math.min(this.bitrate, capability.getMaxBitrate() * 1000);
+            if (capability.getMaxBitrate() * 1000 >= 0) {
+                this.bitrate = Math.min(this.bitrate, capability.getMaxBitrate() * 1000);
+            }
         } // NOTE: the unit of maxBitrate in getSystemCapability is kbps.
         double scale = DEFAULT_SCALE;
         // For resolution and scale, the capability values should be taken rather than parameters specified by developers.

--- a/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
+++ b/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
@@ -92,15 +92,16 @@ public class VideoStreamingParameters {
      * @param format
      * @param stableFrameRate
      */
+    @Deprecated
     public VideoStreamingParameters(int displayDensity, int frameRate, int bitrate, int interval,
-                                    ImageResolution resolution, VideoStreamingFormat format, boolean stableFrameRate){
+                                    ImageResolution resolution, VideoStreamingFormat format){
 	    this.displayDensity = displayDensity;
 	    this.frameRate = frameRate;
 	    this.bitrate = bitrate;
 	    this.interval = interval;
 	    this.resolution = resolution;
 	    this.format = format;
-	    this.stableFrameRate = stableFrameRate;
+	    this.stableFrameRate = true;
     }
 
     /**

--- a/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
+++ b/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
@@ -79,18 +79,7 @@ public class VideoStreamingParameters {
         format = new VideoStreamingFormat();
         format.setProtocol(DEFAULT_PROTOCOL);
         format.setCodec(DEFAULT_CODEC);
-    }
-
-    @Deprecated
-    public VideoStreamingParameters(int displayDensity, int frameRate, int bitrate, int interval,
-                                    ImageResolution resolution, VideoStreamingFormat format) {
-        this.displayDensity = displayDensity;
-        this.frameRate = frameRate;
-        this.bitrate = bitrate;
-        this.interval = interval;
-        this.resolution = resolution;
-        this.format = format;
-        this.stableFrameRate = true;
+        stableFrameRate = true;
     }
 
     /**
@@ -174,6 +163,7 @@ public class VideoStreamingParameters {
             this.bitrate = Math.min(this.bitrate, capability.getMaxBitrate() * 1000);
         } // NOTE: the unit of maxBitrate in getSystemCapability is kbps.
         double scale = DEFAULT_SCALE;
+        // For resolution and scale, the capability values should be taken rather than parameters specified by developers.
         if (capability.getScale() != null) {
             scale = capability.getScale();
         }

--- a/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
+++ b/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
@@ -180,9 +180,8 @@ public class VideoStreamingParameters {
         if (capability.getMaxBitrate() != null) {
             // Taking lower value as per SDL 0323 :
             // https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0323-align-VideoStreamingParameter-with-capability.md
-            if (capability.getMaxBitrate() * 1000 >= 0) {
-                this.bitrate = Math.min(this.bitrate, capability.getMaxBitrate() * 1000);
-            }
+            int capableBitrateInKb = Math.min(Integer.MAX_VALUE / 1000, capability.getMaxBitrate());
+            this.bitrate = Math.min(this.bitrate, capableBitrateInKb * 1000);
         } // NOTE: the unit of maxBitrate in getSystemCapability is kbps.
         double scale = DEFAULT_SCALE;
         // For resolution and scale, the capability values should be taken rather than parameters specified by developers.

--- a/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
+++ b/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
@@ -178,7 +178,9 @@ public class VideoStreamingParameters {
      */
     public void update(VideoStreamingCapability capability, String vehicleMake) {
         if (capability.getMaxBitrate() != null) {
-            this.bitrate = capability.getMaxBitrate() * 1000;
+            // Taking lower value as per SDL 0323 :
+            // https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0323-align-VideoStreamingParameter-with-capability.md
+            this.bitrate = Math.min(this.bitrate, capability.getMaxBitrate() * 1000);
         } // NOTE: the unit of maxBitrate in getSystemCapability is kbps.
         double scale = DEFAULT_SCALE;
         // For resolution and scale, the capability values should be taken rather than parameters specified by developers.
@@ -202,7 +204,8 @@ public class VideoStreamingParameters {
             }
         }
         if (capability.getPreferredFPS() != null) {
-            this.frameRate = capability.getPreferredFPS();
+            // Taking lower value as per SDL 0323
+            this.frameRate = Math.min(this.frameRate, capability.getPreferredFPS());
         }
 
         // This should be the last call as it will return out once a suitable format is found


### PR DESCRIPTION
Fixes #1569 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
This PR does not include additional Unit Tests.

#### Core Tests
Based on SDL 0274 enabled Core and HMI, verified that video streaming works correctly.

Core version / branch / commit hash / module tested against: Core feature/issue-3243 branch; commit #3934b0d8804fc658ccca96f5ce558b9987255f4e.
HMI name / version / branch / commit hash / module tested against: Xevo custom HMI

### Summary
Implement SDL 0323: Align vide streaming parameters with VideoStreamingCapability

### Changelog
##### Breaking Changes
* No breaking changes.

##### Enhancements
* This implements issue #1569.

##### Bug Fixes
* No bug fixes.

### Tasks Remaining:
None

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
