### PR TITLE
Use TaskMaster in AudioDecoderCompat

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/audio/AudioStreamManagerTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/audio/AudioStreamManagerTest.java
@@ -9,6 +9,7 @@ import android.util.Log;
 
 import androidx.test.platform.app.InstrumentationRegistry;
 
+import com.livio.taskmaster.Taskmaster;
 import com.smartdevicelink.managers.CompletionListener;
 import com.smartdevicelink.managers.ISdl;
 import com.smartdevicelink.managers.audio.AudioStreamManager.SampleType;
@@ -50,6 +51,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class AudioStreamManagerTest extends TestCase {
     public static final String TAG = AudioStreamManagerTest.class.getSimpleName();
@@ -107,7 +109,7 @@ public class AudioStreamManagerTest extends TestCase {
             }
         };
 
-        ISdl internalInterface = mock(ISdl.class);
+        ISdl internalInterface = createISdlMock();
         SystemCapabilityManager systemCapabilityManager = mock(SystemCapabilityManager.class);
         doReturn(systemCapabilityManager).when(internalInterface).getSystemCapabilityManager();
         AudioPassThruCapabilities audioCapabilities = new AudioPassThruCapabilities(SamplingRate._16KHZ, BitsPerSample._16_BIT, AudioType.PCM);
@@ -299,7 +301,7 @@ public class AudioStreamManagerTest extends TestCase {
             }
         };
 
-        ISdl internalInterface = mock(ISdl.class);
+        ISdl internalInterface = createISdlMock();
         SystemCapabilityManager systemCapabilityManager = mock(SystemCapabilityManager.class);
         doReturn(systemCapabilityManager).when(internalInterface).getSystemCapabilityManager();
         doReturn(true).when(internalInterface).isConnected();
@@ -530,7 +532,7 @@ public class AudioStreamManagerTest extends TestCase {
             }
         };
 
-        ISdl internalInterface = mock(ISdl.class);
+        ISdl internalInterface = createISdlMock();
         SystemCapabilityManager systemCapabilityManager = mock(SystemCapabilityManager.class);
         doReturn(systemCapabilityManager).when(internalInterface).getSystemCapabilityManager();
         doReturn(true).when(internalInterface).isConnected();
@@ -609,7 +611,7 @@ public class AudioStreamManagerTest extends TestCase {
             }
         };
 
-        ISdl internalInterface = mock(ISdl.class);
+        ISdl internalInterface = createISdlMock();
         SystemCapabilityManager systemCapabilityManager = mock(SystemCapabilityManager.class);
         doReturn(systemCapabilityManager).when(internalInterface).getSystemCapabilityManager();
         doReturn(true).when(internalInterface).isConnected();
@@ -746,5 +748,14 @@ public class AudioStreamManagerTest extends TestCase {
         stream.write((int) ((audiolength >> 8) & 0xff));
         stream.write((int) ((audiolength >> 16) & 0xff));
         stream.write((int) ((audiolength >> 24) & 0xff));
+    }
+
+    private ISdl createISdlMock() {
+        ISdl internalInterface = mock(ISdl.class);
+        Taskmaster taskmaster = new Taskmaster.Builder().build();
+        taskmaster.start();
+
+        when(internalInterface.getTaskmaster()).thenReturn(taskmaster);
+        return internalInterface;
     }
 }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/audio/AudioDecoderCompat.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/audio/AudioDecoderCompat.java
