### PR TITLE
Implement queries instead of blanket QUERY_ALL_PACKAGES permission

### DIFF
--- a/android/hello_sdl_android/src/main/AndroidManifest.xml
+++ b/android/hello_sdl_android/src/main/AndroidManifest.xml
@@ -12,6 +12,16 @@
     <!-- Required to use the USB Accessory mode -->
     <uses-feature android:name="android.hardware.usb.accessory" />
 
+    <!-- Required when targeting Android API 30+ -->
+    <queries>
+        <intent>
+            <action android:name="com.smartdevicelink.router.service" />
+        </intent>
+        <intent>
+            <action android:name="sdl.router.startservice" />
+        </intent>
+    </queries>
+
     <application
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"

--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/IntegrationValidator.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/IntegrationValidator.java
@@ -52,9 +52,6 @@ public class IntegrationValidator {
     private static final char CHECK_MARK = 0x2713;
     private static final char FAIL_MARK = 0x2715;
 
-    //FIXME When the CI is stable with API 30 use Manifest.permission.QUERY_ALL_PACKAGES instead
-    private static final String QUERY_ALL_PACKAGES = "android.permission.QUERY_ALL_PACKAGES";
-
     public static final int FLAG_SKIP_ROUTER_SERVICE_CHECK = 0x01;
 
 
@@ -116,9 +113,6 @@ public class IntegrationValidator {
         permissionList.add(Manifest.permission.ACCESS_NETWORK_STATE);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             permissionList.add(Manifest.permission.FOREGROUND_SERVICE);
-        }
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.Q) {
-            permissionList.add(QUERY_ALL_PACKAGES);
         }
         try {
             PackageInfo packageInfo = context.getPackageManager().getPackageInfo(context.getApplicationContext().getPackageName(), PackageManager.GET_PERMISSIONS);


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android


#### Core Tests

##### HelloSDL Base Test

1. Install HelloSDL Android application
2. Connect with head unit over bluetooth
3. Observe connection is established and HelloSDL is hosting the router service

##### Multi App Test

1. Create an additional Android app with SDL integration and install alongside HelloSDL
2. Connect with head unit over bluetooth
3. Observe connection is established and only one app is hosting the router service. 

If you remove the queries section from the manifest of either app it should be observed that two router services are started instead, one by each app.

### Summary
Android 30 introduced a new permission `QUERY_ALL_PACKAGES` that was necessary to query the Android device for other apps. While adding hte permission into the manifest was a simple update, a recent announcement mentioned that the permission was no longer going to be available for most apps and it was considered a sensitive permission. This change was going to be enforced very soon. This PR removes the dependence on that permission and adds the necessary queries declarations into the HelloSDL app's manifest. 

### Changelog

##### Bug Fixes
* The `QUERY_ALL_PACKAGES` permission is no longer needed by adding the queries declarations.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
