### PR TITLE
Remove handler from SdlRemoteDisplay

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/streaming/video/SdlRemoteDisplayTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/streaming/video/SdlRemoteDisplayTest.java
@@ -101,9 +101,8 @@ public class SdlRemoteDisplayTest extends TestCase {
 
         @Override
         protected void onCreate(Bundle savedInstanceState) {
-            super.onCreate(savedInstanceState);
             setContentView(new RelativeLayout(getContext()));
-
+            super.onCreate(savedInstanceState);
         }
 
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/streaming/video/SdlRemoteDisplayTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/streaming/video/SdlRemoteDisplayTest.java
@@ -101,8 +101,8 @@ public class SdlRemoteDisplayTest extends TestCase {
 
         @Override
         protected void onCreate(Bundle savedInstanceState) {
-            setContentView(new RelativeLayout(getContext()));
             super.onCreate(savedInstanceState);
+            setContentView(new RelativeLayout(getContext()));
         }
 
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/streaming/video/SdlRemoteDisplayTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/streaming/video/SdlRemoteDisplayTest.java
@@ -103,6 +103,7 @@ public class SdlRemoteDisplayTest extends TestCase {
         protected void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
             setContentView(new RelativeLayout(getContext()));
+            
         }
 
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/streaming/video/SdlRemoteDisplayTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/streaming/video/SdlRemoteDisplayTest.java
@@ -103,7 +103,7 @@ public class SdlRemoteDisplayTest extends TestCase {
         protected void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
             setContentView(new RelativeLayout(getContext()));
-            
+
         }
 
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/streaming/video/SdlRemoteDisplay.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/streaming/video/SdlRemoteDisplay.java
@@ -93,7 +93,7 @@ public abstract class SdlRemoteDisplay extends Presentation {
     }
 
     protected void startRefreshTask() {
-        refreshTaskScheduledFuture = executor.scheduleAtFixedRate(mStartRefreshTaskCallback, 0, REFRESH_RATE_MS, TimeUnit.MILLISECONDS);
+        refreshTaskScheduledFuture = executor.scheduleAtFixedRate(mStartRefreshTaskCallback, REFRESH_RATE_MS, REFRESH_RATE_MS, TimeUnit.MILLISECONDS);
     }
 
     protected void stopRefreshTask() {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/streaming/video/SdlRemoteDisplay.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/streaming/video/SdlRemoteDisplay.java
@@ -49,6 +49,10 @@ import com.smartdevicelink.util.DebugTool;
 
 import java.lang.reflect.Constructor;
 import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 /**
  * SdlRemoteDisplay is an abstract class that should be extended by developers to create their remote displays.
@@ -64,7 +68,8 @@ public abstract class SdlRemoteDisplay extends Presentation {
 
     protected Window w;
     protected View mainView;
-    protected final Handler handler = new Handler();
+    protected final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+    protected ScheduledFuture<?> refreshTaskScheduledFuture;
     protected final Handler uiHandler = new Handler(Looper.getMainLooper());
     protected Callback callback;
 
@@ -88,11 +93,13 @@ public abstract class SdlRemoteDisplay extends Presentation {
     }
 
     protected void startRefreshTask() {
-        handler.postDelayed(mStartRefreshTaskCallback, REFRESH_RATE_MS);
+        refreshTaskScheduledFuture = executor.scheduleAtFixedRate(mStartRefreshTaskCallback, 0, REFRESH_RATE_MS, TimeUnit.MILLISECONDS);
     }
 
     protected void stopRefreshTask() {
-        handler.removeCallbacks(mStartRefreshTaskCallback);
+        if (refreshTaskScheduledFuture != null) {
+            refreshTaskScheduledFuture.cancel(false);
+        }
     }
 
     protected final Runnable mStartRefreshTaskCallback = new Runnable() {
@@ -103,8 +110,6 @@ public abstract class SdlRemoteDisplay extends Presentation {
             if (mainView != null) {
                 mainView.invalidate();
             }
-
-            handler.postDelayed(this, REFRESH_RATE_MS);
         }
     };
 


### PR DESCRIPTION
Fixes #858

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Core Tests
Core version tested against: Core 7.0

### Summary
This PR replaces the usage of refresh handler in `SdlRemoteDisplay` with `ScheduledExecutorService` which runs on a different thread and has a specific API to run logic repeatedly at a preset rate.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
