### PR TITLE
add removceDuplicate helper method to VoiceCommand

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/VoiceCommandTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/VoiceCommandTests.java
@@ -39,6 +39,9 @@ import com.smartdevicelink.test.TestValues;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static junit.framework.TestCase.assertEquals;
 
 @RunWith(AndroidJUnit4.class)
@@ -59,4 +62,25 @@ public class VoiceCommandTests {
         assertEquals(voiceCommand.getVoiceCommandSelectionListener(), voiceCommandSelectionListener);
     }
 
+    @Test
+    public void testDuplicateStrings() {
+        List<String> voiceCommandsList = new ArrayList<>();
+        voiceCommandsList.add("Test1");
+        voiceCommandsList.add("Test1");
+        voiceCommandsList.add("Test1");
+        VoiceCommand voiceCommand = new VoiceCommand(voiceCommandsList, voiceCommandSelectionListener);
+
+        assertEquals(1, voiceCommand.getVoiceCommands().size());
+        assertEquals("Test1", voiceCommand.getVoiceCommands().get(0));
+
+        voiceCommandsList = new ArrayList<>();
+        voiceCommandsList.add("Test1");
+        voiceCommandsList.add("Test2");
+        voiceCommandsList.add("Test1");
+        VoiceCommand voiceCommand2 = new VoiceCommand(voiceCommandsList, voiceCommandSelectionListener);
+
+        assertEquals(2, voiceCommand2.getVoiceCommands().size());
+        assertEquals("Test1", voiceCommand2.getVoiceCommands().get(0));
+        assertEquals("Test2", voiceCommand2.getVoiceCommands().get(1));
+    }
 }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/VoiceCommand.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/VoiceCommand.java
@@ -36,6 +36,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 public class VoiceCommand {
@@ -77,7 +79,7 @@ public class VoiceCommand {
      * @param voiceCommands - the list of commands to send to the head unit
      */
     public void setVoiceCommands(@NonNull List<String> voiceCommands) {
-        this.voiceCommands = voiceCommands;
+        this.voiceCommands = new ArrayList<>(removeDuplicateStrings(voiceCommands));
     }
 
     /**
@@ -124,6 +126,10 @@ public class VoiceCommand {
      */
     int getCommandId() {
         return commandId;
+    }
+
+    private HashSet<String> removeDuplicateStrings(List<String> voiceCommands) {
+        return new HashSet<>(voiceCommands);
     }
 
     /**


### PR DESCRIPTION
Fixes #1664 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [X] I have tested Android, Java SE, and Java EE

#### Unit Tests
Added unit test for lists with duplicate strings

#### Core Tests
Test sending a list of voiceCommands where there are duplicate strings
You should now only see one voice command for each unique string you set

Core version / branch / commit hash / module tested against: Manticore
HMI name / version / branch / commit hash / module tested against: Manticore

### Summary
This PR adds a helper function to VoiceCommand.java that will remove any duplicate strings when setVoiceCommands gets called. This PR adds the appropriate unit tests

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
