### PR TITLE
Fix encryption mtu corner case

### DIFF
--- a/base/src/main/java/com/smartdevicelink/protocol/SdlProtocolBase.java
+++ b/base/src/main/java/com/smartdevicelink/protocol/SdlProtocolBase.java
@@ -615,8 +615,9 @@ public class SdlProtocolBase {
             return;
         }
 
-        //Set the MTU according to session MTU provided by the IVI or the max data size for encryption if required
-        final Long mtu = requiresEncryption ? TLS_MAX_DATA_TO_ENCRYPT_SIZE : getMtu(sessionType);
+        //Set the MTU according to service MTU provided by the IVI .
+        //If encryption is required the MTU will be set to lowest value between the max data size for encryption or service MTU
+        final Long mtu = requiresEncryption ? Math.min(TLS_MAX_DATA_TO_ENCRYPT_SIZE, getMtu(sessionType)) : getMtu(sessionType);
 
         synchronized (messageLock) {
             if (data != null && data.length > mtu) {


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Core Tests

1. Setup encryption between all platforms
2. Require PutFile to be encrypted
3. Set MTU to lower value than encryption max data size (16,091)
4. Encrypt RPC service
5. Send a PutFile manually (not through manager)
6. Observe the frame size is that of the set MTU and not of the encryption max data size


### Summary
Added logic to take the minimum between the service type MTU and the max encryption data size. Prior to this PR, the library would use the max encryption data size even if the MTU had been set lower.

### Changelog

##### Bug Fixes
* Fixed the corner case that an IVI can support encryption but its MTU is lower than the ~16k bytes.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
