### PR TITLE
Prevent potential npe on resolution

### DIFF
--- a/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
+++ b/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
@@ -119,6 +119,11 @@ public class VideoStreamingParameters {
                 this.interval = params.interval;
             }
             if (params.resolution != null) {
+                if (this.resolution == null) {
+                    this.resolution = new ImageResolution();
+                    resolution.setResolutionWidth(DEFAULT_WIDTH);
+                    resolution.setResolutionHeight(DEFAULT_HEIGHT);
+                }
                 if (params.resolution.getResolutionHeight() != null && params.resolution.getResolutionHeight() > 0) {
                     this.resolution.setResolutionHeight(params.resolution.getResolutionHeight());
                 }
@@ -151,6 +156,12 @@ public class VideoStreamingParameters {
         }
         ImageResolution resolution = capability.getPreferredResolution();
         if (resolution != null) {
+
+            if (this.resolution == null) {
+                this.resolution = new ImageResolution();
+                resolution.setResolutionWidth(DEFAULT_WIDTH);
+                resolution.setResolutionHeight(DEFAULT_HEIGHT);
+            }
 
             if (vehicleMake != null) {
                 if ((vehicleMake.contains("Ford") || vehicleMake.contains("Lincoln")) && ((resolution.getResolutionHeight() != null && resolution.getResolutionHeight() > 800) || (resolution.getResolutionWidth() != null && resolution.getResolutionWidth() > 800))) {

--- a/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
+++ b/base/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
@@ -120,9 +120,7 @@ public class VideoStreamingParameters {
             }
             if (params.resolution != null) {
                 if (this.resolution == null) {
-                    this.resolution = new ImageResolution();
-                    resolution.setResolutionWidth(DEFAULT_WIDTH);
-                    resolution.setResolutionHeight(DEFAULT_HEIGHT);
+                    this.resolution = new ImageResolution(DEFAULT_WIDTH, DEFAULT_HEIGHT);
                 }
                 if (params.resolution.getResolutionHeight() != null && params.resolution.getResolutionHeight() > 0) {
                     this.resolution.setResolutionHeight(params.resolution.getResolutionHeight());
@@ -158,9 +156,7 @@ public class VideoStreamingParameters {
         if (resolution != null) {
 
             if (this.resolution == null) {
-                this.resolution = new ImageResolution();
-                resolution.setResolutionWidth(DEFAULT_WIDTH);
-                resolution.setResolutionHeight(DEFAULT_HEIGHT);
+                this.resolution = new ImageResolution(DEFAULT_WIDTH, DEFAULT_HEIGHT);
             }
 
             if (vehicleMake != null) {


### PR DESCRIPTION
Fixes #1611 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

### Summary
VideoStreamingParameters.update will now set a default value for resolution if it was null before trying to assign a new resolutionHeight or resolutionWidth

##### Bug Fixes
This will prevent the update method from trying to call setResolutionHeight or setResolutionWidth on a nullObjectReference

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
