### PR TITLE
Ignore RPCGenericTests

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/RPCGenericTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/RPCGenericTests.java
@@ -45,6 +45,7 @@ import static junit.framework.TestCase.fail;
  *     - The enums have a value for every element in the spec and the names and deprecation status match the spec
  */
 @RunWith(AndroidJUnit4.class)
+@Ignore //Remove this annotation before running these tests
 public class RPCGenericTests {
 
     private final String XML_FILE_NAME = "MOBILE_API.xml";

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/RPCGenericTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/RPCGenericTests.java
@@ -5,6 +5,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.smartdevicelink.proxy.rpc.enums.SystemCapabilityType;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.xmlpull.v1.XmlPullParser;


### PR DESCRIPTION
Fixes #1597 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [ ] I have tested Android, Java SE, and Java EE

#### Unit Tests
Added ignore annotation to `RPCGenericTests`

### Summary
This PR adds `Ignore` annotation to `RPCGenericTests` so they don't run automatically on every push. Because the `RPCGenericTests` will keep failing if the state of the java code doesn't match the state of the master branch for rpc_spec. The tests can still be run manually at the end of every release when java code and master branch for rpc_spec are in sync.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
