### PR TITLE
Set AutoCompleteText in PresentChoiceSetOperation

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/PresentChoiceSetOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/PresentChoiceSetOperation.java
@@ -344,6 +344,7 @@ class PresentChoiceSetOperation extends Task {
                         @Override
                         public void onUpdatedAutoCompleteList(List<String> updatedAutoCompleteList) {
                             keyboardProperties.setAutoCompleteList(updatedAutoCompleteList != null ? updatedAutoCompleteList : new ArrayList<String>());
+                            keyboardProperties.setAutoCompleteText(updatedAutoCompleteList != null && !updatedAutoCompleteList.isEmpty() ? updatedAutoCompleteList.get(0) : null);
                             updateKeyboardProperties(null);
                         }
                     });


### PR DESCRIPTION
Fixes #1593 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Core Tests
The PR can be testing using the sample code that is included on the issue page

### Summary
This PR updates `PresentChoiceSetOperation` to set `AutoCompleteText` in addition to `AutoCompleteList` to make the feature backward compatible with old head units that don't support `AutoCompleteList`.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
