### PR TITLE
Fix for voice command that contains no string should be removed

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/VoiceCommandManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/VoiceCommandManagerTests.java
@@ -235,6 +235,10 @@ public class VoiceCommandManagerTests {
         voiceCommandList.add(command2);
         voiceCommandManager.setVoiceCommands(voiceCommandList);
         assertEquals(voiceCommandManager.voiceCommands.size(), 1);
+
+        voiceCommandManager.setVoiceCommands(voiceCommandList);
+        assertEquals(voiceCommandManager.voiceCommands.size(), 1);
+
     }
 
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/VoiceCommandManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/VoiceCommandManagerTests.java
@@ -239,6 +239,10 @@ public class VoiceCommandManagerTests {
         voiceCommandManager.setVoiceCommands(voiceCommandList);
         assertEquals(voiceCommandManager.voiceCommands.size(), 1);
 
+        voiceCommandManager.voiceCommands = null;
+        voiceCommandManager.setVoiceCommands(null);
+        assertNull(voiceCommandManager.voiceCommands);
+
     }
 
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/VoiceCommandManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/VoiceCommandManagerTests.java
@@ -210,4 +210,32 @@ public class VoiceCommandManagerTests {
         assertNull(voiceCommandManager.voiceCommands);
     }
 
+    /**
+     * Test trim whitespace from voice commands and not uploading empty strings.
+     */
+    @Test
+    public void testEmptyStringsAndWhiteSpaceRemoval() {
+        List<VoiceCommand> voiceCommandList = new ArrayList<>();
+        VoiceCommand command1 = new VoiceCommand(Arrays.asList("   Command one "), null);
+
+        voiceCommandList.add(command1);
+        voiceCommandManager.currentHMILevel = HMILevel.HMI_NONE;
+        voiceCommandManager.setVoiceCommands(voiceCommandList);
+        assertEquals(voiceCommandManager.voiceCommands.get(0).getVoiceCommands().get(0), "Command one");
+
+        voiceCommandManager.voiceCommands = null;
+        voiceCommandList = new ArrayList<>();
+        command1 = new VoiceCommand(Arrays.asList(" "), null);
+
+        voiceCommandList.add(command1);
+        voiceCommandManager.setVoiceCommands(voiceCommandList);
+        assertNull(voiceCommandManager.voiceCommands);
+
+        VoiceCommand command2 = new VoiceCommand(Arrays.asList("Command two"), null);
+        voiceCommandList.add(command2);
+        voiceCommandManager.setVoiceCommands(voiceCommandList);
+        assertEquals(voiceCommandManager.voiceCommands.size(), 1);
+    }
+
+
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/VoiceCommandManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/VoiceCommandManagerTests.java
@@ -243,6 +243,13 @@ public class VoiceCommandManagerTests {
         voiceCommandManager.setVoiceCommands(null);
         assertNull(voiceCommandManager.voiceCommands);
 
+        voiceCommandList = new ArrayList<>();
+        VoiceCommand command3 = new VoiceCommand(Arrays.asList("Command three", null, " "), null);
+        voiceCommandList.add(command3);
+        voiceCommandList.add(null);
+        voiceCommandManager.setVoiceCommands(voiceCommandList);
+        assertEquals(voiceCommandManager.voiceCommands.size(), 1);
+
     }
 
 

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
@@ -151,7 +151,7 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
 
         this.originalVoiceCommands = new ArrayList<>(voiceCommands);
         this.voiceCommands = validatedVoiceCommands;
