### PR TITLE
Refactor FileManager to use queues 

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
@@ -255,7 +255,7 @@ public class FileManagerTests {
      */
     @Test
     public void testDeleteRemoteFilesWithNamesSuccess() {
-        final ISdl internalInterface = mock(ISdl.class);
+        final ISdl internalInterface = createISdlMock();
 
         doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
         doAnswer(onListDeleteRequestSuccess).when(internalInterface).sendRPCs(any(List.class), any(OnMultipleRequestListener.class));
@@ -287,7 +287,7 @@ public class FileManagerTests {
      */
     @Test
     public void testDeleteRemoteFilesWithNamesFail() {
-        final ISdl internalInterface = mock(ISdl.class);
+        final ISdl internalInterface = createISdlMock();
 
         doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
         doAnswer(onListDeleteRequestFail).when(internalInterface).sendRPCs(any(List.class), any(OnMultipleRequestListener.class));
@@ -319,7 +319,7 @@ public class FileManagerTests {
      */
     @Test
     public void testFileUploadRetry() {
-        final ISdl internalInterface = mock(ISdl.class);
+        final ISdl internalInterface = createISdlMock();
 
         doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
         doAnswer(onPutFileFailureOnError).when(internalInterface).sendRPC(any(PutFile.class));
@@ -351,7 +351,7 @@ public class FileManagerTests {
      */
     @Test
     public void testArtworkUploadRetry() {
-        final ISdl internalInterface = mock(ISdl.class);
+        final ISdl internalInterface = createISdlMock();
 
         doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
         doAnswer(onPutFileFailureOnError).when(internalInterface).sendRPC(any(PutFile.class));
@@ -410,7 +410,7 @@ public class FileManagerTests {
      */
     @Test
     public void testListFilesUploadRetry() {
-        final ISdl internalInterface = mock(ISdl.class);
+        final ISdl internalInterface = createISdlMock();
 
         doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
         doAnswer(onSendRequestsFailOnError).when(internalInterface).sendRPCs(any(List.class), any(OnMultipleRequestListener.class));
@@ -452,7 +452,7 @@ public class FileManagerTests {
      */
     @Test
     public void testInitializationSuccess() {
-        ISdl internalInterface = mock(ISdl.class);
+        ISdl internalInterface = createISdlMock();
 
         doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
 
@@ -515,7 +515,7 @@ public class FileManagerTests {
      */
     @Test
     public void testFileUploadFailure() {
-        ISdl internalInterface = mock(ISdl.class);
+        ISdl internalInterface = createISdlMock();
 
         doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
         doAnswer(onPutFileFailure).when(internalInterface).sendRPC(any(PutFile.class));
@@ -543,7 +543,7 @@ public class FileManagerTests {
      */
     @Test
     public void testFileUploadForStaticIcon() {
-        ISdl internalInterface = mock(ISdl.class);
+        ISdl internalInterface = createISdlMock();
 
         doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
 
@@ -570,7 +570,7 @@ public class FileManagerTests {
      */
     @Test
     public void testMultipleFileUploadsForStaticIcon() {
-        ISdl internalInterface = mock(ISdl.class);
+        ISdl internalInterface = createISdlMock();
 
         doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
         doAnswer(onListFileUploadSuccess).when(internalInterface).sendRPCs(any(List.class), any(OnMultipleRequestListener.class));
@@ -602,7 +602,7 @@ public class FileManagerTests {
      */
     @Test
     public void testMultipleFileUploadsForPartialStaticIcon() {
-        ISdl internalInterface = mock(ISdl.class);
+        ISdl internalInterface = createISdlMock();
 
         doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
         doAnswer(onListFileUploadSuccess).when(internalInterface).sendRPCs(any(List.class), any(OnMultipleRequestListener.class));
@@ -635,7 +635,7 @@ public class FileManagerTests {
      */
     @Test
     public void testInvalidSdlFileInput() {
-        ISdl internalInterface = mock(ISdl.class);
+        ISdl internalInterface = createISdlMock();
 
         doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
 
@@ -721,7 +721,7 @@ public class FileManagerTests {
      */
     @Test
     public void testMultipleFileUpload() {
-        ISdl internalInterface = mock(ISdl.class);
+        ISdl internalInterface = createISdlMock();
 
         doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
         doAnswer(onListFileUploadSuccess).when(internalInterface).sendRPCs(any(List.class), any(OnMultipleRequestListener.class));
@@ -758,7 +758,7 @@ public class FileManagerTests {
      */
     @Test
     public void testMultipleFileUploadPartialFailure() {
-        ISdl internalInterface = mock(ISdl.class);
+        ISdl internalInterface = createISdlMock();
 
         doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
         doAnswer(onSendRequestsFailPartialOnError).when(internalInterface).sendRPCs(any(List.class), any(OnMultipleRequestListener.class));
@@ -807,7 +807,7 @@ public class FileManagerTests {
      */
     @Test
     public void testMultipleArtworkUploadSuccess() {
-        ISdl internalInterface = mock(ISdl.class);
+        ISdl internalInterface = createISdlMock();
 
         doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
         doAnswer(onListFileUploadSuccess).when(internalInterface).sendRPCs(any(List.class), any(OnMultipleRequestListener.class));
@@ -854,7 +854,7 @@ public class FileManagerTests {
      */
     @Test
     public void testPersistentFileUploaded() {
-        ISdl internalInterface = mock(ISdl.class);
+        ISdl internalInterface = createISdlMock();
 
         doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
 
@@ -890,7 +890,7 @@ public class FileManagerTests {
      */
     @Test
     public void testOverwriteFileProperty() {
-        ISdl internalInterface = mock(ISdl.class);
+        ISdl internalInterface = createISdlMock();
 
         doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
         doAnswer(onPutFileSuccess).when(internalInterface).sendRPC(any(PutFile.class));
@@ -927,7 +927,7 @@ public class FileManagerTests {
      */
     @Test
     public void testOverWriteFilePropertyListFiles() {
-        final ISdl internalInterface = mock(ISdl.class);
+        final ISdl internalInterface = createISdlMock();
 
         doAnswer(onListFilesSuccess).when(internalInterface).sendRPC(any(ListFiles.class));
         doAnswer(onListFileUploadSuccess).when(internalInterface).sendRPCs(any(List.class), any(OnMultipleRequestListener.class));

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lifecycle/SystemCapabilityManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lifecycle/SystemCapabilityManagerTests.java
@@ -1038,6 +1038,11 @@ public class SystemCapabilityManagerTests {
         }
 
         @Override
+        public long getMtu(SessionType serviceType) {
+            return 0;
+        }
+
+        @Override
         public boolean isTransportForServiceAvailable(SessionType serviceType) {
             return false;
         }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/FileManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/FileManager.java
@@ -33,6 +33,7 @@
 package com.smartdevicelink.managers.file;
 
 import android.content.Context;
+import android.content.res.Resources;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.RestrictTo;
@@ -79,7 +80,11 @@ public class FileManager extends BaseFileManager {
         }
 
         if (file.getResourceId() > 0) {
-            inputStream = context.get().getResources().openRawResource(file.getResourceId());
+            try {
+                inputStream = context.get().getResources().openRawResource(file.getResourceId());
+            } catch (Resources.NotFoundException e) {
+                DebugTool.logError(TAG, "File cannot be found.");
+            }
         } else if (file.getUri() != null) {
             try {
                 inputStream = context.get().getContentResolver().openInputStream(file.getUri());
@@ -89,7 +94,7 @@ public class FileManager extends BaseFileManager {
         } else if (file.getFileData() != null) {
             inputStream = new ByteArrayInputStream(file.getFileData());
         } else {
-            throw new IllegalArgumentException("The SdlFile to upload does not specify its resourceId, Uri, or file data");
+            DebugTool.logError(TAG, "The SdlFile to upload does not specify its resourceId, Uri, or file data");
         }
 
         return inputStream;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/FileManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/FileManager.java
@@ -39,6 +39,7 @@ import androidx.annotation.RestrictTo;
 
 import com.smartdevicelink.managers.ISdl;
 import com.smartdevicelink.managers.file.filetypes.SdlFile;
+import com.smartdevicelink.util.DebugTool;
 
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
@@ -50,15 +51,7 @@ import java.lang.ref.WeakReference;
  * <p>
  * Note: This class must be accessed through the SdlManager. Do not instantiate it by itself. <br>
  * <p>
- * The SDLFileManager uploads files and keeps track of all the uploaded files names during a session. <br>
- * <p>
- * We need to add the following struct: SDLFile<br>
- * <p>
- * It is broken down to these areas: <br>
- * <p>
- * 1. Getters <br>
- * 2. Deletion methods <br>
- * 3. Uploading Files / Artwork
+ * The FileManager uploads files and keeps track of all the uploaded files names during a session. <br>
  */
 public class FileManager extends BaseFileManager {
 
@@ -82,19 +75,23 @@ public class FileManager extends BaseFileManager {
     InputStream openInputStreamWithFile(@NonNull SdlFile file) {
         InputStream inputStream = null;
 
+        if (context.get() == null) {
+            DebugTool.logError(TAG, "Context is null. Cannot open file input stream!");
+            return null;
+        }
+
         if (file.getResourceId() > 0) {
             inputStream = context.get().getResources().openRawResource(file.getResourceId());
         } else if (file.getUri() != null) {
             try {
                 inputStream = context.get().getContentResolver().openInputStream(file.getUri());
             } catch (FileNotFoundException e) {
-                e.printStackTrace();
+                DebugTool.logError(TAG, String.format("File at %s cannot be found.", file.getUri()));
             }
         } else if (file.getFileData() != null) {
             inputStream = new ByteArrayInputStream(file.getFileData());
         } else {
-            throw new IllegalArgumentException("The SdlFile to upload does " +
-                    "not specify its resourceId, Uri, or file data");
+            throw new IllegalArgumentException("The SdlFile to upload does not specify its resourceId, Uri, or file data");
         }
 
         return inputStream;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/FileManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/FileManager.java
@@ -48,9 +48,7 @@ import java.lang.ref.WeakReference;
 
 /**
  * <strong>FileManager</strong> <br>
- * <p>
  * Note: This class must be accessed through the SdlManager. Do not instantiate it by itself. <br>
- * <p>
  * The FileManager uploads files and keeps track of all the uploaded files names during a session. <br>
  */
 public class FileManager extends BaseFileManager {

--- a/base/src/main/java/com/smartdevicelink/managers/ISdl.java
+++ b/base/src/main/java/com/smartdevicelink/managers/ISdl.java
@@ -213,6 +213,13 @@ public interface ISdl {
     Version getProtocolVersion();
 
     /**
+     * Get the max payload size for a packet to be sent to the module
+     *
+     * @return the max transfer unit
+     */
+    long getMtu(SessionType serviceType);
+
+    /**
      * Start encrypted RPC service
      */
     void startRPCEncryption();

--- a/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
@@ -378,6 +378,13 @@ abstract class BaseFileManager extends BaseSubManager {
             return;
         }
 
+        if (file.getName() == null) {
+            if (listener != null) {
+                listener.onComplete(false, bytesAvailable, null, "You must specify an file name in the SdlFile.");
+            }
+            return;
+        }
+
         if (file.isStaticIcon()) {
             if (listener != null) {
                 listener.onComplete(false, bytesAvailable, null, "The file upload was canceled. The file is a static icon, which cannot be uploaded.");

--- a/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
@@ -500,7 +500,7 @@ abstract class BaseFileManager extends BaseSubManager {
     /**
      * Increments the number of upload attempts for a file name by 1.
      *
-     * @param name The name used to upload the file to Core
+     * @param name                   The name used to upload the file to Core
      * @param failedFileUploadsCount
      * @return
      */

--- a/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
@@ -359,6 +359,10 @@ abstract class BaseFileManager extends BaseSubManager {
         uploadFilePrivate(file, new FileManagerCompletionListener() {
             @Override
             public void onComplete(boolean success, int bytesAvailable, Collection<String> fileNames, String errorMessage) {
+                if (!success && errorMessage != null) {
+                    DebugTool.logWarning(TAG, errorMessage);
+                }
+
                 if (listener != null) {
                     listener.onComplete(success);
                 }

--- a/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
@@ -63,7 +63,7 @@ abstract class BaseFileManager extends BaseSubManager {
     final static String TAG = "FileManager";
     final static int SPACE_AVAILABLE_MAX_VALUE = 2000000000;
 
-    private final Set<String> mutableRemoteFileNames;
+    final Set<String> mutableRemoteFileNames;
     private final Set<String> uploadedEphemeralFileNames;
     private int bytesAvailable;
     private Queue transactionQueue;

--- a/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/BaseFileManager.java
@@ -57,18 +57,8 @@ import java.util.Set;
 
 /**
  * <strong>FileManager</strong> <br>
- * <p>
  * Note: This class must be accessed through the SdlManager. Do not instantiate it by itself. <br>
- * <p>
- * The SDLFileManager uploads files and keeps track of all the uploaded files names during a session. <br>
- * <p>
- * We need to add the following struct: SDLFile<br>
- * <p>
- * It is broken down to these areas: <br>
- * <p>
- * 1. Getters <br>
- * 2. Deletion methods <br>
- * 3. Uploading Files / Artwork
+ * The FileManager uploads files and keeps track of all the uploaded files names during a session. <br>
  */
 abstract class BaseFileManager extends BaseSubManager {
 

--- a/base/src/main/java/com/smartdevicelink/managers/file/DeleteFileOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/DeleteFileOperation.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2020 Livio, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Livio Inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.smartdevicelink.managers.file;
+
+import com.livio.taskmaster.Task;
+import com.smartdevicelink.managers.ISdl;
+import com.smartdevicelink.proxy.RPCResponse;
+import com.smartdevicelink.proxy.rpc.DeleteFile;
+import com.smartdevicelink.proxy.rpc.DeleteFileResponse;
+import com.smartdevicelink.proxy.rpc.listeners.OnRPCResponseListener;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * Created by Bilal Alsharifi on 12/1/20.
+ */
+class DeleteFileOperation extends Task {
+    private static final String TAG = "FileManager.DeleteFileOperation";
+    private final WeakReference<ISdl> internalInterface;
+    private String fileName;
+    private FileManagerCompletionListener completionListener;
+
+    DeleteFileOperation(ISdl internalInterface, String fileName, FileManagerCompletionListener completionListener) {
+        super("DeleteFileOperation");
+        this.internalInterface = new WeakReference<>(internalInterface);
+        this.fileName = fileName;
+        this.completionListener = completionListener;
+    }
+
+    @Override
+    public void onExecute() {
+        start();
+    }
+
+    private void start() {
+        if (getState() == Task.CANCELED) {
+            return;
+        }
+
+        deleteFile();
+    }
+
+    private void deleteFile() {
+        DeleteFile deleteFile = new DeleteFile(fileName);
+        deleteFile.setOnRPCResponseListener(new OnRPCResponseListener() {
+            @Override
+            public void onResponse(int correlationId, RPCResponse response) {
+                DeleteFileResponse deleteFileResponse = (DeleteFileResponse) response;
+                boolean success = deleteFileResponse.getSuccess();
+
+                // If spaceAvailable is null, set it to the max value
+                int bytesAvailable = deleteFileResponse.getSpaceAvailable() != null ? deleteFileResponse.getSpaceAvailable() : BaseFileManager.SPACE_AVAILABLE_MAX_VALUE;
+
+                if (completionListener != null) {
+                    String errorMessage = response.getInfo() + ": " + response.getResultCode();
+                    completionListener.onComplete(success, bytesAvailable, null, errorMessage);
+                }
+
+                onFinished();
+            }
+        });
+
+        if (internalInterface.get() != null) {
+            internalInterface.get().sendRPC(deleteFile);
+        }
+    }
+
+    @Override
+    public String getName() {
+        return super.getName() + " - " + fileName;
+    }
+}
+

--- a/base/src/main/java/com/smartdevicelink/managers/file/DeleteFileOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/DeleteFileOperation.java
@@ -82,7 +82,7 @@ class DeleteFileOperation extends Task {
                 int bytesAvailable = deleteFileResponse.getSpaceAvailable() != null ? deleteFileResponse.getSpaceAvailable() : BaseFileManager.SPACE_AVAILABLE_MAX_VALUE;
 
                 if (completionListener != null) {
-                    String errorMessage = response.getInfo() + ": " + response.getResultCode();
+                    String errorMessage = success ? null : response.getInfo() + ": " + response.getResultCode();
                     completionListener.onComplete(success, bytesAvailable, null, errorMessage);
                 }
 

--- a/base/src/main/java/com/smartdevicelink/managers/file/DeleteFileOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/DeleteFileOperation.java
@@ -45,7 +45,7 @@ import java.lang.ref.WeakReference;
  * Created by Bilal Alsharifi on 12/1/20.
  */
 class DeleteFileOperation extends Task {
-    private static final String TAG = "FileManager.DeleteFileOperation";
+    private static final String TAG = "DeleteFileOperation";
     private final WeakReference<ISdl> internalInterface;
     private String fileName;
     private FileManagerCompletionListener completionListener;

--- a/base/src/main/java/com/smartdevicelink/managers/file/DispatchGroup.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/DispatchGroup.java
@@ -1,3 +1,35 @@
+/*
+ * Copyright (c) 2020 Livio, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Livio Inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package com.smartdevicelink.managers.file;
 
 /**

--- a/base/src/main/java/com/smartdevicelink/managers/file/DispatchGroup.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/DispatchGroup.java
@@ -1,0 +1,33 @@
+package com.smartdevicelink.managers.file;
+
+/**
+ * Created by Bilal Alsharifi on 12/2/20.
+ */
+class DispatchGroup {
+    private int count;
+    private Runnable runnable;
+
+    DispatchGroup() {
+        count = 0;
+    }
+
+    synchronized void enter() {
+        count++;
+    }
+
+    synchronized void leave() {
+        count--;
+        run();
+    }
+
+    void notify(Runnable runnable) {
+        this.runnable = runnable;
+        run();
+    }
+
+    private void run() {
+        if (count <= 0 && runnable != null) {
+            runnable.run();
+        }
+    }
+}

--- a/base/src/main/java/com/smartdevicelink/managers/file/FileManagerCompletionListener.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/FileManagerCompletionListener.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020 Livio, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Livio Inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.smartdevicelink.managers.file;
+
+import java.util.Collection;
+
+/**
+ * Created by Bilal Alsharifi on 12/1/20.
+ */
+interface FileManagerCompletionListener {
+    void onComplete(boolean success, int bytesAvailable, Collection<String> fileNames, String errorMessage);
+}

--- a/base/src/main/java/com/smartdevicelink/managers/file/ListFilesOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/ListFilesOperation.java
@@ -90,12 +90,8 @@ class ListFilesOperation extends Task {
                 int bytesAvailable = listFilesResponse.getSpaceAvailable() != null ? listFilesResponse.getSpaceAvailable() : BaseFileManager.SPACE_AVAILABLE_MAX_VALUE;
 
                 if (completionListener != null) {
-                    if (!success) {
-                        String errorMessage = response.getInfo() + ": " + response.getResultCode();
-                        completionListener.onComplete(success, bytesAvailable, fileNames, errorMessage);
-                    } else {
-                        completionListener.onComplete(success, bytesAvailable, fileNames, null);
-                    }
+                    String errorMessage = success ? null : response.getInfo() + ": " + response.getResultCode();
+                    completionListener.onComplete(success, bytesAvailable, fileNames, errorMessage);
                 }
 
                 onFinished();

--- a/base/src/main/java/com/smartdevicelink/managers/file/ListFilesOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/ListFilesOperation.java
@@ -48,7 +48,7 @@ import java.util.UUID;
  * Created by Bilal Alsharifi on 12/1/20.
  */
 class ListFilesOperation extends Task {
-    private static final String TAG = "FileManager.ListFilesOperation";
+    private static final String TAG = "ListFilesOperation";
     private UUID operationId;
     private final WeakReference<ISdl> internalInterface;
     private FileManagerCompletionListener completionListener;

--- a/base/src/main/java/com/smartdevicelink/managers/file/ListFilesOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/ListFilesOperation.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2020 Livio, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Livio Inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.smartdevicelink.managers.file;
+
+import com.livio.taskmaster.Task;
+import com.smartdevicelink.managers.ISdl;
+import com.smartdevicelink.proxy.RPCResponse;
+import com.smartdevicelink.proxy.rpc.ListFiles;
+import com.smartdevicelink.proxy.rpc.ListFilesResponse;
+import com.smartdevicelink.proxy.rpc.listeners.OnRPCResponseListener;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Created by Bilal Alsharifi on 12/1/20.
+ */
+class ListFilesOperation extends Task {
+    private static final String TAG = "FileManager.ListFilesOperation";
+    private UUID operationId;
+    private final WeakReference<ISdl> internalInterface;
+    private FileManagerCompletionListener completionListener;
+
+    ListFilesOperation(ISdl internalInterface, FileManagerCompletionListener completionListener) {
+        super("ListFilesOperation");
+        this.operationId = UUID.randomUUID();
+        this.internalInterface = new WeakReference<>(internalInterface);
+        this.completionListener = completionListener;
+    }
+
+    @Override
+    public void onExecute() {
+        start();
+    }
+
+    private void start() {
+        if (getState() == Task.CANCELED) {
+            return;
+        }
+
+        listFiles();
+    }
+
+    private void listFiles() {
+        ListFiles listFiles = new ListFiles();
+        listFiles.setOnRPCResponseListener(new OnRPCResponseListener() {
+            @Override
+            public void onResponse(int correlationId, RPCResponse response) {
+                ListFilesResponse listFilesResponse = (ListFilesResponse) response;
+                boolean success = listFilesResponse.getSuccess();
+
+                List<String> fileNames = new ArrayList<>();
+                if (listFilesResponse.getFilenames() != null) {
+                    fileNames.addAll(listFilesResponse.getFilenames());
+                }
+
+                // If spaceAvailable is null, set it to the max value
+                int bytesAvailable = listFilesResponse.getSpaceAvailable() != null ? listFilesResponse.getSpaceAvailable() : BaseFileManager.SPACE_AVAILABLE_MAX_VALUE;
+
+                if (completionListener != null) {
+                    if (!success) {
+                        String errorMessage = response.getInfo() + ": " + response.getResultCode();
+                        completionListener.onComplete(success, bytesAvailable, fileNames, errorMessage);
+                    } else {
+                        completionListener.onComplete(success, bytesAvailable, fileNames, null);
+                    }
+                }
+
+                onFinished();
+            }
+        });
+
+        if (internalInterface.get() != null) {
+            internalInterface.get().sendRPC(listFiles);
+        }
+    }
+
+    @Override
+    public String getName() {
+        return super.getName() + " - " + operationId;
+    }
+}
+

--- a/base/src/main/java/com/smartdevicelink/managers/file/SdlFileWrapper.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/SdlFileWrapper.java
@@ -46,11 +46,11 @@ class SdlFileWrapper {
         this.completionListener = completionListener;
     }
 
-    public SdlFile getFile() {
+    SdlFile getFile() {
         return file;
     }
 
-    public FileManagerCompletionListener getCompletionListener() {
+    FileManagerCompletionListener getCompletionListener() {
         return completionListener;
     }
 }

--- a/base/src/main/java/com/smartdevicelink/managers/file/SdlFileWrapper.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/SdlFileWrapper.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020 Livio, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Livio Inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.smartdevicelink.managers.file;
+
+import com.smartdevicelink.managers.file.filetypes.SdlFile;
+
+/**
+ * Created by Bilal Alsharifi on 12/1/20.
+ */
+class SdlFileWrapper {
+    private final SdlFile file;
+    private final FileManagerCompletionListener completionListener;
+
+    SdlFileWrapper(SdlFile file, FileManagerCompletionListener completionListener) {
+        this.file = file;
+        this.completionListener = completionListener;
+    }
+
+    public SdlFile getFile() {
+        return file;
+    }
+
+    public FileManagerCompletionListener getCompletionListener() {
+        return completionListener;
+    }
+}

--- a/base/src/main/java/com/smartdevicelink/managers/file/UploadFileOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/UploadFileOperation.java
@@ -49,7 +49,7 @@ import java.lang.ref.WeakReference;
  * Created by Bilal Alsharifi on 12/1/20.
  */
 class UploadFileOperation extends Task {
-    private static final String TAG = "FileManager.UploadFileOperation";
+    private static final String TAG = "UploadFileOperation";
     private final WeakReference<ISdl> internalInterface;
     private final WeakReference<BaseFileManager> fileManager;
     private SdlFileWrapper fileWrapper;

--- a/base/src/main/java/com/smartdevicelink/managers/file/UploadFileOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/UploadFileOperation.java
@@ -187,7 +187,7 @@ class UploadFileOperation extends Task {
                     if (newHighestCorrelationID(correlationId, highestCorrelationIDReceived)) {
                         highestCorrelationIDReceived = correlationId;
 
-                        // If spaceAvailable is nil, set it to the max value
+                        // If spaceAvailable is null, set it to the max value
                         bytesAvailable = putFileResponse.getSpaceAvailable() != null ? putFileResponse.getSpaceAvailable() : BaseFileManager.SPACE_AVAILABLE_MAX_VALUE;
                     }
 

--- a/base/src/main/java/com/smartdevicelink/managers/file/UploadFileOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/UploadFileOperation.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2020 Livio, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Livio Inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.smartdevicelink.managers.file;
+
+import com.livio.taskmaster.Task;
+import com.smartdevicelink.managers.ISdl;
+import com.smartdevicelink.managers.file.filetypes.SdlFile;
+import com.smartdevicelink.protocol.enums.SessionType;
+import com.smartdevicelink.proxy.RPCResponse;
+import com.smartdevicelink.proxy.rpc.PutFile;
+import com.smartdevicelink.proxy.rpc.PutFileResponse;
+import com.smartdevicelink.proxy.rpc.listeners.OnRPCResponseListener;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.ref.WeakReference;
+
+/**
+ * Created by Bilal Alsharifi on 12/1/20.
+ */
+class UploadFileOperation extends Task {
+    private static final String TAG = "FileManager.UploadFileOperation";
+    private final WeakReference<ISdl> internalInterface;
+    private final WeakReference<BaseFileManager> fileManager;
+    private SdlFileWrapper fileWrapper;
+    private InputStream inputStream;
+    private int fileSize;
+    private boolean executing;
+    private boolean finished;
+    private String streamError;
+    int bytesAvailable;
+    int highestCorrelationIDReceived;
+
+    UploadFileOperation(ISdl internalInterface, BaseFileManager fileManager, SdlFileWrapper file) {
+        super("UploadFileOperation");
+
+        executing = false;
+        finished = false;
+
+        this.internalInterface = new WeakReference<>(internalInterface);
+        this.fileManager = new WeakReference<>(fileManager);
+        this.fileWrapper = file;
+    }
+
+    @Override
+    public void onExecute() {
+        start();
+    }
+
+    private void start() {
+        if (getState() == Task.CANCELED) {
+            return;
+        }
+
+        int mtuSize = 0;
+        if (internalInterface.get() != null) {
+            mtuSize = (int) internalInterface.get().getMtu(SessionType.RPC);
+        }
+        sendFile(this.fileWrapper.getFile(), mtuSize, this.fileWrapper.getCompletionListener());
+    }
+
+    /**
+     * Sends data asynchronously to the SDL Core by breaking the data into smaller packets, each of which is
+     * sent via a PutFile. To prevent large files from eating up memory, the data packet is deleted once it
+     * is sent via a PutFile. If the SDL Core receives all the PutFile successfully, a success response with
+     * the amount of free storage space left on the SDL Core is returned. Otherwise the error returned by
+     * the SDL Core is passed along.
+     *
+     * @param file               The file containing the data to be sent to the SDL Core
+     * @param mtuSize            The maximum packet size allowed
+     * @param completionListener listener returning whether or not the upload was a success
+     */
+    private void sendFile(SdlFile file, int mtuSize, final FileManagerCompletionListener completionListener) {
+        streamError = null;
+        bytesAvailable = BaseFileManager.SPACE_AVAILABLE_MAX_VALUE;
+        highestCorrelationIDReceived = -1;
+
+        if (getState() == Task.CANCELED) {
+            String errorMessage = "The file upload transaction was canceled before it could be completed";
+            completionListener.onComplete(false, bytesAvailable, null, errorMessage);
+            onFinished();
+            return;
+        }
+
+        if (file == null) {
+            String errorMessage = "The file manager was unable to send the file. This could be because the file does not exist at the specified file path or that passed data is invalid";
+            completionListener.onComplete(false, bytesAvailable, null, errorMessage);
+            onFinished();
+            return;
+        }
+
+        if (fileManager.get() != null) {
+            this.inputStream = fileManager.get().openInputStreamWithFile(file);
+            this.fileSize = getFileSizeFromInputStream(inputStream);
+        }
+
+        if (inputStream == null || fileSize == 0) {
+            // If the file does not exist or the passed data is null, return an error
+            closeInputStream();
+
+            String errorMessage = "The file manager was unable to send the file. This could be because the file does not exist at the specified file path or that passed data is invalid";
+            completionListener.onComplete(false, bytesAvailable, null, errorMessage);
+            onFinished();
+            return;
+        }
+
+        final DispatchGroup putFileGroup = new DispatchGroup();
+        putFileGroup.enter();
+
+        // Wait for all packets be sent before returning whether or not the upload was a success
+        putFileGroup.notify(new Runnable() {
+            @Override
+            public void run() {
+                closeInputStream();
+
+                if (streamError != null || getState() == Task.CANCELED) {
+                    completionListener.onComplete(false, bytesAvailable, null, streamError);
+                } else {
+                    completionListener.onComplete(true, bytesAvailable, null, null);
+                }
+
+                onFinished();
+            }
+        });
+
+        // Break the data into small pieces, each of which will be sent in a separate PutFile
+        int currentOffset = 0;
+        int numberOfPieces = ((fileSize - 1) / mtuSize) + 1;
+        for (int i = 0; i < numberOfPieces; i++) {
+            putFileGroup.enter();
+
+            // Get a chunk of data from the input stream
+            int putFileLength = getPutFileLengthForOffset(currentOffset, fileSize, mtuSize);
+            int putFileBulkDataSize = getDataSizeForOffset(currentOffset, fileSize, mtuSize);
+            byte[] putFileBulkData = getDataChunkWithSize(putFileBulkDataSize, this.inputStream);
+
+            final PutFile putFile = new PutFile(file.getName(), file.getType())
+                    .setPersistentFile(file.isPersistent())
+                    .setSystemFile(false)
+                    .setOffset(currentOffset)
+                    .setLength(putFileLength);
+            putFile.setBulkData(putFileBulkData);
+            putFile.setOnRPCResponseListener(new OnRPCResponseListener() {
+                @Override
+                public void onResponse(int correlationId, RPCResponse response) {
+                    PutFileResponse putFileResponse = (PutFileResponse) response;
+
+                    // Check if the upload process has been cancelled by another packet. If so, stop the upload process.
+
+                    if (getState() == Task.CANCELED) {
+                        putFileGroup.leave();
+                        return;
+                    }
+
+                    // If the SDL Core returned an error, cancel the upload the process in the future
+                    if (!response.getSuccess() || getState() == Task.CANCELED) {
+                        cancelTask();
+                        streamError = response.getInfo() + ": " + response.getResultCode();
+                        putFileGroup.leave();
+                        return;
+                    }
+
+                    // If no errors, watch for a response containing the amount of storage left on the SDL Core
+                    if (newHighestCorrelationID(correlationId, highestCorrelationIDReceived)) {
+                        highestCorrelationIDReceived = correlationId;
+
+                        // If spaceAvailable is nil, set it to the max value
+                        bytesAvailable = putFileResponse.getSpaceAvailable() != null ? putFileResponse.getSpaceAvailable() : BaseFileManager.SPACE_AVAILABLE_MAX_VALUE;
+                    }
+
+                    putFileGroup.leave();
+                }
+            });
+
+            currentOffset += putFileBulkDataSize;
+
+            if (internalInterface.get() != null) {
+                internalInterface.get().sendRPC(putFile);
+            }
+        }
+
+        putFileGroup.leave();
+    }
+
+    /**
+     * Close the input stream once all the data has been read
+     */
+    private void closeInputStream() {
+        if (this.inputStream == null) {
+            return;
+        }
+        try {
+            this.inputStream.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Returns the length of the data being sent in the PutFile. The first PutFile's length is unique in
+     * that it sends the full size of the data. For the rest of the PutFiles, the length parameter is equal
+     * to the size of the chunk of data being sent in the PutFile.
+     *
+     * @param currentOffset The current position in the file
+     * @param fileSize      The size of the file
+     * @param mtuSize       The maximum packet size allowed
+     * @return The length of the data being sent in the PutFile
+     */
+    private int getPutFileLengthForOffset(int currentOffset, int fileSize, int mtuSize) {
+        int putFileLength = 0;
+        if (currentOffset == 0) {
+            // The first PutFile sends the full file size
+            putFileLength = fileSize;
+        } else if ((fileSize - currentOffset) < mtuSize) {
+            // The last PutFile sends the size of the remaining data
+            putFileLength = fileSize - currentOffset;
+        } else {
+            // All other PutFiles send the maximum allowed packet size
+            putFileLength = mtuSize;
+        }
+        return putFileLength;
+    }
+
+    /**
+     * Gets the size of the data to be sent in a packet. Packet size can not be greater than the max
+     * MTU size allowed by the SDL Core.
+     *
+     * @param currentOffset The position in the file where to start reading data
+     * @param fileSize      he size of the file
+     * @param mtuSize       The maximum packet size allowed
+     * @return The size of the data to be sent in the packet.
+     */
+    private int getDataSizeForOffset(int currentOffset, int fileSize, int mtuSize) {
+        int dataSize = 0;
+        int fileSizeRemaining = fileSize - currentOffset;
+        if (fileSizeRemaining < mtuSize) {
+            dataSize = fileSizeRemaining;
+        } else {
+            dataSize = mtuSize;
+        }
+        return dataSize;
+    }
+
+    /**
+     * Reads a chunk of data from a socket.
+     *
+     * @param size        The amount of data to read from the input stream
+     * @param inputStream The socket from which to read the data
+     * @return The data read from the socket
+     */
+    private byte[] getDataChunkWithSize(int size, InputStream inputStream) {
+        if (size < 0) {
+            return null;
+        }
+
+        int bytesRead = 0;
+        byte[] buffer = new byte[size];
+        try {
+            bytesRead = inputStream.read(buffer, 0, size);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        if (bytesRead > 0) {
+            return buffer;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * One of the responses returned by the SDL Core will contain the correct remaining free storage
+     * size on the SDL Core. Since communication with the SDL Core is asynchronous, there is no way
+     * to predict which response contains the correct bytes available other than to watch for the
+     * largest correlation id, since that will be the last response sent by the SDL Core.
+     *
+     * @param correlationID                The correlationID for the newest response returned by the SDL Core for a PutFile
+     * @param highestCorrelationIDReceived The largest currently received correlation id
+     * @return Whether or not the newest request contains the highest correlationId
+     */
+    private boolean newHighestCorrelationID(int correlationID, int highestCorrelationIDReceived) {
+        if (correlationID > highestCorrelationIDReceived) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Gets the size of the data.
+     *
+     * @return The size of the data.
+     */
+    private int getFileSizeFromInputStream(InputStream inputStream) {
+        int size = 0;
+        if (inputStream != null) {
+            try {
+                size = inputStream.available();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        return size;
+    }
+
+    @Override
+    public String getName() {
+        return super.getName() + " - " + fileWrapper.getFile().getName();
+    }
+}
+

--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
@@ -1042,6 +1042,11 @@ abstract class BaseLifecycleManager {
         }
 
         @Override
+        public long getMtu(SessionType serviceType) {
+            return BaseLifecycleManager.this.session.getMtu(serviceType);
+        }
+
+        @Override
         public void startRPCEncryption() {
             BaseLifecycleManager.this.startRPCEncryption();
         }

--- a/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/file/FileManager.java
+++ b/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/file/FileManager.java
@@ -83,7 +83,7 @@ public class FileManager extends BaseFileManager {
         } else if (file.getFileData() != null) {
             inputStream = new ByteArrayInputStream(file.getFileData());
         } else {
-            throw new IllegalArgumentException("The SdlFile to upload does not specify its path, URI, or file data");
+            DebugTool.logError(TAG, "The SdlFile to upload does not specify its path, URI, or file data");
         }
 
         return inputStream;

--- a/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/file/FileManager.java
+++ b/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/file/FileManager.java
@@ -50,15 +50,7 @@ import java.nio.file.Files;
  * <p>
  * Note: This class must be accessed through the SdlManager. Do not instantiate it by itself. <br>
  * <p>
- * The SDLFileManager uploads files and keeps track of all the uploaded files names during a session. <br>
- * <p>
- * We need to add the following struct: SDLFile<br>
- * <p>
- * It is broken down to these areas: <br>
- * <p>
- * 1. Getters <br>
- * 2. Deletion methods <br>
- * 3. Uploading Files / Artwork
+ * The FileManager uploads files and keeps track of all the uploaded files names during a session. <br>
  */
 public class FileManager extends BaseFileManager {
 
@@ -82,19 +74,18 @@ public class FileManager extends BaseFileManager {
             try {
                 inputStream = new FileInputStream(file.getFilePath());
             } catch (FileNotFoundException e) {
-                e.printStackTrace();
+                DebugTool.logError(TAG, String.format("File at %s cannot be found.", file.getFilePath()));
             }
         } else if (file.getURI() != null) {
             try {
                 inputStream = file.getURI().toURL().openStream();
             } catch (IOException e) {
-                e.printStackTrace();
+                DebugTool.logError(TAG, String.format("File at %s cannot be found.", file.getURI()));
             }
         } else if (file.getFileData() != null) {
             inputStream = new ByteArrayInputStream(file.getFileData());
         } else {
-            throw new IllegalArgumentException("The SdlFile to upload does " +
-                    "not specify its resourceId, Uri, or file data");
+            throw new IllegalArgumentException("The SdlFile to upload does not specify its path, URI, or file data");
         }
 
         return inputStream;

--- a/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/file/FileManager.java
+++ b/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/file/FileManager.java
@@ -34,16 +34,11 @@ package com.smartdevicelink.managers.file;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.RestrictTo;
-
 import com.smartdevicelink.managers.ISdl;
 import com.smartdevicelink.managers.file.filetypes.SdlFile;
-import com.smartdevicelink.proxy.rpc.PutFile;
 import com.smartdevicelink.util.DebugTool;
-import com.smartdevicelink.util.FileUtls;
 
 import java.io.*;
-import java.net.URI;
-import java.nio.file.Files;
 
 /**
  * <strong>FileManager</strong> <br>

--- a/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/file/FileManager.java
+++ b/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/file/FileManager.java
@@ -41,9 +41,9 @@ import com.smartdevicelink.proxy.rpc.PutFile;
 import com.smartdevicelink.util.DebugTool;
 import com.smartdevicelink.util.FileUtls;
 
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.URI;
+import java.nio.file.Files;
 
 /**
  * <strong>FileManager</strong> <br>
@@ -74,76 +74,29 @@ public class FileManager extends BaseFileManager {
         super(internalInterface, fileManagerConfig);
     }
 
-    /**
-     * Creates and returns a PutFile request that would upload a given SdlFile
-     *
-     * @param file SdlFile with fileName and one of A) fileData, B) Uri, or C) resourceID set
-     * @return a valid PutFile request if SdlFile contained a fileName and sufficient data
-     */
     @Override
-    PutFile createPutFile(@NonNull final SdlFile file) {
-        PutFile putFile = new PutFile();
-        if (file.getName() == null) {
-            throw new IllegalArgumentException("You must specify an file name in the SdlFile");
-        } else {
-            putFile.setSdlFileName(file.getName());
-        }
+    InputStream openInputStreamWithFile(@NonNull SdlFile file) {
+        InputStream inputStream = null;
 
         if (file.getFilePath() != null) {
-            //Attempt to access the file via a path
-            byte[] data = FileUtls.getFileData(file.getFilePath());
-            if (data != null) {
-                putFile.setFileData(data);
-            } else {
-                throw new IllegalArgumentException("File at path was empty");
+            try {
+                inputStream = new FileInputStream(file.getFilePath());
+            } catch (FileNotFoundException e) {
+                e.printStackTrace();
             }
         } else if (file.getURI() != null) {
-            // Use URI to upload file
-            byte[] data = contentsOfUri(file.getURI());
-            if (data != null) {
-                putFile.setFileData(data);
-            } else {
-                throw new IllegalArgumentException("Uri was empty");
+            try {
+                inputStream = file.getURI().toURL().openStream();
+            } catch (IOException e) {
+                e.printStackTrace();
             }
         } else if (file.getFileData() != null) {
-            // Use file data (raw bytes) to upload file
-            putFile.setFileData(file.getFileData());
+            inputStream = new ByteArrayInputStream(file.getFileData());
         } else {
             throw new IllegalArgumentException("The SdlFile to upload does " +
                     "not specify its resourceId, Uri, or file data");
         }
 
-        if (file.getType() != null) {
-            putFile.setFileType(file.getType());
-        }
-        putFile.setPersistentFile(file.isPersistent());
-
-        return putFile;
-    }
-
-
-    /**
-     * Helper method to take Uri and turn it into byte array
-     *
-     * @param uri Uri for desired file
-     * @return Resulting byte array
-     */
-    private byte[] contentsOfUri(URI uri) {
-        InputStream is = null;
-        try {
-            is = uri.toURL().openStream();
-            return contentsOfInputStream(is);
-        } catch (IOException e) {
-            DebugTool.logError(TAG, "Can't read from URI", e);
-            return null;
-        } finally {
-            if (is != null) {
-                try {
-                    is.close();
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-        }
+        return inputStream;
     }
 }

--- a/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/file/FileManager.java
+++ b/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/file/FileManager.java
@@ -47,9 +47,7 @@ import java.nio.file.Files;
 
 /**
  * <strong>FileManager</strong> <br>
- * <p>
  * Note: This class must be accessed through the SdlManager. Do not instantiate it by itself. <br>
- * <p>
  * The FileManager uploads files and keeps track of all the uploaded files names during a session. <br>
  */
 public class FileManager extends BaseFileManager {


### PR DESCRIPTION
Fixes #1572  & #1580 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, and Java SE

#### Unit Tests
Unit tests have been updated to test the new `FileManager`

#### Core Tests
- [x] Test uploading a file using _all_ variations for `SdlFile` constructors
- [x] Test uploading a file, then confirm that `RemoteFileNames` and `BytesAvailable` are updated correctly 
- [x] Test uploading a persistent file that make sure it stays between ignition cycles 
- [x] Test uploading a file that exists and has `override = false`
- [x] Test uploading a file that exists and has `override = true`
- [x]  Test uploading a file when HMI level is `NONE`
- [x] Test uploading a static icon file
- [x] Test uploading an artwork 
- [x] Test uploading multiple files
- [x] Test uploading multiple artworks
- [x] Test uploading file bigger than MTU size (more than 131072 bytes)
- [x] Test deleting a file
- [x] Test deleting multiple files
- [x] Test `hasUploadedFile()`
- [x] Test fileRetryCount & artworkRetryCount
- [x] Test `ScreenManager` basic features and confirm they still work
- [x] Test with javaSE

Core version tested against : 7.0.0

### Summary
This PR refactors `FilesManager` to:
- Split the code into multiple operations and run the operations using transaction queues
- Update sending big files logic to split the data into multiple RPCs if the data size exceeds the MTU site 
 
### Tasks Remaining:
- [x] Refactor `FileManager`
- [x] Smoke tests all changes
- [x] Update unit tests

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