@@ -53,20 +53,6 @@ public class AudioDecoderCompat extends BaseAudioDecoder {
     /**
      * Creates a new object of AudioDecoder.
      *
-     * @param audioSource The audio source to decode.
-     * @param context     The context object to use to open the audio source.
-     * @param sampleRate  The desired sample rate for decoded audio data.
-     * @param sampleType  The desired sample type (8bit, 16bit, float).
-     * @param listener    A listener who receives the decoded audio.
-     */
-    @Deprecated
-    AudioDecoderCompat(@NonNull Uri audioSource, @NonNull Context context, int sampleRate, @SampleType int sampleType, AudioDecoderListener listener) {
-        super(audioSource, context, sampleRate, sampleType, listener);
-    }
-
-    /**
-     * Creates a new object of AudioDecoder.
-     *
      * @param internalInterface The internal interface to the connected device.
      * @param audioSource       The audio source to decode.
      * @param context           The context object to use to open the audio source.

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/audio/AudioDecoderCompat.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/audio/AudioDecoderCompat.java
@@ -32,27 +32,23 @@
 package com.smartdevicelink.managers.audio;
 
 import android.content.Context;
-import android.media.MediaCodec;
-import android.media.MediaFormat;
 import android.net.Uri;
 
 import androidx.annotation.NonNull;
 
+import com.livio.taskmaster.Queue;
+import com.livio.taskmaster.Taskmaster;
+import com.smartdevicelink.managers.ISdl;
 import com.smartdevicelink.managers.audio.AudioStreamManager.SampleType;
-import com.smartdevicelink.util.DebugTool;
 
 import java.lang.ref.WeakReference;
-import java.nio.ByteBuffer;
 
 /**
  * The audio decoder to decode a single audio file to PCM.
  * This decoder supports phones with api < 21 but uses methods deprecated with api 21.
  */
 public class AudioDecoderCompat extends BaseAudioDecoder {
-    private static final String TAG = AudioDecoderCompat.class.getSimpleName();
-    private static final int DEQUEUE_TIMEOUT = 3000;
-    private static Runnable sRunnable;
-    private Thread mThread;
+    private WeakReference<ISdl> internalInterface;
 
     /**
      * Creates a new object of AudioDecoder.
@@ -63,8 +59,24 @@ public class AudioDecoderCompat extends BaseAudioDecoder {
      * @param sampleType  The desired sample type (8bit, 16bit, float).
      * @param listener    A listener who receives the decoded audio.
      */
+    @Deprecated
     AudioDecoderCompat(@NonNull Uri audioSource, @NonNull Context context, int sampleRate, @SampleType int sampleType, AudioDecoderListener listener) {
         super(audioSource, context, sampleRate, sampleType, listener);
+    }
+
+    /**
+     * Creates a new object of AudioDecoder.
+     *
+     * @param internalInterface The internal interface to the connected device.
+     * @param audioSource       The audio source to decode.
+     * @param context           The context object to use to open the audio source.
+     * @param sampleRate        The desired sample rate for decoded audio data.
+     * @param sampleType        The desired sample type (8bit, 16bit, float).
+     * @param listener          A listener who receives the decoded audio.
+     */
+    AudioDecoderCompat(@NonNull ISdl internalInterface, @NonNull Uri audioSource, @NonNull Context context, int sampleRate, @SampleType int sampleType, AudioDecoderListener listener) {
+        super(audioSource, context, sampleRate, sampleType, listener);
+        this.internalInterface = new WeakReference<>(internalInterface);
     }
 
     /**
@@ -74,8 +86,15 @@ public class AudioDecoderCompat extends BaseAudioDecoder {
         try {
             initMediaComponents();
             decoder.start();
-            mThread = new Thread(new DecoderRunnable(AudioDecoderCompat.this));
-            mThread.start();
+
+            if (internalInterface != null && internalInterface.get() != null) {
+                Taskmaster taskmaster = internalInterface.get().getTaskmaster();
+                if (taskmaster != null) {
+                    Queue transactionQueue = taskmaster.createQueue("AudioDecoderCompat", 6, false);
+                    AudioDecoderCompatOperation operation = new AudioDecoderCompatOperation(this);
+                    transactionQueue.add(operation, false);
+                }
+            }
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -84,86 +103,6 @@ public class AudioDecoderCompat extends BaseAudioDecoder {
                 this.listener.onDecoderFinish(false);
             }
             stop();
-        }
-    }
-
-
-    /**
-     * Runnable to decode audio data
-     */
-    private static class DecoderRunnable implements Runnable {
-        final WeakReference<AudioDecoderCompat> weakReference;
-
-        /**
-         * Decodes all audio data from source
-         *
-         * @param audioDecoderCompat instance of this class
-         */
-        DecoderRunnable(@NonNull AudioDecoderCompat audioDecoderCompat) {
-            weakReference = new WeakReference<>(audioDecoderCompat);
-
-        }
-
-        @Override
-        public void run() {
-            final AudioDecoderCompat reference = weakReference.get();
-            if (reference == null) {
-                DebugTool.logWarning(TAG, "AudioDecoderCompat reference was null");
-                return;
-            }
-            final ByteBuffer[] inputBuffersArray = reference.decoder.getInputBuffers();
-            final ByteBuffer[] outputBuffersArray = reference.decoder.getOutputBuffers();
-            MediaCodec.BufferInfo outputBufferInfo = new MediaCodec.BufferInfo();
-            MediaCodec.BufferInfo inputBufferInfo;
-            ByteBuffer inputBuffer, outputBuffer;
-            SampleBuffer sampleBuffer;
-
-            while (reference != null && !reference.mThread.isInterrupted()) {
-                int inputBuffersArrayIndex = 0;
-                while (inputBuffersArrayIndex != MediaCodec.INFO_TRY_AGAIN_LATER) {
-                    inputBuffersArrayIndex = reference.decoder.dequeueInputBuffer(DEQUEUE_TIMEOUT);
-                    if (inputBuffersArrayIndex >= 0) {
-                        inputBuffer = inputBuffersArray[inputBuffersArrayIndex];
-                        inputBufferInfo = reference.onInputBufferAvailable(reference.extractor, inputBuffer);
-                        reference.decoder.queueInputBuffer(inputBuffersArrayIndex, inputBufferInfo.offset, inputBufferInfo.size, inputBufferInfo.presentationTimeUs, inputBufferInfo.flags);
-                    }
-                }
-
-                int outputBuffersArrayIndex = 0;
-                while (outputBuffersArrayIndex != MediaCodec.INFO_TRY_AGAIN_LATER) {
-                    outputBuffersArrayIndex = reference.decoder.dequeueOutputBuffer(outputBufferInfo, DEQUEUE_TIMEOUT);
-                    if (outputBuffersArrayIndex >= 0) {
-                        outputBuffer = outputBuffersArray[outputBuffersArrayIndex];
-                        if ((outputBufferInfo.flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0 && outputBufferInfo.size != 0) {
-                            reference.decoder.releaseOutputBuffer(outputBuffersArrayIndex, false);
-                        } else if (outputBuffer.limit() > 0) {
-                            sampleBuffer = reference.onOutputBufferAvailable(outputBuffer);
-                            if (reference.listener != null) {
-                                reference.listener.onAudioDataAvailable(sampleBuffer);
-                            }
-                            reference.decoder.releaseOutputBuffer(outputBuffersArrayIndex, false);
-                        }
-                    } else if (outputBuffersArrayIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
-                        MediaFormat newFormat = reference.decoder.getOutputFormat();
-                        reference.onOutputFormatChanged(newFormat);
-                    }
-                }
-
-                if (outputBufferInfo.flags == MediaCodec.BUFFER_FLAG_END_OF_STREAM) {
-                    if (reference.listener != null) {
-                        reference.listener.onDecoderFinish(true);
-                    }
-                    reference.stop();
-                    try {
-                        reference.mThread.interrupt();
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    } finally {
-                        reference.mThread = null;
-                        break;
-                    }
-                }
-            }
         }
     }
 }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/audio/AudioDecoderCompatOperation.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/audio/AudioDecoderCompatOperation.java
@@ -1,0 +1,84 @@
+package com.smartdevicelink.managers.audio;
+
+import android.media.MediaCodec;
+import android.media.MediaFormat;
+
+import com.livio.taskmaster.Task;
+import com.smartdevicelink.util.DebugTool;
+
+import java.lang.ref.WeakReference;
+import java.nio.ByteBuffer;
+
+class AudioDecoderCompatOperation extends Task {
+    private static final String TAG = "AudioDecoderCompatOperation";
+    private final WeakReference<AudioDecoderCompat> audioDecoderCompatWeakReference;
+    private static final int DEQUEUE_TIMEOUT = 3000;
+
+    AudioDecoderCompatOperation(AudioDecoderCompat audioDecoderCompat) {
+        super("AudioDecoderCompatOperation");
+        this.audioDecoderCompatWeakReference = new WeakReference<>(audioDecoderCompat);
+    }
+
+    @Override
+    public void onExecute() {
+        start();
+    }
+
+    private void start() {
+        if (getState() == Task.CANCELED) {
+            return;
+        }
+
+        final AudioDecoderCompat audioDecoderCompat = audioDecoderCompatWeakReference.get();
+        if (audioDecoderCompat == null) {
+            DebugTool.logWarning(TAG, "AudioDecoderCompat reference was null");
+            return;
+        }
+        final ByteBuffer[] inputBuffersArray = audioDecoderCompat.decoder.getInputBuffers();
+        final ByteBuffer[] outputBuffersArray = audioDecoderCompat.decoder.getOutputBuffers();
+        MediaCodec.BufferInfo outputBufferInfo = new MediaCodec.BufferInfo();
+        MediaCodec.BufferInfo inputBufferInfo;
+        ByteBuffer inputBuffer, outputBuffer;
+        SampleBuffer sampleBuffer;
+
+        while (true) {
+            int inputBuffersArrayIndex = 0;
+            while (inputBuffersArrayIndex != MediaCodec.INFO_TRY_AGAIN_LATER) {
+                inputBuffersArrayIndex = audioDecoderCompat.decoder.dequeueInputBuffer(DEQUEUE_TIMEOUT);
+                if (inputBuffersArrayIndex >= 0) {
+                    inputBuffer = inputBuffersArray[inputBuffersArrayIndex];
+                    inputBufferInfo = audioDecoderCompat.onInputBufferAvailable(audioDecoderCompat.extractor, inputBuffer);
+                    audioDecoderCompat.decoder.queueInputBuffer(inputBuffersArrayIndex, inputBufferInfo.offset, inputBufferInfo.size, inputBufferInfo.presentationTimeUs, inputBufferInfo.flags);
+                }
+            }
+
+            int outputBuffersArrayIndex = 0;
+            while (outputBuffersArrayIndex != MediaCodec.INFO_TRY_AGAIN_LATER) {
+                outputBuffersArrayIndex = audioDecoderCompat.decoder.dequeueOutputBuffer(outputBufferInfo, DEQUEUE_TIMEOUT);
+                if (outputBuffersArrayIndex >= 0) {
+                    outputBuffer = outputBuffersArray[outputBuffersArrayIndex];
+                    if ((outputBufferInfo.flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0 && outputBufferInfo.size != 0) {
+                        audioDecoderCompat.decoder.releaseOutputBuffer(outputBuffersArrayIndex, false);
+                    } else if (outputBuffer.limit() > 0) {
+                        sampleBuffer = audioDecoderCompat.onOutputBufferAvailable(outputBuffer);
+                        if (audioDecoderCompat.listener != null) {
+                            audioDecoderCompat.listener.onAudioDataAvailable(sampleBuffer);
+                        }
+                        audioDecoderCompat.decoder.releaseOutputBuffer(outputBuffersArrayIndex, false);
+                    }
+                } else if (outputBuffersArrayIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
+                    MediaFormat newFormat = audioDecoderCompat.decoder.getOutputFormat();
+                    audioDecoderCompat.onOutputFormatChanged(newFormat);
+                }
+            }
+
+            if (outputBufferInfo.flags == MediaCodec.BUFFER_FLAG_END_OF_STREAM) {
+                if (audioDecoderCompat.listener != null) {
+                    audioDecoderCompat.listener.onDecoderFinish(true);
+                }
+                audioDecoderCompat.stop();
+                break;
+            }
+        }
+    }
+}

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/audio/AudioStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/audio/AudioStreamManager.java
@@ -437,7 +437,7 @@ public class AudioStreamManager extends BaseAudioStreamManager {
             decoder = new AudioDecoder(audioSource, context.get(), sdlSampleRate, sdlSampleType, decoderListener);
         } else {
             // this BaseAudioDecoder subclass uses methods deprecated with api 21
-            decoder = new AudioDecoderCompat(audioSource, context.get(), sdlSampleRate, sdlSampleType, decoderListener);
+            decoder = new AudioDecoderCompat(internalInterface, audioSource, context.get(), sdlSampleRate, sdlSampleType, decoderListener);
         }
 
         synchronized (queue) {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/audio/AudioStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/audio/AudioStreamManager.java
@@ -101,6 +101,7 @@ public class AudioStreamManager extends BaseAudioStreamManager {
     private StreamPacketizer audioPacketizer;
     private SdlSession sdlSession = null;
     private SessionType sessionType = null;
+    private com.livio.taskmaster.Queue transactionQueue;
 
     private final Runnable serviceCompletionTimeoutCallback = new Runnable() {
         @Override
@@ -437,7 +438,7 @@ public class AudioStreamManager extends BaseAudioStreamManager {
             decoder = new AudioDecoder(audioSource, context.get(), sdlSampleRate, sdlSampleType, decoderListener);
         } else {
             // this BaseAudioDecoder subclass uses methods deprecated with api 21
-            decoder = new AudioDecoderCompat(internalInterface, audioSource, context.get(), sdlSampleRate, sdlSampleType, decoderListener);
+            decoder = new AudioDecoderCompat(getTransactionQueue(), audioSource, context.get(), sdlSampleRate, sdlSampleType, decoderListener);
         }
 
         synchronized (queue) {
@@ -447,6 +448,13 @@ public class AudioStreamManager extends BaseAudioStreamManager {
                 decoder.start();
             }
         }
+    }
+
+    private com.livio.taskmaster.Queue getTransactionQueue() {
+        if (transactionQueue == null && internalInterface != null && internalInterface.getTaskmaster() != null) {
+            transactionQueue = internalInterface.getTaskmaster().createQueue("AudioDecoderCompat", 6, false);
+        }
+        return transactionQueue;
     }
 
     /**

--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
@@ -169,7 +169,12 @@ abstract class BaseLifecycleManager {
     Taskmaster getTaskmaster() {
         if (taskmaster == null) {
             Taskmaster.Builder builder = new Taskmaster.Builder();
-            builder.setThreadCount(2);
+            int threadCount = 2;
+            // Give NAVIGATION & PROJECTION apps an extra thread to handle audio/video streaming operations
+            if (appConfig != null && appConfig.appType != null && (appConfig.appType.contains(AppHMIType.NAVIGATION) || appConfig.appType.contains(AppHMIType.PROJECTION))) {
+                threadCount = 3;
+            }
+            builder.setThreadCount(threadCount);
             builder.shouldBeDaemon(true);
             taskmaster = builder.build();
             taskmaster.start();


### PR DESCRIPTION
Fixes #1596

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Core Tests
To smoke test the PR you will need to test audio streaming with either of the following two options: 
- Test on a phone that has API < 21 
- Test on a new phone and force the pre 21 decoder logic by manually changing the decoder from `AudioDecoder` to `AudioDecoderCompat` for newer phones on this line:
https://github.com/smartdevicelink/sdl_java_suite/blob/5e80169552e4f51ec8d9d083a01f52678545342f/android/sdl_android/src/main/java/com/smartdevicelink/managers/audio/AudioStreamManager.java#L438

Core version / branch / commit hash / module tested against: Core 7.0 & SYNC 3.4

### Summary
This PR refactors `AudioDecoderCompat` to use Taskmaster to run decoding operations instead of creating a new thread every time.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
