### PR TITLE
Developer can set minDiagonal to 0 in VideoStreamingRange

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -872,7 +872,7 @@ public class VideoStreamManager extends BaseVideoStreamManager {
         if (capability.getDiagonalScreenSize() != null) {
             double diagonal = capability.getDiagonalScreenSize();
             if (range.getMinimumDiagonal() != null) {
-                if (range.getMinimumDiagonal() <= 0.0 || range.getMinimumDiagonal() > diagonal) {
+                if (range.getMinimumDiagonal() < 0.0 || range.getMinimumDiagonal() > diagonal) {
                     return false;
                 }
             }


### PR DESCRIPTION
This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [X] I have tested Android

#### Unit Tests
N/A

#### Core Tests
Try to stream video with both videoStreamingRanges set at `new VideoStreamingRange(null, null, 0.0, null, null);`


Core version / branch / commit hash / module tested against: Core 7.1
HMI name / version / branch / commit hash / module tested against: 5.5.0

### Summary
Updated so that 0.0 is considered a valid minDiagonal size

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
