### PR TITLE
[SDL-0293] OEM Exclusive App Support - Protocol & Manager layers

### DIFF
--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlService.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlService.java
@@ -47,6 +47,7 @@ import com.smartdevicelink.transport.BaseTransportConfig;
 import com.smartdevicelink.transport.MultiplexTransportConfig;
 import com.smartdevicelink.transport.TCPTransportConfig;
 import com.smartdevicelink.util.DebugTool;
+import com.smartdevicelink.util.SystemInfo;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -238,6 +239,12 @@ public class SdlService extends Service {
                     } else {
                         return null;
                     }
+                }
+
+                @Override
+                public boolean onSystemInfoReceived(SystemInfo systemInfo) {
+                    //Check the SystemInfo object to ensure that the connection to the device should continue
+                    return true;
                 }
             };
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/SdlManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/SdlManagerTests.java
@@ -23,6 +23,7 @@ import com.smartdevicelink.proxy.rpc.listeners.OnRPCResponseListener;
 import com.smartdevicelink.test.TestValues;
 import com.smartdevicelink.transport.BaseTransportConfig;
 import com.smartdevicelink.transport.TCPTransportConfig;
+import com.smartdevicelink.util.SystemInfo;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -113,6 +114,11 @@ public class SdlManagerTests {
             @Override
             public LifecycleConfigurationUpdate managerShouldUpdateLifecycle(Language language, Language hmiLanguage) {
                 return null;
+            }
+
+            @Override
+            public boolean onSystemInfoReceived(SystemInfo systemInfo) {
+                return true;
             }
         };
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/streaming/MockInterfaceBroker.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/streaming/MockInterfaceBroker.java
@@ -3,6 +3,7 @@ package com.smartdevicelink.test.streaming;
 import com.smartdevicelink.proxy.RPCMessage;
 import com.smartdevicelink.session.ISdlSessionListener;
 import com.smartdevicelink.transport.BaseTransportConfig;
+import com.smartdevicelink.util.SystemInfo;
 import com.smartdevicelink.util.Version;
 
 /**
@@ -24,7 +25,7 @@ public class MockInterfaceBroker implements ISdlSessionListener {
     }
 
     @Override
-    public void onSessionStarted(int sessionID, Version version) {
+    public void onSessionStarted(int sessionID, Version version, SystemInfo systemInfo) {
 
     }
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManagerListener.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManagerListener.java
@@ -34,6 +34,7 @@ package com.smartdevicelink.managers;
 
 import com.smartdevicelink.managers.lifecycle.LifecycleConfigurationUpdate;
 import com.smartdevicelink.proxy.rpc.enums.Language;
+import com.smartdevicelink.util.SystemInfo;
 
 public interface SdlManagerListener extends BaseSdlManagerListener {
 
@@ -68,4 +69,12 @@ public interface SdlManagerListener extends BaseSdlManagerListener {
      * otherwise null to indicate that the language is not supported.
      */
     LifecycleConfigurationUpdate managerShouldUpdateLifecycle(Language language, Language hmiLanguage);
+
+    /**
+     * A way to determine if this SDL session should continue to be active while
+     * connected to the determined system information of the vehicle.
+     * @param systemInfo systemInfo - the system information of the vehicle that this session is currently active on.
+     * @return Return true if this session should continue, false if the session should end
+     */
+    boolean onSystemInfoReceived(SystemInfo systemInfo);
 }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/session/SdlSession.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/session/SdlSession.java