-        updateIdsOnVoiceCommands(voiceCommands);
+        updateIdsOnVoiceCommands(this.voiceCommands);
 
         cleanTransactionQueue();
         updateOperation = new VoiceCommandUpdateOperation(internalInterface, currentVoiceCommands, this.voiceCommands, new VoiceCommandUpdateOperation.VoiceCommandChangesListener() {

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
@@ -56,7 +56,7 @@ import java.util.List;
 
 abstract class BaseVoiceCommandManager extends BaseSubManager {
     private static final String TAG = "BaseVoiceCommandManager";
-    List<VoiceCommand> voiceCommands, currentVoiceCommands;
+    List<VoiceCommand> voiceCommands, currentVoiceCommands, originalVoiceCommands;
 
     int lastVoiceCommandId;
     private static final int voiceCommandIdMin = 1900000000;
@@ -132,7 +132,7 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
     public void setVoiceCommands(List<VoiceCommand> voiceCommands) {
 
         // we actually need voice commands to set.
-        if (voiceCommands == null || voiceCommands.equals(this.voiceCommands)) {
+        if (voiceCommands == null || voiceCommands.equals(this.originalVoiceCommands)) {
             DebugTool.logInfo(TAG, "Voice commands list was null or matches the current voice commands");
             return;
         }
@@ -142,11 +142,19 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
             return;
         }
 
+        List<VoiceCommand> validatedVoiceCommands = removeEmptyVoiceCommands(voiceCommands);
+
+        if (validatedVoiceCommands.size() == 0 && voiceCommands.size() > 0) {
+            DebugTool.logError(TAG, "New voice commands are invalid, skipping...");
+            return;
+        }
+
+        this.originalVoiceCommands = new ArrayList<>(voiceCommands);
+        this.voiceCommands = validatedVoiceCommands;
         updateIdsOnVoiceCommands(voiceCommands);
-        this.voiceCommands = new ArrayList<>(voiceCommands);
 
         cleanTransactionQueue();
-        updateOperation = new VoiceCommandUpdateOperation(internalInterface, currentVoiceCommands, voiceCommands, new VoiceCommandUpdateOperation.VoiceCommandChangesListener() {
+        updateOperation = new VoiceCommandUpdateOperation(internalInterface, currentVoiceCommands, this.voiceCommands, new VoiceCommandUpdateOperation.VoiceCommandChangesListener() {
             @Override
             public void updateVoiceCommands(List<VoiceCommand> newCurrentVoiceCommands, HashMap<RPCRequest, String> errorObject) {
                 DebugTool.logInfo(TAG, "The updated list of VoiceCommands: " + newCurrentVoiceCommands);
@@ -192,6 +200,24 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
         for (VoiceCommand command : voiceCommands) {
             command.setCommandId(++lastVoiceCommandId);
         }
+    }
+
+    List<VoiceCommand> removeEmptyVoiceCommands(List<VoiceCommand> voiceCommands) {
+        List<VoiceCommand> validatedVoiceCommands = new ArrayList<>();
+        for (VoiceCommand voiceCommand : voiceCommands) {
+            List<String> voiceCommandStrings = new ArrayList<>();
+            for (String voiceCommandString : voiceCommand.getVoiceCommands()) {
+                String trimmedString = voiceCommandString.trim();
+                if (trimmedString.length() > 0) {
+                    voiceCommandStrings.add(trimmedString);
+                }
+            }
+            if (voiceCommandStrings.size() > 0) {
+                voiceCommand.setVoiceCommands(voiceCommandStrings);
+                validatedVoiceCommands.add(voiceCommand);
+            }
+        }
+        return validatedVoiceCommands;
     }
 
     // LISTENERS

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
@@ -144,7 +144,7 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
 
         List<VoiceCommand> validatedVoiceCommands = removeEmptyVoiceCommands(voiceCommands);
 
-        if (validatedVoiceCommands.size() == 0 && voiceCommands.size() > 0) {
+        if (validatedVoiceCommands.size() == 0) {
             DebugTool.logError(TAG, "New voice commands are invalid, skipping...");
             return;
         }
@@ -205,8 +205,14 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
     List<VoiceCommand> removeEmptyVoiceCommands(List<VoiceCommand> voiceCommands) {
         List<VoiceCommand> validatedVoiceCommands = new ArrayList<>();
         for (VoiceCommand voiceCommand : voiceCommands) {
+            if (voiceCommand == null) {
+                continue;
+            }
             List<String> voiceCommandStrings = new ArrayList<>();
             for (String voiceCommandString : voiceCommand.getVoiceCommands()) {
+                if (voiceCommandString == null) {
+                    continue;
+                }
                 String trimmedString = voiceCommandString.trim();
                 if (trimmedString.length() > 0) {
                     voiceCommandStrings.add(trimmedString);

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
@@ -137,15 +137,15 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
             return;
         }
 
-        if (!isVoiceCommandsUnique(voiceCommands)) {
-            DebugTool.logError(TAG, "Not all voice command strings are unique across all voice commands. Voice commands will not be set.");
-            return;
-        }
-
         List<VoiceCommand> validatedVoiceCommands = removeEmptyVoiceCommands(voiceCommands);
 
         if (validatedVoiceCommands.size() == 0) {
             DebugTool.logError(TAG, "New voice commands are invalid, skipping...");
+            return;
+        }
+
+        if (!isVoiceCommandsUnique(validatedVoiceCommands)) {
+            DebugTool.logError(TAG, "Not all voice command strings are unique across all voice commands. Voice commands will not be set.");
             return;
         }
 

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
@@ -205,9 +205,6 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
     List<VoiceCommand> removeEmptyVoiceCommands(List<VoiceCommand> voiceCommands) {
         List<VoiceCommand> validatedVoiceCommands = new ArrayList<>();
         for (VoiceCommand voiceCommand : voiceCommands) {
-            if (voiceCommand == null) {
-                continue;
-            }
             List<String> voiceCommandStrings = new ArrayList<>();
             for (String voiceCommandString : voiceCommand.getVoiceCommands()) {
                 if (voiceCommandString == null) {
@@ -275,6 +272,10 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
         int voiceCommandCount = 0;
 
         for (VoiceCommand voiceCommand : voiceCommands) {
+            if (voiceCommand == null) {
+                voiceCommands.remove(voiceCommand);
+                continue;
+            }
             voiceCommandHashSet.addAll(voiceCommand.getVoiceCommands());
             voiceCommandCount += voiceCommand.getVoiceCommands().size();
         }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
@@ -205,6 +205,9 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
     List<VoiceCommand> removeEmptyVoiceCommands(List<VoiceCommand> voiceCommands) {
         List<VoiceCommand> validatedVoiceCommands = new ArrayList<>();
         for (VoiceCommand voiceCommand : voiceCommands) {
+            if (voiceCommand == null) {
+                continue;
+            }
             List<String> voiceCommandStrings = new ArrayList<>();
             for (String voiceCommandString : voiceCommand.getVoiceCommands()) {
                 if (voiceCommandString == null) {
@@ -273,7 +276,6 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
 
         for (VoiceCommand voiceCommand : voiceCommands) {
             if (voiceCommand == null) {
-                voiceCommands.remove(voiceCommand);
                 continue;
             }
             voiceCommandHashSet.addAll(voiceCommand.getVoiceCommands());


### PR DESCRIPTION
Fixes #1675

This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
Unit tests were added to VoiceCommandManagerTests.java

#### Core Tests
Test sending voice commands with extra white space on the front and back for example: "  command one  ", verify that extra white space is removed and the uploaded voice command is:  "command one"
Test sending two voice commands one with an empty string set like " " and one normal one, verify that only the normal voice command is sent to the update operation.
Test sending voice commands only with empty strings, like "   ". Verify that an error message is printed out in the logs: "New voice commands are invalid, skipping..."

Core version / branch / commit hash / module tested against: Core 7.1.1
HMI name / version / branch / commit hash / module tested against: Sdl_HMI 5.5.1

### Summary
Stripped extra white space from voice commands.
Removes empty strings from being sent in voice commands.

### Changelog
##### Enhancements
* Stripped extra white space from voice commands.
* Removes empty strings from being sent in voice commands.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
