### PR TITLE
Bugfix/issue 1630 fix choice set default timeout

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/choiceset/ChoiceSetTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/choiceset/ChoiceSetTests.java
@@ -94,6 +94,8 @@ public class ChoiceSetTests {
         assertEquals(choiceSet.getTimeout().intValue(), 5);
         choiceSet.setTimeout(101);
         assertEquals(choiceSet.getTimeout().intValue(), 100);
+        // Reset default value for other unit test
+        choiceSet.setDefaultTimeout(10);
     }
 
     @Test

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/choiceset/ChoiceSetTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/choiceset/ChoiceSetTests.java
@@ -79,6 +79,21 @@ public class ChoiceSetTests {
         assertEquals(choiceSet.getTimeout(), defaultTimeout);
         assertEquals(choiceSet.getChoices(), choices);
         assertEquals(choiceSet.getChoiceSetSelectionListener(), listener);
+
+        // Test timeout and default timeout
+        choiceSet.setDefaultTimeout(20);
+        assertEquals(choiceSet.getDefaultTimeout(), 20);
+        choiceSet.setDefaultTimeout(1);
+        assertEquals(choiceSet.getDefaultTimeout(), 5);
+        choiceSet.setDefaultTimeout(101);
+        assertEquals(choiceSet.getDefaultTimeout(), 100);
+
+        choiceSet.setTimeout(20);
+        assertEquals(choiceSet.getTimeout().intValue(), 20);
+        choiceSet.setTimeout(1);
+        assertEquals(choiceSet.getTimeout().intValue(), 5);
+        choiceSet.setTimeout(101);
+        assertEquals(choiceSet.getTimeout().intValue(), 100);
     }
 
     @Test
