### PR TITLE
Fix issue of overlapping softButton ID's in the screenManager

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/screen/BaseScreenManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/BaseScreenManager.java
@@ -742,15 +742,17 @@ abstract class BaseScreenManager extends BaseSubManager {
      * @return True if ButtonID's are good, False if not.
      */
     static boolean checkAndAssignButtonIds(List<SoftButtonObject> softButtonObjects, @ManagerLocation int location) {
+        HashSet<Integer> buttonIdsSetHashSet = new HashSet<>();
         // Depending on location form which the softButtons came from, we will clear out the id list so they can be reset
         if (location == ManagerLocation.ALERT_MANAGER) {
             softButtonIDByAlertManager.clear();
+            buttonIdsSetHashSet = (HashSet) softButtonIDBySoftButtonManager.clone();
         } else if (location == ManagerLocation.SOFTBUTTON_MANAGER) {
             softButtonIDBySoftButtonManager.clear();
+            buttonIdsSetHashSet = (HashSet) softButtonIDByAlertManager.clone();
         }
         // Check if multiple soft button objects have the same id
-        HashSet<Integer> buttonIdsSetHashSet = new HashSet<>();
-        int currentSoftButtonId, numberOfButtonIdsSet = 0, maxButtonIdsSetByDev = SOFT_BUTTON_ID_MIN_VALUE;
+        int currentSoftButtonId, numberOfButtonIdsSet = buttonIdsSetHashSet.size(), maxButtonIdsSetByDev = SOFT_BUTTON_ID_MIN_VALUE;
 
         for (SoftButtonObject softButtonObject : softButtonObjects) {
             currentSoftButtonId = softButtonObject.getButtonId();


### PR DESCRIPTION
Fixes #1643 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Core Tests
1. Set soft button via screen manager, send an alert with a softButton via the AlertManager, verify that the correct listeners get called when you click on the Alert softButtons and the softButtons set via the screenManager.

Core version / branch / commit hash / module tested against: Core 7.1 RC
HMI name / version / branch / commit hash / module tested against: generic HMI

### Summary
This PR fixes the issue that would cause the ScreenManager's sub-managers to generate overlapping button IDs that trigger the same button listeners. The AlertManager will now consider the SoftButtonManager's button IDs and vice versa.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
