### PR TITLE
Fix issue in passing  encrypted param to startRemoteDisplayStream()

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -365,7 +365,7 @@ public class VideoStreamManager extends BaseVideoStreamManager {
      */
     @Deprecated
     public void startRemoteDisplayStream(Context context, Class<? extends SdlRemoteDisplay> remoteDisplayClass, VideoStreamingParameters parameters, final boolean encrypted){
-        configureGlobalParameters(context, remoteDisplayClass, isEncrypted, null, null);
+        configureGlobalParameters(context, remoteDisplayClass, encrypted, null, null);
         boolean isCapabilitySupported = internalInterface.getSystemCapabilityManager() != null && internalInterface.getSystemCapabilityManager().isCapabilitySupported(SystemCapabilityType.VIDEO_STREAMING);
         if (majorProtocolVersion >= 5 && !isCapabilitySupported) {
             DebugTool.logError(TAG, "Video streaming not supported on this module");
@@ -385,7 +385,7 @@ public class VideoStreamManager extends BaseVideoStreamManager {
     }
 
 
-    private void processCapabilitiesWithPendingStart(boolean encrypted, VideoStreamingParameters parameters) {
+    private void processCapabilitiesWithPendingStart(final boolean encrypted, VideoStreamingParameters parameters) {
         final VideoStreamingParameters params = (parameters == null) ? new VideoStreamingParameters() : new VideoStreamingParameters(parameters);
         if (majorProtocolVersion >= 5) {
             if (internalInterface.getSystemCapabilityManager() != null) {
@@ -411,7 +411,7 @@ public class VideoStreamManager extends BaseVideoStreamManager {
 
                         OnAppCapabilityUpdated onAppCapabilityUpdated = new OnAppCapabilityUpdated(appCapability);
                         internalInterface.sendRPC(onAppCapabilityUpdated);
-                        startStreaming(params, isEncrypted);
+                        startStreaming(params, encrypted);
                     }
 
                     @Override

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -346,7 +346,7 @@ public class VideoStreamManager extends BaseVideoStreamManager {
      * @param supportedPortraitStreamingRange      constraints for vehicle display : min/max aspect ratio, min/max resolutions, max diagonal size.
      */
     public void startRemoteDisplayStream(Context context, Class<? extends SdlRemoteDisplay> remoteDisplayClass, VideoStreamingParameters parameters, final boolean encrypted, VideoStreamingRange supportedLandscapeStreamingRange, VideoStreamingRange supportedPortraitStreamingRange) {
-        configureGlobalParameters(context, remoteDisplayClass, isEncrypted, supportedPortraitStreamingRange, supportedLandscapeStreamingRange);
+        configureGlobalParameters(context, remoteDisplayClass, encrypted, supportedPortraitStreamingRange, supportedLandscapeStreamingRange);
         if(majorProtocolVersion >= 5 && !internalInterface.getSystemCapabilityManager().isCapabilitySupported(SystemCapabilityType.VIDEO_STREAMING)){
             stateMachine.transitionToState(StreamingStateMachine.ERROR);
             return;


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Core Tests
- Setup encryption in Core & HMI
- Start encrypted video stream from the app
- Make sure encrypted NAV service is started and that packets get encrypted before they get sent to Core

Core version / branch / commit hash / module tested against: 7.1.0 RC

### Summary
This PR fixes an issue in `startRemoteDisplayStream()` where the incorrect `isEncrypted` param is passed instead of `encrypted` param

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