@@ -95,21 +110,6 @@ public class ChoiceSetTests {
         assertEquals(choiceSet.getTimeout(), TestValues.GENERAL_INTEGER);
         assertEquals(choiceSet.getChoices(), choices);
         assertEquals(choiceSet.getChoiceSetSelectionListener(), listener);
-
-        // Test timeout and default timeout
-        choiceSet.setDefaultTimeout(20);
-        assertEquals(choiceSet.getDefaultTimeout(), 20);
-        choiceSet.setDefaultTimeout(1);
-        assertEquals(choiceSet.getDefaultTimeout(), 5);
-        choiceSet.setDefaultTimeout(101);
-        assertEquals(choiceSet.getDefaultTimeout(), 100);
-
-        choiceSet.setTimeout(20);
-        assertEquals(choiceSet.getTimeout().intValue(), 20);
-        choiceSet.setTimeout(1);
-        assertEquals(choiceSet.getTimeout().intValue(), 5);
-        choiceSet.setTimeout(101);
-        assertEquals(choiceSet.getTimeout().intValue(), 100);
 
 
         ChoiceSet choiceSet2 = new ChoiceSet(TestValues.GENERAL_STRING, layout, TestValues.GENERAL_INTEGER, TestValues.GENERAL_TTSCHUNK_LIST, TestValues.GENERAL_TTSCHUNK_LIST, TestValues.GENERAL_TTSCHUNK_LIST, TestValues.GENERAL_VRHELPITEM_LIST, TestValues.GENERAL_KEYBOARDPROPERTIES, choices, listener);

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/choiceset/ChoiceSetTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/choiceset/ChoiceSetTests.java
@@ -86,6 +86,7 @@ public class ChoiceSetTests {
 
         // first constructor was tested in previous method, use the rest here
         ChoiceSet choiceSet = new ChoiceSet(TestValues.GENERAL_STRING, layout, TestValues.GENERAL_INTEGER, TestValues.GENERAL_STRING, TestValues.GENERAL_STRING, TestValues.GENERAL_STRING, TestValues.GENERAL_VRHELPITEM_LIST, TestValues.GENERAL_KEYBOARDPROPERTIES, choices, listener);
+        choiceSet.setDefaultTimeout(5);
         assertEquals(choiceSet.getTitle(), TestValues.GENERAL_STRING);
         assertEquals(choiceSet.getInitialPrompt().get(0).getText(), TestValues.GENERAL_STRING);
         assertEquals(choiceSet.getHelpPrompt().get(0).getText(), TestValues.GENERAL_STRING);
@@ -94,6 +95,7 @@ public class ChoiceSetTests {
         assertEquals(choiceSet.getTimeout(), TestValues.GENERAL_INTEGER);
         assertEquals(choiceSet.getChoices(), choices);
         assertEquals(choiceSet.getChoiceSetSelectionListener(), listener);
+        assertEquals(choiceSet.getDefaultTimeout(), 5);
 
         ChoiceSet choiceSet2 = new ChoiceSet(TestValues.GENERAL_STRING, layout, TestValues.GENERAL_INTEGER, TestValues.GENERAL_TTSCHUNK_LIST, TestValues.GENERAL_TTSCHUNK_LIST, TestValues.GENERAL_TTSCHUNK_LIST, TestValues.GENERAL_VRHELPITEM_LIST, TestValues.GENERAL_KEYBOARDPROPERTIES, choices, listener);
         assertEquals(choiceSet2.getTitle(), TestValues.GENERAL_STRING);

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/choiceset/ChoiceSetTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/choiceset/ChoiceSetTests.java
@@ -86,7 +86,7 @@ public class ChoiceSetTests {
 
         // first constructor was tested in previous method, use the rest here
         ChoiceSet choiceSet = new ChoiceSet(TestValues.GENERAL_STRING, layout, TestValues.GENERAL_INTEGER, TestValues.GENERAL_STRING, TestValues.GENERAL_STRING, TestValues.GENERAL_STRING, TestValues.GENERAL_VRHELPITEM_LIST, TestValues.GENERAL_KEYBOARDPROPERTIES, choices, listener);
-        choiceSet.setDefaultTimeout(5);
+
         assertEquals(choiceSet.getTitle(), TestValues.GENERAL_STRING);
         assertEquals(choiceSet.getInitialPrompt().get(0).getText(), TestValues.GENERAL_STRING);
         assertEquals(choiceSet.getHelpPrompt().get(0).getText(), TestValues.GENERAL_STRING);
@@ -95,7 +95,22 @@ public class ChoiceSetTests {
         assertEquals(choiceSet.getTimeout(), TestValues.GENERAL_INTEGER);
         assertEquals(choiceSet.getChoices(), choices);
         assertEquals(choiceSet.getChoiceSetSelectionListener(), listener);
+
+        // Test timeout and default timeout
+        choiceSet.setDefaultTimeout(20);
+        assertEquals(choiceSet.getDefaultTimeout(), 20);
+        choiceSet.setDefaultTimeout(1);
         assertEquals(choiceSet.getDefaultTimeout(), 5);
+        choiceSet.setDefaultTimeout(101);
+        assertEquals(choiceSet.getDefaultTimeout(), 100);
+
+        choiceSet.setTimeout(20);
+        assertEquals(choiceSet.getTimeout().intValue(), 20);
+        choiceSet.setTimeout(1);
+        assertEquals(choiceSet.getTimeout().intValue(), 5);
+        choiceSet.setTimeout(101);
+        assertEquals(choiceSet.getTimeout().intValue(), 100);
+
 
         ChoiceSet choiceSet2 = new ChoiceSet(TestValues.GENERAL_STRING, layout, TestValues.GENERAL_INTEGER, TestValues.GENERAL_TTSCHUNK_LIST, TestValues.GENERAL_TTSCHUNK_LIST, TestValues.GENERAL_TTSCHUNK_LIST, TestValues.GENERAL_VRHELPITEM_LIST, TestValues.GENERAL_KEYBOARDPROPERTIES, choices, listener);
         assertEquals(choiceSet2.getTitle(), TestValues.GENERAL_STRING);

--- a/base/src/main/java/com/smartdevicelink/managers/screen/AlertView.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/AlertView.java
@@ -53,7 +53,6 @@ public class AlertView implements Cloneable {
 
 
     private AlertView() {
-        this.timeout = defaultTimeout;
     }
 
     public static class Builder {
@@ -166,7 +165,7 @@ public class AlertView implements Cloneable {
 
     public Integer getTimeout() {
         if (timeout == null) {
-            timeout = defaultTimeout;
+            timeout = getDefaultTimeout();
         } else if (timeout < TIMEOUT_MIN) {
             return TIMEOUT_MIN;
         } else if (timeout > TIMEOUT_MAX) {
@@ -246,7 +245,7 @@ public class AlertView implements Cloneable {
     }
 
     public void setDefaultTimeout(int defaultTimeout) {
-        this.defaultTimeout = defaultTimeout;
+        AlertView.defaultTimeout = defaultTimeout;
     }
 
     public void setTimeout(int timeout) {

--- a/base/src/main/java/com/smartdevicelink/managers/screen/AlertView.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/AlertView.java
@@ -237,18 +237,16 @@ public class AlertView implements Cloneable {
     }
 
     public int getDefaultTimeout() {
+        if (defaultTimeout < TIMEOUT_MIN) {
+            return TIMEOUT_MIN;
+        } else if (defaultTimeout > TIMEOUT_MAX) {
+            return TIMEOUT_MAX;
+        }
         return defaultTimeout;
     }
 
     public void setDefaultTimeout(int defaultTimeout) {
-        if (defaultTimeout <= TIMEOUT_MIN) {
-            AlertView.defaultTimeout = TIMEOUT_MIN;
-            return;
-        } else if (defaultTimeout >= TIMEOUT_MAX) {
-            AlertView.defaultTimeout = TIMEOUT_MAX;
-            return;
-        }
-        AlertView.defaultTimeout = defaultTimeout;
+        this.defaultTimeout = defaultTimeout;
     }
 
     public void setTimeout(int timeout) {

--- a/base/src/main/java/com/smartdevicelink/managers/screen/AlertView.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/AlertView.java
@@ -39,10 +39,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class AlertView implements Cloneable {
-    
-    private static Integer defaultTimeout = 5;
+
+    private static final int TIMEOUT_DEFAULT = 0;
     private static final int TIMEOUT_MIN = 3;
     private static final int TIMEOUT_MAX = 10;
+    private static Integer defaultTimeout = 5;
     private String text, secondaryText, tertiaryText;
     private Integer timeout;
     private AlertAudioData audio;
@@ -61,6 +62,9 @@ public class AlertView implements Cloneable {
 
         public Builder() {
             alertView = new AlertView();
+            if (alertView.timeout == null) {
+                alertView.timeout = TIMEOUT_DEFAULT;
+            }
         }
 
         /**
@@ -68,7 +72,7 @@ public class AlertView implements Cloneable {
          * on the head unit, the screen manager will automatically concatenate some of the lines together.
          */
         public Builder setText(String text) {
-            this.alertView.text = text;
+            alertView.text = text;
             return this;
         }
 
@@ -164,7 +168,7 @@ public class AlertView implements Cloneable {
     }
 
     public Integer getTimeout() {
-        if (timeout == null) {
+        if (timeout == TIMEOUT_DEFAULT) {
             timeout = getDefaultTimeout();
         } else if (timeout < TIMEOUT_MIN) {
             return TIMEOUT_MIN;

--- a/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/ChoiceSet.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/ChoiceSet.java
@@ -322,6 +322,11 @@ public class ChoiceSet {
     }
 
     public int getDefaultTimeout() {
+        if (defaultTimeout < TIMEOUT_MIN) {
+            this.defaultTimeout = TIMEOUT_MIN;
+        } else if (defaultTimeout > TIMEOUT_MAX) {
+            this.defaultTimeout = TIMEOUT_MAX;
+        }
         return defaultTimeout;
     }
 
@@ -333,13 +338,6 @@ public class ChoiceSet {
      * at 3 seconds. If this is set above the maximum, it will be capped at 10 seconds.
      */
     public void setDefaultTimeout(int defaultTimeout) {
-        if (defaultTimeout <= TIMEOUT_MIN) {
-            this.defaultTimeout = TIMEOUT_MIN;
-            return;
-        } else if (defaultTimeout >= TIMEOUT_MAX) {
-            this.defaultTimeout = TIMEOUT_MAX;
-            return;
-        }
         this.defaultTimeout = defaultTimeout;
     }
 

--- a/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/ChoiceSet.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/ChoiceSet.java
@@ -59,9 +59,10 @@ public class ChoiceSet {
     ChoiceSetCanceledListener canceledListener;
 
     // defaults
-    private static Integer defaultTimeout = 10;
+    private static final int TIMEOUT_DEFAULT = 0;
     private static final int TIMEOUT_MIN = 5;
     private static final int TIMEOUT_MAX = 100;
+    private static Integer defaultTimeout = 10;
     private final ChoiceSetLayout defaultLayout = ChoiceSetLayout.CHOICE_SET_LAYOUT_LIST;
 
     /**
@@ -81,6 +82,7 @@ public class ChoiceSet {
         setTitle(title);
         setChoiceSetSelectionListener(listener);
         setChoices(choices);
+        setTimeout(TIMEOUT_DEFAULT);
 
         // defaults
         setLayout(defaultLayout);
@@ -302,7 +304,7 @@ public class ChoiceSet {
      * @return The Timeout
      */
     public Integer getTimeout() {
-        if (timeout == null) {
+        if (timeout == TIMEOUT_DEFAULT) {
             timeout = getDefaultTimeout();
         } else if (timeout < TIMEOUT_MIN) {
             return TIMEOUT_MIN;

--- a/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/ChoiceSet.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/ChoiceSet.java
@@ -303,7 +303,7 @@ public class ChoiceSet {
      */
     public Integer getTimeout() {
         if (timeout == null) {
-            timeout = defaultTimeout;
+            timeout = getDefaultTimeout();
         } else if (timeout < TIMEOUT_MIN) {
             return TIMEOUT_MIN;
         } else if (timeout > TIMEOUT_MAX) {
@@ -323,9 +323,9 @@ public class ChoiceSet {
 
     public int getDefaultTimeout() {
         if (defaultTimeout < TIMEOUT_MIN) {
-            this.defaultTimeout = TIMEOUT_MIN;
+            return TIMEOUT_MIN;
         } else if (defaultTimeout > TIMEOUT_MAX) {
-            this.defaultTimeout = TIMEOUT_MAX;
+            return TIMEOUT_MAX;
         }
         return defaultTimeout;
     }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/ChoiceSet.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/ChoiceSet.java
@@ -59,7 +59,9 @@ public class ChoiceSet {
     ChoiceSetCanceledListener canceledListener;
 
     // defaults
-    private final Integer defaultTimeout = 10;
+    private static Integer defaultTimeout = 10;
+    private static final int TIMEOUT_MIN = 5;
+    private static final int TIMEOUT_MAX = 100;
     private final ChoiceSetLayout defaultLayout = ChoiceSetLayout.CHOICE_SET_LAYOUT_LIST;
 
     /**
@@ -82,7 +84,6 @@ public class ChoiceSet {
 
         // defaults
         setLayout(defaultLayout);
-        setTimeout(defaultTimeout);
 
         // things to do
         checkChoiceSetParameters();
@@ -301,21 +302,45 @@ public class ChoiceSet {
      * @return The Timeout
      */
     public Integer getTimeout() {
+        if (timeout == null) {
+            timeout = defaultTimeout;
+        } else if (timeout < TIMEOUT_MIN) {
+            return TIMEOUT_MIN;
+        } else if (timeout > TIMEOUT_MAX) {
+            return TIMEOUT_MAX;
+        }
         return timeout;
     }
 
     /**
-     * @param timeout - Maps to PerformInteraction.timeout. This applies only to a manual selection
-     *                (not a voice selection, which has its timeout handled by the system). Defaults to `defaultTimeout`.
-     *                <strong>This is set to seconds if using the screen manager.</strong>
+     * Maps to PerformInteraction.timeout. Timeout in seconds. Defaults to 0, which will use `defaultTimeout`.
+     * If this is set below the minimum, it will be capped at 5 seconds. Minimum 5 seconds, maximum 100 seconds.
+     * If this is set above the maximum, it will be capped at 100 seconds.
      */
     public void setTimeout(Integer timeout) {
-        if (timeout == null) {
-            this.timeout = defaultTimeout;
-        } else {
             this.timeout = timeout;
+    }
+
+    public int getDefaultTimeout() {
+        return defaultTimeout;
+    }
+
+    /**
+     * Set this to change the default timeout for all ChoiceSets. If a timeout is not set on an individual
+     * ChoiceSet object (or if it is set to 0), then it will use this timeout instead. See `timeout`
+     * for more details. If this is not set by you, it will default to 10 seconds. The minimum is
+     * 5 seconds, the maximum is 100 seconds. If this is set below the minimum, it will be capped
+     * at 3 seconds. If this is set above the maximum, it will be capped at 10 seconds.
+     */
+    public void setDefaultTimeout(int defaultTimeout) {
+        if (defaultTimeout <= TIMEOUT_MIN) {
+            this.defaultTimeout = TIMEOUT_MIN;
+            return;
+        } else if (defaultTimeout >= TIMEOUT_MAX) {
+            this.defaultTimeout = TIMEOUT_MAX;
+            return;
         }
-        checkChoiceSetParameters();
+        this.defaultTimeout = defaultTimeout;
     }
 
     /**
@@ -386,11 +411,6 @@ public class ChoiceSet {
             if (getTitle() != null) {
                 if (getTitle().length() == 0 || getTitle().length() > 500) {
                     DebugTool.logWarning(TAG, "Attempted to create a choice set with a title of " + getTitle().length() + " length. Only 500 characters are supported.");
-                }
-            }
-            if (getTimeout() != null) {
-                if (getTimeout() < 5 || getTimeout() > 100) {
-                    DebugTool.logWarning(TAG, "Attempted to create a choice set with a " + getTimeout() + " second timeout; Only 5 - 100 seconds is valid");
                 }
             }
             if (getChoices() != null) {


### PR DESCRIPTION
Fixes #1630 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
Unit test were added to `ChoiceSet`

#### Core Tests

Setting `ChoiceSet` timeout to:
1. Below 5 seconds: result `ChoiceSet` displays for 5 seconds
2. Above 100 seconds: result `ChoiceSet` displays for 100 seconds
3. 20 seconds: result `ChoiceSet` displays for 20 seconds
Not setting `ChoiceSet` timeout:
1. `ChoiceSet` displays for 10 seconds
Not setting `ChoiceSet` timeout and setting `ChoiceSet` defaultTimeout to:
1.  Below 5 seconds: result `ChoiceSet` displays for 5 seconds
2. Above 100 seconds: result `ChoiceSet` displays for 100 seconds
3. 20 seconds: result `ChoiceSet` displays for 20 seconds

Core version / branch / commit hash / module tested against: Manticore (Core 7.0)
HMI name / version / branch / commit hash / module tested against:Manticore: Generic HMI v0.9.0

### Summary
Added `defaultTimeout` to `ChoiceSet` and refactored timeout for 'ChoiceSet` to automatically set the 5 seconds if you try to set a timeout below that and the maximum if you try to set above 100 seconds (min and max allowed by core).

```
// This is how to set defaultTimeout
choiceSet.setDefaultTimeout(20);
```

### Changelog
##### Bug Fixes
* Added `defaultTimeout` and refactored `timeout`  for `ChoiceSet`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
