### PR TITLE
Deprecate mediaClock

### DIFF
--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/Show.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/Show.java
@@ -124,7 +124,7 @@ import java.util.List;
  * 			    @since SmartDeviceLink 1.0.0
  * 			    @deprecated in SmartDeviceLink 7.1.0
  * 			</td>
- *  </tr>
+ *      </tr>
  * 		<tr>
  * 			<td>mediaTrack</td>
  * 			<td>String</td>

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/Show.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/Show.java
@@ -117,11 +117,14 @@ import java.util.List;
  * 		<tr>
  * 			<td>mediaClock</td>
  * 			<td>String</td>
- * 			<td><p>Text value for MediaClock field.</p> <p>Has to be properly formatted by Mobile App according to SDL capabilities.</p>If this text is set, any automatic media clock updates previously set with SetMediaClockTimer will be stopped.</td>
+ * 			<td>Text value for MediaClock field. Has to be properly formatted by Mobile App according to the module's capabilities. If this text is set, any automatic media clock updates previously set with SetMediaClockTimer will be stopped.</td>
  *                 <td>N</td>
- * 			<td><p>Must be properly formatted as described in the MediaClockFormat enumeration. </p><p>If a value of five spaces is provided, this will clear that field on the display (i.e. the media clock timer field will not display anything) </p>Maxlength = 500</td>
- * 			<td>SmartDeviceLink 1.0</td>
- * 		</tr>
+ * 			<td>{"string_min_length": 0, "string_max_length": 500}</td>
+ * 			<td>
+ *             @since SmartDeviceLink 1.0.0
+ *             @deprecated in SmartDeviceLink 7.1.0
+ * 			</td>
+ *  </tr>
  * 		<tr>
  * 			<td>mediaTrack</td>
  * 			<td>String</td>
@@ -198,6 +201,10 @@ public class Show extends RPCRequest {
     public static final String KEY_MAIN_FIELD_3 = "mainField3";
     public static final String KEY_MAIN_FIELD_4 = "mainField4";
     public static final String KEY_STATUS_BAR = "statusBar";
+    /**
+     * @since SmartDeviceLink 1.0.0
+     * @deprecated in SmartDeviceLink 7.1.0
+     */
     @Deprecated
     public static final String KEY_MEDIA_CLOCK = "mediaClock";
     public static final String KEY_ALIGNMENT = "alignment";
@@ -421,9 +428,14 @@ public class Show extends RPCRequest {
     }
 
     /**
-     * Gets the String value of the MediaClock
+     * Gets the mediaClock.
      *
-     * @return String -a String value of the MediaClock
+     * @return String Text value for MediaClock field. Has to be properly formatted by Mobile App according to
+     * the module's capabilities. If this text is set, any automatic media clock updates
+     * previously set with SetMediaClockTimer will be stopped.
+     * {"string_min_length": 0, "string_max_length": 500}
+     * @since SmartDeviceLink 1.0.0
+     * @deprecated in SmartDeviceLink 7.1.0
      */
     @Deprecated
     public String getMediaClock() {
@@ -431,19 +443,14 @@ public class Show extends RPCRequest {
     }
 
     /**
-     * Sets the value for the MediaClock field using a format described in the
-     * MediaClockFormat enumeration
+     * Sets the mediaClock.
      *
-     * @param mediaClock a String value for the MediaClock
-     *                   <p></p>
-     *                   <b>Notes: </b>
-     *                   <ul>
-     *                   <li>Must be properly formatted as described in the
-     *                   MediaClockFormat enumeration</li>
-     *                   <li>If a value of five spaces is provided, this will clear
-     *                   that field on the display (i.e. the media clock timer field
-     *                   will not display anything)</li>
-     *                   </ul>
+     * @param mediaClock Text value for MediaClock field. Has to be properly formatted by Mobile App according to
+     * the module's capabilities. If this text is set, any automatic media clock updates
+     * previously set with SetMediaClockTimer will be stopped.
+     * {"string_min_length": 0, "string_max_length": 500}
+     * @since SmartDeviceLink 1.0.0
+     * @deprecated in SmartDeviceLink 7.1.0
      */
     @Deprecated
     public Show setMediaClock(String mediaClock) {

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/Show.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/Show.java
@@ -124,7 +124,7 @@ import java.util.List;
  * 			    @since SmartDeviceLink 1.0.0
  * 			    @deprecated in SmartDeviceLink 7.1.0
  * 			</td>
- *      </tr>
+ * 		</tr>
  * 		<tr>
  * 			<td>mediaTrack</td>
  * 			<td>String</td>

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/Show.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/Show.java
@@ -121,8 +121,8 @@ import java.util.List;
  *                 <td>N</td>
  * 			<td>{"string_min_length": 0, "string_max_length": 500}</td>
  * 			<td>
- *             @since SmartDeviceLink 1.0.0
- *             @deprecated in SmartDeviceLink 7.1.0
+ * 			    @since SmartDeviceLink 1.0.0
+ * 			    @deprecated in SmartDeviceLink 7.1.0
  * 			</td>
  *  </tr>
  * 		<tr>

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/TextFieldName.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/enums/TextFieldName.java
@@ -65,8 +65,11 @@ public enum TextFieldName {
     statusBar,
     /**
      * Text value for MediaClock field; applies to "Show"
+     *
+     * @since SmartDeviceLink 1.0.0
+     * @deprecated in SmartDeviceLink 7.1.0
      */
-
+    @Deprecated
     mediaClock,
     /**
      * The track field of NGN and GEN1.1 MFD displays. This field is only available for media applications; applies to "Show"


### PR DESCRIPTION
Fixes #1606 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
n/a

#### Core Tests
n/a

### Summary
Deprecated MediaClock in Show.java and TextFieldName.java according to rpc spec changes https://github.com/smartdevicelink/rpc_spec/pull/309
### Changelog

##### Enhancements
* Deprecated MediaClock in Show.java and TextFieldName.java

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
