### PR TITLE
Fix deprecated keyword issue in class javadoc

### DIFF
--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/BodyInformation.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/BodyInformation.java
@@ -89,7 +89,7 @@ import java.util.List;
  * 			<td>The information about the park brake: - true, if active - false if not.</td>
  * 			<td>
  * 				@since SmartDeviceLink 2.0.0
- * 				@deprecated  in SmartDeviceLink 7.1.0
+ * 				@property-deprecated in SmartDeviceLink 7.1.0
  * 			</td>
  * 		</tr>
  * 		<tr>
@@ -99,7 +99,7 @@ import java.util.List;
  * 			<td>The information about the park brake: - true, if active - false if not.</td>
  * 			<td>
  * 				@since SmartDeviceLink 2.0.0
- * 				@deprecated  in SmartDeviceLink 7.1.0
+ * 				@property-deprecated in SmartDeviceLink 7.1.0
  * 			</td>
  * 		</tr>
  * 		<tr>
@@ -109,7 +109,7 @@ import java.util.List;
  * 			<td>The information about the park brake: - true, if active - false if not.</td>
  * 			<td>
  * 				@since SmartDeviceLink 2.0.0
- * 				@deprecated  in SmartDeviceLink 7.1.0
+ * 				@property-deprecated in SmartDeviceLink 7.1.0
  * 			</td>
  * 		</tr>
  * 		<tr>
@@ -119,7 +119,7 @@ import java.util.List;
  * 			<td>References signal "DrStatRr_B_Actl".</td>
  * 			<td>
  * 				@since SmartDeviceLink 2.0.0
- * 				@deprecated  in SmartDeviceLink 7.1.0
+ * 				@property-deprecated in SmartDeviceLink 7.1.0
  * 			</td>
  * 		</tr>
  * 		<tr>

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/DisplayCapabilities.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/DisplayCapabilities.java
@@ -52,7 +52,7 @@ import java.util.List;
  * 			<th>SmartDeviceLink Ver. Available</th>
  * 		</tr>
  * 		<tr>
- * 			<td>@Deprecated <s>displayType</s></td>
+ * 			<td>@property-deprecated <s>displayType</s></td>
  * 			<td><s>DisplayType</s></td>
  * 			<td><s>The type of display</s>
  * 			</td>

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/GetVehicleData.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/GetVehicleData.java
@@ -113,7 +113,7 @@ import java.util.Hashtable;
  *                 <td>Subscribable</td>
  * 			<td>
  * 				@since SmartDeviceLink 2.0.0
- * 				@deprecated in SmartDeviceLink 7.1.0
+ * 				@property-deprecated in SmartDeviceLink 7.1.0
  * 			</td>
  * 		</tr>
  * 		<tr>

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/Show.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/Show.java
@@ -122,7 +122,7 @@ import java.util.List;
  * 			<td>{"string_min_length": 0, "string_max_length": 500}</td>
  * 			<td>
  * 			    @since SmartDeviceLink 1.0.0
- * 			    @deprecated in SmartDeviceLink 7.1.0
+ * 			    @property-deprecated in SmartDeviceLink 7.1.0
  * 			</td>
  * 		</tr>
  * 		<tr>

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/SubscribeVehicleData.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/SubscribeVehicleData.java
@@ -121,7 +121,7 @@ import java.util.Hashtable;
  *                 <td>Subscribable</td>
  * 			<td>
  * 				@since SmartDeviceLink 2.0.0
- * 				@deprecated in SmartDeviceLink 7.1.0
+ * 				@property-deprecated in SmartDeviceLink 7.1.0
  * 			</td>
  * 		</tr>
  *  	<tr>

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/UnsubscribeVehicleData.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/UnsubscribeVehicleData.java
@@ -116,7 +116,7 @@ import java.util.Hashtable;
  *                 <td>Subscribable</td>
  * 			<td>
  * 				@since SmartDeviceLink 2.0.0
- * 				@deprecated in SmartDeviceLink 7.1.0
+ * 				@property-deprecated in SmartDeviceLink 7.1.0
  * 			</td>
  * 		</tr>
  *  	<tr>

--- a/generator/templates/base_template.java
+++ b/generator/templates/base_template.java
@@ -63,7 +63,7 @@ import {{i}};{{ '\n' if loop.last }}
  *      <td>{%- for d in param.description %}{{d}}{%- endfor %}</td>
  *      <td>{%- if param.mandatory is eq true %}Y{%- else %}N{%- endif %}</td>
  *      <td>{%- for k in param.values %}{{ '{' if loop.first}}"{{k}}": {{param.values[k]}}{{ ', ' if not loop.last else  '}'}}{%- endfor %}</td>
-        {%- if param.since is defined and param.since is not none %}{% set see, deprecated, since, history, spacing = param.see, param.deprecated, param.since, param.history, ' *         ' %}
+        {%- if param.since is defined and param.since is not none %}{% set see, deprecated, since, history, spacing, headerParam = param.see, param.deprecated, param.since, param.history, ' *         ', 'true' %}
  *      <td>
         {%- include "javadoc_version_info.java" %}
  *      </td>

--- a/generator/templates/javadoc_version_info.java
+++ b/generator/templates/javadoc_version_info.java
@@ -4,7 +4,11 @@
 {%- endif %}
 {%- if deprecated is defined and deprecated is not none %}
 {{spacing}}{{prefix}}@since SmartDeviceLink {{history[0].since}}
+{%- if headerParam is defined and headerParam is not none %}
+{{spacing}}{{prefix}}@property-deprecated in SmartDeviceLink {{since}}
+{%- else %}
 {{spacing}}{{prefix}}@deprecated in SmartDeviceLink {{since}}
+{%- endif %}
 {%- elif history is defined and history is not none %}
 {{spacing}}{{prefix}}@since SmartDeviceLink {{history[0].since}}
 {%- else %}


### PR DESCRIPTION
Fixes #1626 
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR:
- Updates the `@deprecated` keyword in class Javadoc to `@property-deprecated` to prevent Android Studio from marking the whole class as deprecated if only one property in the class is deprecated.
- Updates the RPC Generator to generate the correct deprecated annotations.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