@@ -156,7 +156,7 @@ public class SdlSession extends BaseSdlSession {
         if (serviceType != null && serviceType.eq(SessionType.RPC) && this.sessionId == -1) {
             this.sessionId = sessionID;
             SystemInfo systemInfo = null;
-            if(version != null && version.isNewerThan(new Version(5,4,0)) >= 0) {
+            if (version != null && version.isNewerThan(new Version(5, 4, 0)) >= 0) {
                 systemInfo = extractSystemInfo(packet);
             }
             this.sessionListener.onSessionStarted(sessionID, version, systemInfo);

--- a/android/sdl_android/src/main/java/com/smartdevicelink/session/SdlSession.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/session/SdlSession.java
@@ -41,12 +41,15 @@ import com.smartdevicelink.protocol.ISdlServiceListener;
 import com.smartdevicelink.protocol.SdlPacket;
 import com.smartdevicelink.protocol.SdlProtocol;
 import com.smartdevicelink.protocol.SdlProtocolBase;
+import com.smartdevicelink.protocol.enums.ControlFrameTags;
 import com.smartdevicelink.protocol.enums.SessionType;
+import com.smartdevicelink.proxy.rpc.VehicleType;
 import com.smartdevicelink.transport.MultiplexTransportConfig;
 import com.smartdevicelink.transport.TCPTransportConfig;
 import com.smartdevicelink.transport.enums.TransportType;
 import com.smartdevicelink.util.DebugTool;
 import com.smartdevicelink.util.MediaStreamingStatus;
+import com.smartdevicelink.util.SystemInfo;
 import com.smartdevicelink.util.Version;
 
 import java.lang.ref.WeakReference;
@@ -152,7 +155,11 @@ public class SdlSession extends BaseSdlSession {
 
         if (serviceType != null && serviceType.eq(SessionType.RPC) && this.sessionId == -1) {
             this.sessionId = sessionID;
-            this.sessionListener.onSessionStarted(sessionID, version);
+            SystemInfo systemInfo = null;
+            if(version != null && version.isNewerThan(new Version(5,4,0)) >= 0) {
+                systemInfo = extractSystemInfo(packet);
+            }
+            this.sessionListener.onSessionStarted(sessionID, version, systemInfo);
         }
 
         if (isEncrypted) {

--- a/base/src/main/java/com/smartdevicelink/managers/BaseSdlManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/BaseSdlManager.java
@@ -63,6 +63,7 @@ import com.smartdevicelink.proxy.rpc.listeners.OnRPCResponseListener;
 import com.smartdevicelink.security.SdlSecurityBase;
 import com.smartdevicelink.transport.BaseTransportConfig;
 import com.smartdevicelink.util.DebugTool;
+import com.smartdevicelink.util.SystemInfo;
 import com.smartdevicelink.util.Version;
 
 import org.json.JSONException;
@@ -148,6 +149,15 @@ abstract class BaseSdlManager {
         @Override
         public void onError(LifecycleManager lifeCycleManager, String info, Exception e) {
 
+        }
+
+        @Override
+        public boolean onSystemInfoReceived(SystemInfo systemInfo) {
+            if (managerListener != null) {
+                return managerListener.onSystemInfoReceived(systemInfo);
+            } else {
+                return true;
+            }
         }
     };
 

--- a/base/src/main/java/com/smartdevicelink/protocol/SdlProtocolBase.java
+++ b/base/src/main/java/com/smartdevicelink/protocol/SdlProtocolBase.java
@@ -85,7 +85,7 @@ public class SdlProtocolBase {
     public static final int V2_HEADER_SIZE = 12;
 
     //If increasing MAX PROTOCOL VERSION major version, make sure to alter it in SdlPsm
-    private static final Version MAX_PROTOCOL_VERSION = new Version(5, 3, 0);
+    private static final Version MAX_PROTOCOL_VERSION = new Version(5, 4, 0);
 
     public static final int V1_V2_MTU_SIZE = 1500;
     public static final int V3_V4_MTU_SIZE = 131072;

--- a/base/src/main/java/com/smartdevicelink/protocol/enums/ControlFrameTags.java
+++ b/base/src/main/java/com/smartdevicelink/protocol/enums/ControlFrameTags.java
@@ -85,6 +85,19 @@ public class ControlFrameTags {
              * Auth token to be used for log in into services
              **/
             public static final String AUTH_TOKEN = "authToken";
+            /**
+             * Vehicle info to describe connected device
+             */
+            public static final String MAKE = "make";
+            public static final String MODEL = "model";
+            public static final String MODEL_YEAR = "modelYear";
+            public static final String TRIM = "trim";
+
+            /**
+             * System specifics for hardware and software versions of connected device
+             */
+            public static final String SYSTEM_SOFTWARE_VERSION = "systemSoftwareVersion";
+            public static final String SYSTEM_HARDWARE_VERSION = "systemHardwareVersion";
 
         }
 

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterfaceResponse.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterfaceResponse.java
@@ -53,6 +53,7 @@ import java.util.List;
  * @since SmartDeviceLink 1.0
  */
 public class RegisterAppInterfaceResponse extends RPCResponse {
+    @Deprecated
     public static final String KEY_VEHICLE_TYPE = "vehicleType";
     public static final String KEY_SPEECH_CAPABILITIES = "speechCapabilities";
     public static final String KEY_VR_CAPABILITIES = "vrCapabilities";
@@ -73,6 +74,7 @@ public class RegisterAppInterfaceResponse extends RPCResponse {
     public static final String KEY_PRESET_BANK_CAPABILITIES = "presetBankCapabilities";
     public static final String KEY_HMI_CAPABILITIES = "hmiCapabilities"; //As of v4.0
     public static final String KEY_SDL_VERSION = "sdlVersion"; //As of v4.0
+    @Deprecated
     public static final String KEY_SYSTEM_SOFTWARE_VERSION = "systemSoftwareVersion"; //As of v4.0
     public static final String KEY_ICON_RESUMED = "iconResumed";
     public static final String KEY_PCM_STREAM_CAPABILITIES = "pcmStreamCapabilities";
@@ -382,18 +384,20 @@ public class RegisterAppInterfaceResponse extends RPCResponse {
 
     /**
      * Gets getVehicleType set when application interface is registered.
-     *
+     * @deprecated in SmartDeviceLink 7.1.0
      * @return vehicleType
      */
+    @Deprecated
     public VehicleType getVehicleType() {
         return (VehicleType) getObject(VehicleType.class, KEY_VEHICLE_TYPE);
     }
 
     /**
      * Sets vehicleType
-     *
+     * @deprecated in SmartDeviceLink 7.1.0
      * @param vehicleType
      */
+    @Deprecated
     public RegisterAppInterfaceResponse setVehicleType(VehicleType vehicleType) {
         setParameters(KEY_VEHICLE_TYPE, vehicleType);
         return this;
@@ -466,11 +470,24 @@ public class RegisterAppInterfaceResponse extends RPCResponse {
         return getString(KEY_SDL_VERSION);
     }
 
+    /**
+     * The software version of the connected device.
+     * @param systemSoftwareVersion the version of software on the connected device
+     * @return RegisterAppInterface
+     * @deprecated in SmartDeviceLink 7.1.0
+     */
+    @Deprecated
     public RegisterAppInterfaceResponse setSystemSoftwareVersion(String systemSoftwareVersion) {
         setParameters(KEY_SYSTEM_SOFTWARE_VERSION, systemSoftwareVersion);
         return this;
     }
 
+    /**
+     * The software version of the connected device.
+     * @return String the version of software on the connected device
+     * @deprecated in SmartDeviceLink 7.1.0
+     */
+    @Deprecated
     public String getSystemSoftwareVersion() {
         return getString(KEY_SYSTEM_SOFTWARE_VERSION);
     }

--- a/base/src/main/java/com/smartdevicelink/session/ISdlSessionListener.java
+++ b/base/src/main/java/com/smartdevicelink/session/ISdlSessionListener.java
@@ -35,6 +35,7 @@ import androidx.annotation.RestrictTo;
 
 import com.smartdevicelink.proxy.RPCMessage;
 import com.smartdevicelink.transport.BaseTransportConfig;
+import com.smartdevicelink.util.SystemInfo;
 import com.smartdevicelink.util.Version;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
@@ -63,8 +64,9 @@ public interface ISdlSessionListener {
      *
      * @param sessionID session ID associated with the session that was established
      * @param version   the protocol version that has been negotiated for this session
+     * @param systemInfo info about the device that this service is started
      */
-    void onSessionStarted(int sessionID, Version version);
+    void onSessionStarted(int sessionID, Version version, SystemInfo systemInfo);
 
     /**
      * Called to indicate that the session that was previously established has now ended. This means

--- a/base/src/main/java/com/smartdevicelink/util/SystemInfo.java
+++ b/base/src/main/java/com/smartdevicelink/util/SystemInfo.java
@@ -38,6 +38,7 @@ import com.smartdevicelink.proxy.rpc.VehicleType;
 
 public class SystemInfo {
 
+    @Nullable
     private VehicleType vehicleType;
     @Nullable
     private String systemSoftwareVersion;

--- a/base/src/main/java/com/smartdevicelink/util/SystemInfo.java
+++ b/base/src/main/java/com/smartdevicelink/util/SystemInfo.java
@@ -51,6 +51,7 @@ public class SystemInfo {
         this.systemHardwareVersion = systemHardwareVersion;
     }
 
+    @Nullable
     public VehicleType getVehicleType() {
         return vehicleType;
     }

--- a/base/src/main/java/com/smartdevicelink/util/SystemInfo.java
+++ b/base/src/main/java/com/smartdevicelink/util/SystemInfo.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021 Livio, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Livio Inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.smartdevicelink.util;
+
+import androidx.annotation.Nullable;
+
+import com.smartdevicelink.proxy.rpc.VehicleType;
+
+public class SystemInfo {
+
+    private VehicleType vehicleType;
+    @Nullable
+    private String systemSoftwareVersion;
+    @Nullable
+    private String systemHardwareVersion;
+
+    public SystemInfo(@Nullable VehicleType vehicleType, @Nullable String systemSoftwareVersion, @Nullable String systemHardwareVersion) {
+        this.vehicleType = vehicleType;
+        this.systemSoftwareVersion = systemSoftwareVersion;
+        this.systemHardwareVersion = systemHardwareVersion;
+    }
+
+    public VehicleType getVehicleType() {
+        return vehicleType;
+    }
+
+    @Nullable
+    public String getSystemSoftwareVersion() {
+        return systemSoftwareVersion;
+    }
+
+    @Nullable
+    public String getSystemHardwareVersion() {
+        return systemHardwareVersion;
+    }
+}

--- a/javaEE/hello_sdl_java_ee/src/main/java/com/smartdevicelink/SdlService.java
+++ b/javaEE/hello_sdl_java_ee/src/main/java/com/smartdevicelink/SdlService.java
@@ -55,6 +55,8 @@ import com.smartdevicelink.proxy.rpc.enums.*;
 import com.smartdevicelink.proxy.rpc.listeners.OnRPCNotificationListener;
 import com.smartdevicelink.transport.BaseTransportConfig;
 import com.smartdevicelink.util.DebugTool;
+import com.smartdevicelink.util.SystemInfo;
+
 
 import java.util.*;
 
@@ -153,6 +155,12 @@ public class SdlService {
                     }
 
                     return new LifecycleConfigurationUpdate(appName, null, TTSChunkFactory.createSimpleTTSChunks(appName), null);
+                }
+
+                @Override
+                public boolean onSystemInfoReceived(SystemInfo systemInfo) {
+                    //Check the SystemInfo object to ensure that the connection to the device should continue
+                    return true;
                 }
             };
 

--- a/javaSE/hello_sdl_java/src/main/java/com/smartdevicelink/java/SdlService.java
+++ b/javaSE/hello_sdl_java/src/main/java/com/smartdevicelink/java/SdlService.java
@@ -52,6 +52,7 @@ import com.smartdevicelink.proxy.rpc.enums.*;
 import com.smartdevicelink.proxy.rpc.listeners.OnRPCNotificationListener;
 import com.smartdevicelink.transport.BaseTransportConfig;
 import com.smartdevicelink.util.DebugTool;
+import com.smartdevicelink.util.SystemInfo;
 
 import java.util.*;
 
@@ -169,6 +170,12 @@ public class SdlService {
                     } else {
                         return null;
                     }
+                }
+
+                @Override
+                public boolean onSystemInfoReceived(SystemInfo systemInfo) {
+                    //Check the SystemInfo object to ensure that the connection to the device should continue
+                    return true;
                 }
             };
 

--- a/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/SdlManagerListener.java
+++ b/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/SdlManagerListener.java
@@ -33,6 +33,7 @@ package com.smartdevicelink.managers;
 
 import com.smartdevicelink.managers.lifecycle.LifecycleConfigurationUpdate;
 import com.smartdevicelink.proxy.rpc.enums.Language;
+import com.smartdevicelink.util.SystemInfo;
 
 public interface SdlManagerListener extends BaseSdlManagerListener {
 
@@ -67,4 +68,12 @@ public interface SdlManagerListener extends BaseSdlManagerListener {
      * otherwise null to indicate that the language is not supported.
      */
     LifecycleConfigurationUpdate managerShouldUpdateLifecycle(Language language, Language hmiLanguage);
+
+    /**
+     * A way to determine if this SDL session should continue to be active while
+     * connected to the determined system information of the vehicle.
+     * @param systemInfo systemInfo - the system information of the vehicle that this session is currently active on.
+     * @return Return true if this session should continue, false if the session should end
+     */
+    boolean onSystemInfoReceived(SystemInfo systemInfo);
 }

--- a/javaSE/javaSE/src/main/java/com/smartdevicelink/session/SdlSession.java
+++ b/javaSE/javaSE/src/main/java/com/smartdevicelink/session/SdlSession.java
@@ -69,7 +69,7 @@ public class SdlSession extends BaseSdlSession {
         if (serviceType != null && serviceType.eq(SessionType.RPC) && this.sessionId == -1) {
             this.sessionId = sessionID;
             SystemInfo systemInfo = null;
-            if(version != null && version.isNewerThan(new Version(5,4,0)) >= 0) {
+            if (version != null && version.isNewerThan(new Version(5, 4, 0)) >= 0) {
                 systemInfo = extractSystemInfo(packet);
             }
             this.sessionListener.onSessionStarted(sessionID, version, systemInfo);

--- a/javaSE/javaSE/src/main/java/com/smartdevicelink/session/SdlSession.java
+++ b/javaSE/javaSE/src/main/java/com/smartdevicelink/session/SdlSession.java
@@ -42,6 +42,7 @@ import com.smartdevicelink.protocol.SdlProtocolBase;
 import com.smartdevicelink.protocol.enums.SessionType;
 import com.smartdevicelink.transport.BaseTransportConfig;
 import com.smartdevicelink.util.DebugTool;
+import com.smartdevicelink.util.SystemInfo;
 import com.smartdevicelink.util.Version;
 
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -67,7 +68,11 @@ public class SdlSession extends BaseSdlSession {
 
         if (serviceType != null && serviceType.eq(SessionType.RPC) && this.sessionId == -1) {
             this.sessionId = sessionID;
-            this.sessionListener.onSessionStarted(sessionID, version);
+            SystemInfo systemInfo = null;
+            if(version != null && version.isNewerThan(new Version(5,4,0)) >= 0) {
+                systemInfo = extractSystemInfo(packet);
+            }
+            this.sessionListener.onSessionStarted(sessionID, version, systemInfo);
         }
 
         if (isEncrypted) {


### PR DESCRIPTION
Fixes part of #1588 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
- Updated unit tests to handle the new API updates

#### Core Tests

- [Core version](https://github.com/LuxoftSDL/sdl_core/tree/feature/sdl_0293_enable_oem_exclusive_apps_support)
- [HMI](https://github.com/LuxoftSDL/sdl_hmi/tree/feature/sdl_0293_enable_oem_exclusive_apps_support)

### Summary
- Added updates to implement part of the evolution proposal SDL-0293
- The changes included this PR reflect only the protocol level changes up to the manager layer APIs. A second PR is necessary to implement the Android specific router service feature of the proposal.
- The `SdlSession` will now extract the `SystemInfo` from the `StartSerivceACK` for the RPC service and pass that to the `LifecycleManager`. There the LCM will pass it to the `SdlManager` and supporting listener to the developer for what they wish to do. If the developer does not wish to remain connected to the device, the session will be ended.
    - A callback method in the `ISdlSessionListener` was updated to include the SystemInfo object. This is acceptable due to the class being only scoped for the library as described using annotations. 
- In case of the `SystemInfo` not being included in the `StartServiceACK`, the LCM will look in the RAI response and present the developer the chance to determine if they wish to continue there through the same `SdlManager` and listener APIs.
- The updates follow existing checks and flows as to not add ad hoc changes where possible.
- Sample apps were also updated to reflect the new method in the `SdlManagerListener`.

### Changelog

##### Enhancements
* Listener method was added so that developers could determine if they wish to stay connected to a device based on the `SystemInfo` that is supplied.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
