### PR TITLE
Override Clone, Equals, and hashcode for RPCStruct

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/RPCStructTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/RPCStructTests.java
@@ -1,5 +1,6 @@
 package com.smartdevicelink.test.proxy;
 
+import com.smartdevicelink.proxy.RPCMessage;
 import com.smartdevicelink.proxy.RPCStruct;
 import com.smartdevicelink.proxy.rpc.AirbagStatus;
 import com.smartdevicelink.proxy.rpc.Choice;
@@ -182,5 +183,62 @@ public class RPCStructTests extends TestCase {
         } catch (ClassCastException e) {
             fail(e.getMessage());
         }
+    }
+
+    public void testClone() {
+        Hashtable<String, Object> map = new Hashtable<>();
+        String key = "test";
+        Integer value = 42;
+        map.put(key, value);
+
+        RPCStruct rpcStruct = new RPCStruct(map);
+        rpcStruct.setPayloadProtected(true);
+        RPCStruct rpcClone = rpcStruct.clone();
+
+        assertEquals(rpcStruct.getStore().get("test"), rpcClone.getStore().get("test"));
+        assertTrue(rpcClone.isPayloadProtected());
+    }
+
+    public void testHashCode() {
+        Hashtable<String, Object> map = new Hashtable<>();
+        String key = "test";
+        Integer value = 42;
+        map.put(key, value);
+
+        RPCStruct rpcStruct = new RPCStruct(map);
+
+        Hashtable<String, Object> map2 = new Hashtable<>();
+        String key2 = "test2";
+        Integer value2 = 24;
+        map2.put(key2, value2);
+
+        RPCStruct rpcStruct2 = new RPCStruct(map2);
+
+        assertEquals(rpcStruct.hashCode(), 3556536);
+        assertNotSame(rpcStruct2.hashCode(), 3556536);
+    }
+
+    public void testEquals() {
+        Hashtable<String, Object> map = new Hashtable<>();
+        String key = "test";
+        Integer value = 42;
+        map.put(key, value);
+
+        RPCStruct rpcStruct = new RPCStruct(map);
+
+        RPCStruct rpcClone = rpcStruct.clone();
+
+        RPCStruct rpcNull = new RPCStruct(null);
+
+        RPCMessage nonStruct = new RPCMessage("TEST");
+
+        RPCStruct rpcStruct2 = new RPCStruct(map);
+
+        assertFalse(rpcStruct.equals(null));
+        assertTrue(rpcStruct.equals(rpcStruct));
+        assertFalse(rpcStruct.equals(nonStruct));
+        assertFalse(rpcStruct.equals(rpcNull));
+        assertTrue(rpcStruct.equals(rpcStruct2));
+        assertTrue(rpcStruct.equals(rpcClone));
     }
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/RPCStructTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/RPCStructTests.java
@@ -206,16 +206,17 @@ public class RPCStructTests extends TestCase {
         map.put(key, value);
 
         RPCStruct rpcStruct = new RPCStruct(map);
+        RPCStruct rpcStruct2 = new RPCStruct(map);
 
         Hashtable<String, Object> map2 = new Hashtable<>();
         String key2 = "test2";
         Integer value2 = 24;
         map2.put(key2, value2);
 
-        RPCStruct rpcStruct2 = new RPCStruct(map2);
+        RPCStruct rpcStruct3 = new RPCStruct(map2);
 
-        assertEquals(rpcStruct.hashCode(), 3556536);
-        assertNotSame(rpcStruct2.hashCode(), 3556536);
+        assertEquals(rpcStruct.hashCode(), rpcStruct2.hashCode());
+        assertNotSame(rpcStruct2.hashCode(), rpcStruct3.hashCode());
     }
 
     public void testEquals() {

--- a/base/src/main/java/com/smartdevicelink/proxy/RPCStruct.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/RPCStruct.java
@@ -31,7 +31,10 @@
  */
 package com.smartdevicelink.proxy;
 
+import androidx.annotation.Nullable;
+
 import com.smartdevicelink.marshal.JsonRPCMarshaller;
+import com.smartdevicelink.util.DebugTool;
 import com.smartdevicelink.util.SdlDataTypeConverter;
 import com.smartdevicelink.util.Version;
 
@@ -46,7 +49,7 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Set;
 
-public class RPCStruct {
+public class RPCStruct implements Cloneable {
     public static final String KEY_BULK_DATA = "bulkData";
     public static final String KEY_PROTECTED = "protected";
 
@@ -374,5 +377,44 @@ public class RPCStruct {
             return (Long) result;
         }
         return null;
+    }
+
+    @Override
+    public RPCStruct clone() {
+        try {
+            RPCStruct clone = (RPCStruct) super.clone();
+            clone.setPayloadProtected(protectedPayload);
+            clone.setBulkData(_bulkData);
+            return clone;
+        } catch (CloneNotSupportedException e) {
+            DebugTool.logError("RPCStruct", "Failed to clone: " + e);
+            return null;
+        }
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        // if this is the same memory address, its the same
+        if (this == obj) {
+            return true;
+        }
+        // if this is not an instance of the same class, not the same
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+        // return comparison of store
+        return isEqualToRPC((RPCStruct) obj);
+    }
+
+    private boolean isEqualToRPC(RPCStruct rpc) {
+        return store.equals(rpc.store);
+    }
+
+    @Override
+    public int hashCode() {
+        return store.hashCode();
     }
 }

--- a/base/src/main/java/com/smartdevicelink/proxy/RPCStruct.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/RPCStruct.java
@@ -379,12 +379,18 @@ public class RPCStruct implements Cloneable {
         return null;
     }
 
+    /**
+     * Creates a deep copy of the object
+     *
+     * @return deep copy of the object, null if an exception occurred
+     */
     @Override
     public RPCStruct clone() {
         try {
             RPCStruct clone = (RPCStruct) super.clone();
             clone.setPayloadProtected(protectedPayload);
             clone.setBulkData(_bulkData);
+            clone.store = (Hashtable) store.clone();
             return clone;
         } catch (CloneNotSupportedException e) {
             DebugTool.logError("RPCStruct", "Failed to clone: " + e);
@@ -392,6 +398,12 @@ public class RPCStruct implements Cloneable {
         }
     }
 
+    /**
+     * Uses the RPCStruct store for RPCStruct objects
+     *
+     * @param obj - The object to compare
+     * @return boolean of whether the objects are the same or not
+     */
     @Override
     public boolean equals(@Nullable Object obj) {
         if (obj == null) {
@@ -413,6 +425,11 @@ public class RPCStruct implements Cloneable {
         return store.equals(rpc.store);
     }
 
+    /**
+     * Used to compile hashcode for RPCStruct
+     *
+     * @return Custom hashcode of RPCStruct
+     */
     @Override
     public int hashCode() {
         return store.hashCode();


### PR DESCRIPTION
Fixes #116

This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
Added Unit tests to RPCStructTests to verify new method behaviors

### Summary
This PR adds methods to the RPCStruct class to override the Clone, Equals, and hashCode methods.
RPCStruct now implements Clonable and the `clone()` method will create a deepCopy of RPCStruct when called.
`equals()` is now overriden and can be used to compare two RPCStruct objects
`hashCode()` will return the hashCode of the store in the RPCStruct

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
