### PR TITLE
Allow SdlDeviceListener to start after BT connection

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
@@ -77,7 +77,8 @@ public class MultiplexBluetoothTransport extends MultiplexBaseTransport {
     Handler timeOutHandler;
     Runnable socketRunnable;
     boolean keepSocketAlive = true;
-
+    BluetoothDevice connectedDevice;
+    
     /**
      * Constructor. Prepares a new BluetoothChat session.
      *
@@ -110,6 +111,14 @@ public class MultiplexBluetoothTransport extends MultiplexBaseTransport {
 
     public void setKeepSocketAlive(boolean keepSocketAlive) {
         this.keepSocketAlive = keepSocketAlive;
+    }
+
+    /**
+     * A method to retrieve the currently connected bluetooth device
+     * @return the connected bluetooth device if connected, null otherwise.
+     */
+    public BluetoothDevice getConnectedDevice(){
+        return connectedDevice;
     }
 
     /**
@@ -225,6 +234,7 @@ public class MultiplexBluetoothTransport extends MultiplexBaseTransport {
 
         //Store a static name of the device that is connected.
         if (device != null) {
+            connectedDevice = device;
             connectedDeviceName = device.getName();
             connectedDeviceAddress = device.getAddress();
             if (connectedDeviceAddress != null) {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -275,9 +275,16 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver {
                             DebugTool.logInfo(TAG, ": This app's package: " + myPackage);
                             DebugTool.logInfo(TAG, ": Router service app's package: " + routerServicePackage);
                             if (myPackage != null && myPackage.equalsIgnoreCase(routerServicePackage)) {
-                                SdlDeviceListener sdlDeviceListener = getSdlDeviceListener(context, device);
-                                if (!sdlDeviceListener.isRunning()) {
-                                    sdlDeviceListener.start();
+                                //If the device is not null the listener should start as well as the
+                                //case where this app was installed after BT connected and is the
+                                //only SDL app installed on the device. (Rare corner case)
+                                if(device != null || sdlAppInfoList.size() == 1) {
+                                    SdlDeviceListener sdlDeviceListener = getSdlDeviceListener(context, device);
+                                    if (!sdlDeviceListener.isRunning()) {
+                                        sdlDeviceListener.start();
+                                    }
+                                } else {
+                                    DebugTool.logInfo(TAG, "Not starting device listener, bluetooth device is null and other SDL apps installed.");
                                 }
                             } else {
                                 DebugTool.logInfo(TAG, ": Not the app to start the router service nor device listener");


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android


#### Core Tests

Tested with Sync Gen3 TDK

##### Regression Tests

Performed tests as outline with the original SdlDeviceListener proposal in PR #1384 

##### New Tests

###### Single app installed after BT connection
- Remove all SDL apps from phone, if HelloSDL was installed be sure to clear storage prior to uninstall
- Turn on bluetooth adapter on phone.
- Allow BT to connect (A2DP); pair with IVI if necessary.
- Install Hello SDL and ensure it is the only SDL app installed.
- Observe through logs that the SDL Listener was started and is currently listening on an RFCOMM channel.
- IVI should connect with SDL Listener's RFCOMM channel, this will cause the listener to close the connection and attempt to start the router service. (Might need to perform SDP Query / press "Find new apps"
- Observe the router service notification appears as an indication the service has started
- The IVI should hopefully then connect with the router service's RFCOMM channel and the normal connection flow should occur.  

###### Multiple apps, one installed after BT connection, non SDL device
- Remove all SDL apps from phone except for one app ( do not use HelloSDL), if HelloSDL was installed be sure to clear storage prior to uninstall
- Turn on bluetooth adapter on phone.
- Allow BT to connect (A2DP); pair with headphones/headset if necessary.
- Observe through logs the already installed app attempted to listen for an SDL connection, however, none was made so the listener closed and the router service was not started
- Install Hello SDL and ensure it is the only SDL app installed.
- Observe through logs that the SDL Listener was not started due to an SDL app already being installed.
 
### Summary
Prior to this PR it was not possible to get an app to connect to an IVI until the BT adapter was either power cycled or the disconnected and reconnected. This was due to the fact that the doesn't immediately have access to the BT device when it is installed and obtains it through the initial ACL connection intent. The `SdlDeviceListener` would return an error if no BT device was supplied. With this PR, the `SdlDeviceListener` is allowed to continue without a BT device supplied with slightly modified logic. If not device is supplied it only opens the RFCOMM channel for 15 seconds and is not able to check for prior connection. If a connection is made, the `MultiplexBluetoothTransport` is used to retrieve the BT device which can then be used to cache it's connection status in the shared preferences. The caveat to this feature is that this will only be called from the `SdlBroadcastReceiver` if it is the only SDL app on the device at that time. The logic is that if an SDL app was already installed then it should have been notified of the BT connection and start the SDL process.

### Changelog


##### Enhancements
* MultiplexBluetoothTransport now stores the connect bluetooth device and can be retrieved
* The `SdlDeviceListener` is allowed to start if the BT device is null
* The `SdlBroadcastReceiver` only starts the `SdlDeviceListener` when there is no BT device in the case that it is the only SDL app installed


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
