### PR TITLE
Improve packet state machine

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/transport/SdlPsmTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/transport/SdlPsmTests.java
@@ -3,11 +3,16 @@ package com.smartdevicelink.test.transport;
 import android.util.Log;
 
 import com.smartdevicelink.protocol.SdlPacket;
+import com.smartdevicelink.protocol.SdlPacketFactory;
 import com.smartdevicelink.protocol.SdlProtocol;
+import com.smartdevicelink.protocol.enums.ControlFrameTags;
+import com.smartdevicelink.protocol.enums.SessionType;
 import com.smartdevicelink.test.TestValues;
 import com.smartdevicelink.transport.SdlPsm;
 
 import junit.framework.TestCase;
+
+import org.junit.Assert;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -18,11 +23,14 @@ import java.lang.reflect.Method;
  */
 public class SdlPsmTests extends TestCase {
     private static final String TAG = "SdlPsmTests";
-    private static final int MAX_DATA_LENGTH = SdlProtocol.V1_V2_MTU_SIZE - SdlProtocol.V1_HEADER_SIZE;
+    private static final int MAX_DATA_LENGTH_V1 = SdlProtocol.V1_V2_MTU_SIZE - SdlProtocol.V1_HEADER_SIZE;
+    private static final int MAX_DATA_LENGTH_V2 = SdlProtocol.V1_V2_MTU_SIZE - SdlProtocol.V2_HEADER_SIZE;
     SdlPsm sdlPsm;
     Field frameType, dataLength, version, controlFrameInfo;
     Method transitionOnInput;
     byte rawByte = (byte) 0x0;
+
+    SdlPacket startServiceACK;
 
     protected void setUp() throws Exception {
         super.setUp();
@@ -38,8 +46,43 @@ public class SdlPsmTests extends TestCase {
         dataLength.setAccessible(true);
         version.setAccessible(true);
         controlFrameInfo.setAccessible(true);
+
+        startServiceACK = SdlPacketFactory.createStartSessionACK(SessionType.RPC, (byte) 0x01, (byte) 0x05, (byte) 0x05);
+        startServiceACK.putTag(ControlFrameTags.RPC.StartServiceACK.HASH_ID, "3bb34978fe3a");
+        startServiceACK.putTag(ControlFrameTags.RPC.StartServiceACK.MTU, "150000");
+        startServiceACK.putTag(ControlFrameTags.RPC.StartServiceACK.PROTOCOL_VERSION, "5.1.0");
     }
 
+
+    public void testHappyPath() {
+
+
+        byte[] packetBytes = startServiceACK.constructPacket();
+
+        SdlPsm sdlPsm = new SdlPsm();
+        boolean didTransition = false;
+
+        for (byte packetByte : packetBytes) {
+            didTransition = sdlPsm.handleByte(packetByte);
+            assertTrue(didTransition);
+        }
+
+        assertEquals(SdlPsm.FINISHED_STATE, sdlPsm.getState());
+        SdlPacket parsedPacket = sdlPsm.getFormedPacket();
+        assertNotNull(parsedPacket);
+
+        assertEquals(startServiceACK.getVersion(), parsedPacket.getVersion());
+        assertEquals(startServiceACK.getServiceType(), parsedPacket.getServiceType());
+        assertEquals(startServiceACK.getFrameInfo(), parsedPacket.getFrameInfo());
+        assertEquals(startServiceACK.getFrameType(), parsedPacket.getFrameType());
+        assertEquals(startServiceACK.getDataSize(), parsedPacket.getDataSize());
+        assertEquals(startServiceACK.getMessageId(), parsedPacket.getMessageId());
+
+        assertTrue(startServiceACK.getTag(ControlFrameTags.RPC.StartServiceACK.HASH_ID).equals(parsedPacket.getTag(ControlFrameTags.RPC.StartServiceACK.HASH_ID)));
+        assertTrue(startServiceACK.getTag(ControlFrameTags.RPC.StartServiceACK.MTU).equals(parsedPacket.getTag(ControlFrameTags.RPC.StartServiceACK.MTU)));
+        assertTrue(startServiceACK.getTag(ControlFrameTags.RPC.StartServiceACK.PROTOCOL_VERSION).equals(parsedPacket.getTag(ControlFrameTags.RPC.StartServiceACK.PROTOCOL_VERSION)));
+
+    }
 
     public void testGarbledControlFrame() {
         try {
@@ -48,27 +91,46 @@ public class SdlPsmTests extends TestCase {
             controlFrameInfo.set(sdlPsm, SdlPacket.FRAME_INFO_START_SERVICE);
             frameType.set(sdlPsm, SdlPacket.FRAME_TYPE_CONTROL);
 
-            dataLength.set(sdlPsm, MAX_DATA_LENGTH + 1);
+            dataLength.set(sdlPsm, MAX_DATA_LENGTH_V1 + 1);
             int STATE = (Integer) transitionOnInput.invoke(sdlPsm, rawByte, SdlPsm.DATA_SIZE_4_STATE);
 
             assertEquals(TestValues.MATCH, SdlPsm.ERROR_STATE, STATE);
         } catch (Exception e) {
+            Assert.fail(e.toString());
             Log.e(TAG, e.toString());
         }
     }
 
-    public void testMaximumControlFrame() {
+    public void testMaximumControlFrameForVersion1() {
         try {
             rawByte = 0x0;
             version.set(sdlPsm, 1);
             controlFrameInfo.set(sdlPsm, SdlPacket.FRAME_INFO_START_SERVICE);
             frameType.set(sdlPsm, SdlPacket.FRAME_TYPE_CONTROL);
 
-            dataLength.set(sdlPsm, MAX_DATA_LENGTH);
+            dataLength.set(sdlPsm, MAX_DATA_LENGTH_V1);
             int STATE = (Integer) transitionOnInput.invoke(sdlPsm, rawByte, SdlPsm.DATA_SIZE_4_STATE);
 
             assertEquals(TestValues.MATCH, SdlPsm.DATA_PUMP_STATE, STATE);
         } catch (Exception e) {
+            Assert.fail(e.toString());
+            Log.e(TAG, e.toString());
+        }
+    }
+
+    public void testMaximumControlFrameForVersion2Plus() {
+        try {
+            rawByte = 0x0;
+            version.set(sdlPsm, 2);
+            controlFrameInfo.set(sdlPsm, SdlPacket.FRAME_INFO_START_SERVICE);
+            frameType.set(sdlPsm, SdlPacket.FRAME_TYPE_CONTROL);
+
+            dataLength.set(sdlPsm, MAX_DATA_LENGTH_V2);
+            int STATE = (Integer) transitionOnInput.invoke(sdlPsm, rawByte, SdlPsm.DATA_SIZE_4_STATE);
+
+            assertEquals(TestValues.MATCH, SdlPsm.MESSAGE_1_STATE, STATE);
+        } catch (Exception e) {
+            Assert.fail(e.toString());
             Log.e(TAG, e.toString());
         }
     }
@@ -80,13 +142,116 @@ public class SdlPsmTests extends TestCase {
             frameType.set(sdlPsm, SdlPacket.FRAME_TYPE_SINGLE);
 
             dataLength.set(sdlPsm, 2147483647);
-            int STATE = (Integer) transitionOnInput.invoke(sdlPsm, rawByte, SdlPsm.DATA_SIZE_4_STATE);
+            int STATE = (Integer) transitionOnInput.invoke(sdlPsm, rawByte, SdlPsm.MESSAGE_4_STATE);
 
             assertEquals(TestValues.MATCH, SdlPsm.ERROR_STATE, STATE);
         } catch (Exception e) {
+            Assert.fail(e.toString());
             Log.e(TAG, e.toString());
         }
     }
+
+    public void testNegativeDataSize() {
+        byte[] packetBytes = startServiceACK.constructPacket();
+
+        SdlPsm sdlPsm = new SdlPsm();
+        boolean didTransition = false;
+
+        for (byte packetByte : packetBytes) {
+            int state = sdlPsm.getState();
+            switch (state) {
+                case SdlPsm.MESSAGE_4_STATE:
+                    didTransition = sdlPsm.handleByte(packetByte);
+                    assertFalse(didTransition);
+                    assertEquals(SdlPsm.ERROR_STATE, sdlPsm.getState());
+                    return;
+                case SdlPsm.DATA_SIZE_1_STATE:
+                case SdlPsm.DATA_SIZE_2_STATE:
+                case SdlPsm.DATA_SIZE_3_STATE:
+                case SdlPsm.DATA_SIZE_4_STATE:
+                    didTransition = sdlPsm.handleByte((byte) 0xFF);
+                    assertTrue(didTransition);
+                    break;
+                default:
+                    didTransition = sdlPsm.handleByte(packetByte);
+                    assertTrue(didTransition);
+            }
+        }
+    }
+
+    public void testIncorrectVersion() {
+        SdlPacket startServiceACK = SdlPacketFactory.createStartSessionACK(SessionType.RPC, (byte) 0x01, (byte) 0x05, (byte) 0x06);
+        startServiceACK.putTag(ControlFrameTags.RPC.StartServiceACK.HASH_ID, "3bb34978fe3a");
+        startServiceACK.putTag(ControlFrameTags.RPC.StartServiceACK.MTU, "150000");
+        startServiceACK.putTag(ControlFrameTags.RPC.StartServiceACK.PROTOCOL_VERSION, "5.1.0");
+        byte[] packetBytes = startServiceACK.constructPacket();
+
+        SdlPsm sdlPsm = new SdlPsm();
+        boolean didTransition = sdlPsm.handleByte(packetBytes[0]);
+        assertFalse(didTransition);
+    }
+
+    public void testIncorrectService() {
+
+        byte[] packetBytes = startServiceACK.constructPacket();
+
+        SdlPsm sdlPsm = new SdlPsm();
+        boolean didTransition = false;
+
+        for (byte packetByte : packetBytes) {
+            int state = sdlPsm.getState();
+            switch (state) {
+                case SdlPsm.SERVICE_TYPE_STATE:
+                    didTransition = sdlPsm.handleByte((byte) 0xFF);
+                    assertFalse(didTransition);
+                    assertEquals(SdlPsm.ERROR_STATE, sdlPsm.getState());
+                    return;
+                default:
+                    didTransition = sdlPsm.handleByte(packetByte);
+                    assertTrue(didTransition);
+            }
+        }
+    }
+
+    public void testRecovery() {
+        byte[] packetBytes = startServiceACK.constructPacket();
+        byte[] processingBytes = new byte[packetBytes.length + 15];
+
+        System.arraycopy(packetBytes, 10, processingBytes, 0, 15);
+        System.arraycopy(packetBytes, 0, processingBytes, 15, packetBytes.length);
+
+
+        SdlPsm sdlPsm = new SdlPsm();
+        boolean didTransition = false;
+        byte packetByte;
+        int state = SdlPsm.START_STATE, i = 0, limit = 0;
+
+        while (state != SdlPsm.FINISHED_STATE && limit < 10) {
+
+            packetByte = processingBytes[i];
+            didTransition = sdlPsm.handleByte(packetByte);
+            state = sdlPsm.getState();
+            if (!didTransition) {
+                assertEquals(SdlPsm.ERROR_STATE, state);
+                sdlPsm.reset();
+            } else if (state == SdlPsm.FINISHED_STATE) {
+                break;
+            }
+
+            if (i == processingBytes.length - 1) {
+                i = 0;
+                limit++;
+            } else {
+                i++;
+            }
+        }
+
+        assertEquals(SdlPsm.FINISHED_STATE, sdlPsm.getState());
+        SdlPacket parsedPacket = sdlPsm.getFormedPacket();
+        assertNotNull(parsedPacket);
+
+    }
+
 
     protected void tearDown() throws Exception {
         super.tearDown();

--- a/base/src/main/java/com/smartdevicelink/transport/SdlPsm.java
+++ b/base/src/main/java/com/smartdevicelink/transport/SdlPsm.java
@@ -32,7 +32,6 @@
 package com.smartdevicelink.transport;
 
 import com.smartdevicelink.protocol.SdlPacket;
-import com.smartdevicelink.protocol.enums.SessionType;
 import com.smartdevicelink.util.DebugTool;
 
 import static com.smartdevicelink.protocol.SdlProtocol.V1_HEADER_SIZE;


### PR DESCRIPTION
Fixes #1678 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against an IVI system
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
Additional tests were added to test the SdlPsm.java class and some tests were refactored. These included more corner case issues as provided in #1678. 

#### Core Tests
Basic smoke testing can be done to ensure the packet state machine still works as intended. It is difficult to perform tests that would have actually broken the PSM so we rely on the unit tests for those scenarios.

### Summary
- Surrounded the base operation of the SdlPsm class in a try/catch that will set the state to ERROR state and safely exit. This prevents exceptions from being thrown in developer's applications. A log is written out through the DebugTool
- Added a check for correct service types. This helps with recovery tremendously. 
- Added better dataSize checking per early versions of the protocol. Dynamic MTUs are not included, but adding them might not actually help that much since they could be extremely large anyways.
- Refactored some checks to reduce redundant logic.
 
### Changelog
##### Enhancements
* Added better checks into the SdlPsm class
 
##### Bug Fixes
* Added safeguards to prevent crashes from propagating to developer's apps.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
