### PR TITLE
Fix video streaming incorrect restart

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -117,6 +117,7 @@ public class VideoStreamManager extends BaseVideoStreamManager {
     private String vehicleMake = null;
     private boolean isEncrypted = false;
     private boolean withPendingRestart = false;
+    private boolean wasCapabilityListenerAdded = false;
     private AbstractPacketizer videoPacketizer;
 
     // INTERNAL INTERFACES
@@ -188,7 +189,10 @@ public class VideoStreamManager extends BaseVideoStreamManager {
                     if (VideoStreamManager.this.parameters == null) {
                         getVideoStreamingParams();
                     }
-                    internalInterface.getSystemCapabilityManager().addOnSystemCapabilityListener(SystemCapabilityType.VIDEO_STREAMING, systemCapabilityListener);
+                    if (!wasCapabilityListenerAdded) {
+                        wasCapabilityListenerAdded = true;
+                        internalInterface.getSystemCapabilityManager().addOnSystemCapabilityListener(SystemCapabilityType.VIDEO_STREAMING, systemCapabilityListener);
+                    }
                 }
                 checkState();
                 if (hasStarted && (isHMIStateVideoStreamCapable(prevOnHMIStatus)) && (!isHMIStateVideoStreamCapable(currentOnHMIStatus))) {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/streaming/video/SdlRemoteDisplay.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/streaming/video/SdlRemoteDisplay.java
@@ -133,14 +133,16 @@ public abstract class SdlRemoteDisplay extends Presentation {
             @Override
             public void run() {
                 try {
-                    Constructor<? extends ViewGroup.LayoutParams> ctor =
-                            mainView.getLayoutParams().getClass().getDeclaredConstructor(int.class, int.class);
-                    mainView.setLayoutParams(ctor.newInstance(newWidth, newHeight));
-                    mainView.requestLayout();
-                    invalidate();
-                    onViewResized(newWidth, newHeight);
+                    if (mainView != null) {
+                        Constructor<? extends ViewGroup.LayoutParams> ctor =
+                                mainView.getLayoutParams().getClass().getDeclaredConstructor(int.class, int.class);
+                        mainView.setLayoutParams(ctor.newInstance(newWidth, newHeight));
+                        mainView.requestLayout();
+                        invalidate();
+                        onViewResized(newWidth, newHeight);
+                    }
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    DebugTool.logError(TAG, "Exception thrown during view resize", e);
                 }
             }
         });


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android


### Summary
Added a flag to prevent a listener from being added multiple times and with each time being added, it gets an immediate callback which therefore causes the video stream to stop and restart. This caused issues when the IVI simply displays an alert or dialog over the stream which would move the app to HMI_LIMITED but cause the stream to stop and restart.

Also added a check for null in the remote display class as it was simply just catching the NPE and printing it out in normal logs. It will no longer cause an NPE and exceptions will be logged through the `DebugTool` instead of `Log`.

### Changelog

##### Bug Fixes
* Incorrectly restarting stream when moving between HMI states
* Avoidable NPE in the remote display class


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
