### PR TITLE
Make sure mOutputQueue capacity is never < 1

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/streaming/StreamPacketizer.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/streaming/StreamPacketizer.java
@@ -86,7 +86,7 @@ public class StreamPacketizer extends AbstractPacketizer implements IVideoStream
             bufferSize = BUFF_READ_SIZE;
             buffer = new byte[bufferSize];
         }
-        mOutputQueue = new LinkedBlockingQueue<>(MAX_QUEUE_SIZE / bufferSize);
+        mOutputQueue = new LinkedBlockingQueue<>(Math.max(MAX_QUEUE_SIZE / bufferSize, 1));
     }
 
     public void start() throws IOException {

--- a/base/src/main/java/com/smartdevicelink/streaming/video/RTPH264Packetizer.java
+++ b/base/src/main/java/com/smartdevicelink/streaming/video/RTPH264Packetizer.java
@@ -124,7 +124,7 @@ public class RTPH264Packetizer extends AbstractPacketizer implements IVideoStrea
             bufferSize = MAX_DATA_SIZE_FOR_ENCRYPTED_SERVICE;
         }
 
-        mOutputQueue = new LinkedBlockingQueue<>(MAX_QUEUE_SIZE / bufferSize);
+        mOutputQueue = new LinkedBlockingQueue<>(Math.max(MAX_QUEUE_SIZE / bufferSize, 1));
         mNALUnitReader = new NALUnitReader();
         mPayloadType = DEFAULT_RTP_PAYLOAD_TYPE;
 


### PR DESCRIPTION
Fixes #1667

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [X] I have tested Android, Java SE, and Java EE

#### Unit Tests
N/a

#### Core Tests
Follow steps outlined in issue using java test suite

Core version / branch / commit hash / module tested against: 7.1
HMI name / version / branch / commit hash / module tested against: sdl_hmi 5.5.1

### Summary
When the MaximumRpcPayloadSize is greater than the max queue size the queue capacity was being set to a decimal or 0 value. Adding a math.max to make sure it is always atleast 1. 

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
