### PR TITLE
SDL-0305 Homogenize TextFieldName

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lifecycle/SystemCapabilityManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lifecycle/SystemCapabilityManagerTests.java
@@ -204,7 +204,7 @@ public class SystemCapabilityManagerTests {
     @Test
     public void testNullDisplayCapabilitiesEnablesAllTextAndImageFields() {
         List<DisplayCapability> displayCapabilityList = createDisplayCapabilityList(null, TestValues.GENERAL_BUTTONCAPABILITIES_LIST, TestValues.GENERAL_SOFTBUTTONCAPABILITIES_LIST);
-        assertEquals(displayCapabilityList.get(0).getWindowCapabilities().get(0).getTextFields().size(), 35);
+        assertEquals(displayCapabilityList.get(0).getWindowCapabilities().get(0).getTextFields().size(), 34);
         assertEquals(displayCapabilityList.get(0).getWindowCapabilities().get(0).getImageFields().size(), 16);
     }
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lifecycle/SystemCapabilityManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lifecycle/SystemCapabilityManagerTests.java
@@ -204,7 +204,7 @@ public class SystemCapabilityManagerTests {
     @Test
     public void testNullDisplayCapabilitiesEnablesAllTextAndImageFields() {
         List<DisplayCapability> displayCapabilityList = createDisplayCapabilityList(null, TestValues.GENERAL_BUTTONCAPABILITIES_LIST, TestValues.GENERAL_SOFTBUTTONCAPABILITIES_LIST);
-        assertEquals(displayCapabilityList.get(0).getWindowCapabilities().get(0).getTextFields().size(), 32);
+        assertEquals(displayCapabilityList.get(0).getWindowCapabilities().get(0).getTextFields().size(), 35);
         assertEquals(displayCapabilityList.get(0).getWindowCapabilities().get(0).getImageFields().size(), 16);
     }
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/TextFieldNameTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/TextFieldNameTests.java
@@ -172,6 +172,9 @@ public class TextFieldNameTests extends TestCase {
         enumTestList.add(TextFieldName.locationDescription);
         enumTestList.add(TextFieldName.addressLines);
         enumTestList.add(TextFieldName.phoneNumber);
+        enumTestList.add(TextFieldName.timeToDestination);
+        enumTestList.add(TextFieldName.turnText);
+        enumTestList.add(TextFieldName.navigationText);
         enumTestList.add(TextFieldName.templateTitle);
         enumTestList.add(TextFieldName.subtleAlertText1);
         enumTestList.add(TextFieldName.subtleAlertText2);

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/TextFieldNameTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/TextFieldNameTests.java
@@ -174,7 +174,6 @@ public class TextFieldNameTests extends TestCase {
         enumTestList.add(TextFieldName.phoneNumber);
         enumTestList.add(TextFieldName.timeToDestination);
         enumTestList.add(TextFieldName.turnText);
-        enumTestList.add(TextFieldName.navigationText);
         enumTestList.add(TextFieldName.templateTitle);
         enumTestList.add(TextFieldName.subtleAlertText1);
         enumTestList.add(TextFieldName.subtleAlertText2);

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/TextFieldName.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/TextFieldName.java
@@ -182,6 +182,24 @@ public enum TextFieldName {
      */
     phoneNumber,
     /**
+     * Optional time to destination field for navigationTexts parameter in ShowConstantTB
+     *
+     * @since SmartDeviceLink 7.1.0
+     */
+    timeToDestination,
+    /**
+     * Turn text for turnList parameter of UpdateTurnList
+     *
+     * @since SmartDeviceLink 7.1.0
+     */
+    turnText,
+    /**
+     * Navigation text for turnList parameter of UpdateTurnList
+     *
+     * @since SmartDeviceLink 7.1.0
+     */
+    navigationText,
+    /**
      * Optional title of the template that will be displayed
      *
      * @since SmartDeviceLink 6.0

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/TextFieldName.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/TextFieldName.java
@@ -194,12 +194,6 @@ public enum TextFieldName {
      */
     turnText,
     /**
-     * Navigation text for turnList parameter of UpdateTurnList
-     *
-     * @since SmartDeviceLink 7.1.0
-     */
-    navigationText,
-    /**
      * Optional title of the template that will be displayed
      *
      * @since SmartDeviceLink 6.0

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/TextFieldName.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/TextFieldName.java
@@ -182,7 +182,7 @@ public enum TextFieldName {
      */
     phoneNumber,
     /**
-     * Optional time to destination field for navigationTexts parameter in ShowConstantTB
+     * Optional time to destination field for ShowConstantTBT
      *
      * @since SmartDeviceLink 7.1.0
      */


### PR DESCRIPTION
Fixes #1367 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
Additions were made to unit test.

### Summary
Implements proposal [SDL 0305](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0305-homogenize-textfieldname.md) which Homogenizes the Enum TextFieldName in HMI_API.xml with MOBILE_API.xml in the Rpc spec.

### Changelog

##### Enhancements
* Adds  timeToDestination, and turnText to TextFieldName enum.
### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
