### PR TITLE
Fix empty string bug with MenuCell text fields

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseMenuManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseMenuManager.java
@@ -962,8 +962,8 @@ abstract class BaseMenuManager extends BaseSubManager {
     private AddCommand commandForMenuCell(MenuCell cell, boolean shouldHaveArtwork, int position) {
 
         MenuParams params = new MenuParams(cell.getUniqueTitle());
-        params.setSecondaryText(cell.getSecondaryText());
-        params.setTertiaryText(cell.getTertiaryText());
+        params.setSecondaryText((cell.getSecondaryText() != null && cell.getSecondaryText().length() == 0) ? null : cell.getSecondaryText());
+        params.setTertiaryText((cell.getTertiaryText() != null && cell.getTertiaryText().length() == 0) ? null : cell.getTertiaryText());
         params.setParentID(cell.getParentCellId() != MAX_ID ? cell.getParentCellId() : null);
         params.setPosition(position);
 
@@ -982,8 +982,8 @@ abstract class BaseMenuManager extends BaseSubManager {
 
     private AddSubMenu subMenuCommandForMenuCell(MenuCell cell, boolean shouldHaveArtwork, int position) {
         AddSubMenu subMenu = new AddSubMenu(cell.getCellId(), cell.getUniqueTitle());
-        subMenu.setSecondaryText(cell.getSecondaryText());
-        subMenu.setTertiaryText(cell.getTertiaryText());
+        subMenu.setSecondaryText((cell.getSecondaryText() != null && cell.getSecondaryText().length() == 0) ? null : cell.getSecondaryText());
+        subMenu.setTertiaryText((cell.getTertiaryText() != null && cell.getTertiaryText().length() == 0) ? null : cell.getTertiaryText());
         subMenu.setPosition(position);
         if (cell.getSubMenuLayout() != null) {
             subMenu.setMenuLayout(cell.getSubMenuLayout());


### PR DESCRIPTION
Fixes #1623 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have run the unit tests with this PR
- [X]  I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [X] I have tested Android, Java SE, and Java EE

#### Unit Tests
N/A

#### Core Tests
Create a menuCell and set the secondartText and tertiaryText to an empty string, When the menuCells are sent to core, all menuCells should be uploaded correctly

### Summary
If the secondaryText or tertiaryText field of a MenuCell is set to an empty string, the BaseMenuManager will replace the value with null so core can support it.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
