### PR TITLE
Add null checks and synch around session in LCM

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
@@ -44,6 +44,7 @@ import com.smartdevicelink.managers.permission.PermissionManager;
 import com.smartdevicelink.marshal.JsonRPCMarshaller;
 import com.smartdevicelink.protocol.ISdlServiceListener;
 import com.smartdevicelink.protocol.ProtocolMessage;
+import com.smartdevicelink.protocol.SdlProtocolBase;
 import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.protocol.enums.MessageType;
 import com.smartdevicelink.protocol.enums.SessionType;
@@ -987,17 +988,30 @@ abstract class BaseLifecycleManager {
 
         @Override
         public boolean isConnected() {
-            return BaseLifecycleManager.this.session.getIsConnected();
+            synchronized (BaseLifecycleManager.this) {
+                if (BaseLifecycleManager.this.session != null) {
+                    return BaseLifecycleManager.this.session.getIsConnected();
+                }
+            }
+            return false;
         }
 
         @Override
         public void addServiceListener(SessionType serviceType, ISdlServiceListener sdlServiceListener) {
-            BaseLifecycleManager.this.session.addServiceListener(serviceType, sdlServiceListener);
+            synchronized (BaseLifecycleManager.this) {
+                if(BaseLifecycleManager.this.session != null ){
+                    BaseLifecycleManager.this.session.addServiceListener(serviceType, sdlServiceListener);
+                }
+            }
         }
 
         @Override
         public void removeServiceListener(SessionType serviceType, ISdlServiceListener sdlServiceListener) {
-            BaseLifecycleManager.this.session.removeServiceListener(serviceType, sdlServiceListener);
+            synchronized (BaseLifecycleManager.this) {
+                if (BaseLifecycleManager.this.session != null) {
+                    BaseLifecycleManager.this.session.removeServiceListener(serviceType, sdlServiceListener);
+                }
+            }
         }
 
         @Override
@@ -1064,14 +1078,25 @@ abstract class BaseLifecycleManager {
 
         @Override
         public boolean isTransportForServiceAvailable(SessionType serviceType) {
-            return BaseLifecycleManager.this.session.isTransportForServiceAvailable(serviceType);
+            synchronized (BaseLifecycleManager.this) {
+                if (BaseLifecycleManager.this.session != null) {
+                    return BaseLifecycleManager.this.session.isTransportForServiceAvailable(serviceType);
+                }
+            }
+            return false;
         }
 
         @NonNull
         @Override
         public SdlMsgVersion getSdlMsgVersion() {
-            SdlMsgVersion msgVersion = new SdlMsgVersion(rpcSpecVersion.getMajor(), rpcSpecVersion.getMinor());
-            msgVersion.setPatchVersion(rpcSpecVersion.getPatch());
+            SdlMsgVersion msgVersion;
+            if(rpcSpecVersion != null) {
+                msgVersion = new SdlMsgVersion(rpcSpecVersion.getMajor(), rpcSpecVersion.getMinor());
+                msgVersion.setPatchVersion(rpcSpecVersion.getPatch());
+            } else {
+                msgVersion = new SdlMsgVersion(1,0);
+            }
+
             return msgVersion;
         }
 
@@ -1083,7 +1108,12 @@ abstract class BaseLifecycleManager {
 
         @Override
         public long getMtu(SessionType serviceType) {
-            return BaseLifecycleManager.this.session.getMtu(serviceType);
+            synchronized (BaseLifecycleManager.this) {
+                if (BaseLifecycleManager.this.session != null) {
+                    return BaseLifecycleManager.this.session.getMtu(serviceType);
+                }
+            }
+            return SdlProtocolBase.V1_V2_MTU_SIZE;
         }
 
         @Override


### PR DESCRIPTION
Fixes #1658 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android



#### Core Tests

Based on the reported issue the testing revolved around adding and removing service listeners which happens during connection and disconnection. So simply connecting and disconnected on different transports with different types of apps was used.

### Summary
The `BaseLifecycleManager` made an assumption that the session variable would always be not null, however, it is set to null in the `stop()` method. Therefore it is possible that the session instance is null when operations are attempted on it. Added a synch block around the check of the session instance with the lock as the LCM itself, the same that is used in the `stop()` method.

We should consider this for a hotfix, especially if there are any other issues we need to address.

### Changelog


##### Bug Fixes
* Fixed NPE in LCM

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
