### PR TITLE
Move exception reporting to debugtool

### DIFF
--- a/base/src/main/java/com/smartdevicelink/exception/SdlException.java
+++ b/base/src/main/java/com/smartdevicelink/exception/SdlException.java
@@ -71,7 +71,6 @@ public class SdlException extends Exception {
         }
         if (detail != null) {
             ret += "\nnested: " + detail.toString();
-            detail.printStackTrace();
         }
         return ret;
     }

--- a/base/src/main/java/com/smartdevicelink/managers/BaseSdlManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/BaseSdlManager.java
@@ -205,7 +205,7 @@ abstract class BaseSdlManager {
                             try {
                                 DebugTool.logInfo(TAG, response.serializeJSON().toString());
                             } catch (JSONException e) {
-                                e.printStackTrace();
+                                DebugTool.logError(TAG, "Error attempting to serialize ChangeRegistrationResponse", e);
                             }
 
                             // go through and change sdlManager properties that were changed via the LCU update

--- a/base/src/main/java/com/smartdevicelink/managers/file/UploadFileOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/file/UploadFileOperation.java
@@ -43,6 +43,7 @@ import com.smartdevicelink.proxy.RPCResponse;
 import com.smartdevicelink.proxy.rpc.PutFile;
 import com.smartdevicelink.proxy.rpc.PutFileResponse;
 import com.smartdevicelink.proxy.rpc.listeners.OnRPCResponseListener;
+import com.smartdevicelink.util.DebugTool;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -221,7 +222,7 @@ class UploadFileOperation extends Task {
         try {
             this.inputStream.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            DebugTool.logError(TAG,"Error attempting to close input stream", e);
         }
     }
 
@@ -330,7 +331,7 @@ class UploadFileOperation extends Task {
         try {
             bytesRead = inputStream.read(buffer, 0, size);
         } catch (IOException e) {
-            e.printStackTrace();
+            DebugTool.logError(TAG,"Error attempting to read from input stream", e);
         }
 
         if (bytesRead > 0) {
@@ -365,7 +366,7 @@ class UploadFileOperation extends Task {
             try {
                 size = inputStream.available();
             } catch (IOException e) {
-                e.printStackTrace();
+                DebugTool.logError(TAG,"Error trying to get input stream size", e);
             }
         }
         return size;

--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
@@ -146,7 +146,7 @@ abstract class BaseLifecycleManager {
         try {
             session.startSession();
         } catch (SdlException e) {
-            e.printStackTrace();
+            DebugTool.logError(TAG,"Error attempting to start session", e);
         }
     }
 
@@ -851,7 +851,7 @@ abstract class BaseLifecycleManager {
             session.sendMessage(pm);
 
         } catch (OutOfMemoryError e) {
-            e.printStackTrace();
+            DebugTool.logError(TAG,"Error attempting to send RPC message.", e);
         }
     }
 

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseMenuManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseMenuManager.java
@@ -1275,7 +1275,7 @@ abstract class BaseMenuManager extends BaseSubManager {
                     try {
                         DebugTool.logInfo(TAG, "Main Menu response: " + response.serializeJSON().toString());
                     } catch (JSONException e) {
-                        e.printStackTrace();
+                        DebugTool.logError(TAG,"Error attempting to serialize JSON of RPC response", e);
                     }
                 } else {
                     DebugTool.logError(TAG, "Result: " + response.getResultCode() + " Info: " + response.getInfo());
@@ -1313,7 +1313,7 @@ abstract class BaseMenuManager extends BaseSubManager {
                     try {
                         DebugTool.logInfo(TAG, "Sub Menu response: " + response.serializeJSON().toString());
                     } catch (JSONException e) {
-                        e.printStackTrace();
+                        DebugTool.logError(TAG,"Error attempting to serialize JSON of RPC response", e);
                     }
                 } else {
                     DebugTool.logError(TAG, "Failed to send sub menu commands: " + response.getInfo());
@@ -1365,7 +1365,7 @@ abstract class BaseMenuManager extends BaseSubManager {
                     try {
                         DebugTool.logInfo(TAG, "Dynamic Sub Menu response: " + response.serializeJSON().toString());
                     } catch (JSONException e) {
-                        e.printStackTrace();
+                        DebugTool.logError(TAG,"Error attempting to serialize JSON of RPC response", e);
                     }
                 } else {
                     DebugTool.logError(TAG, "Result: " + response.getResultCode() + " Info: " + response.getInfo());

--- a/base/src/main/java/com/smartdevicelink/proxy/RPCStruct.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/RPCStruct.java
@@ -50,6 +50,8 @@ import java.util.List;
 import java.util.Set;
 
 public class RPCStruct implements Cloneable {
+    private static final String TAG = "RPCStruct";
+
     public static final String KEY_BULK_DATA = "bulkData";
     public static final String KEY_PROTECTED = "protected";
 
@@ -268,7 +270,7 @@ public class RPCStruct implements Cloneable {
 
                 return customObject;
             } catch (Exception e) {
-                e.printStackTrace();
+                DebugTool.logError(TAG,"Error attempting to format an object from a Hashtable", e);
             }
         } else if (obj instanceof List<?>) {
             List<?> list = (List<?>) obj;
@@ -300,7 +302,7 @@ public class RPCStruct implements Cloneable {
                             }
                             newList.add(customObject);
                         } catch (Exception e) {
-                            e.printStackTrace();
+                            DebugTool.logError(TAG,"Error attempting to format object from list of Hashtables", e);
                             return null;
                         }
                     }
@@ -334,15 +336,15 @@ public class RPCStruct implements Cloneable {
         try {
             valueForString = tClass.getDeclaredMethod("valueForString", String.class);
         } catch (NoSuchMethodException e) {
-            e.printStackTrace();
+            DebugTool.logError(TAG,"Error attempting to find valueForString method in class", e);
         }
         if (valueForString != null) {
             try {
                 return valueForString.invoke(null, (String) s);
             } catch (IllegalAccessException e) {
-                e.printStackTrace();
+                DebugTool.logError(TAG,"Illegal access while using reflection to get enum from string", e);
             } catch (InvocationTargetException e) {
-                e.printStackTrace();
+                DebugTool.logError(TAG,"Error attempting to use method from reflection to get enum from string", e);
             }
         }
         return null;

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/OnSystemRequest.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/OnSystemRequest.java
@@ -179,11 +179,9 @@ public class OnSystemRequest extends RPCNotification {
                 tempBody = getBody(httpJson);
                 tempHeaders = getHeaders(httpJson);
             } catch (JSONException e) {
-                DebugTool.logError(TAG, "HTTPRequest in bulk data was malformed.");
-                e.printStackTrace();
+                DebugTool.logError(TAG, "HTTPRequest in bulk data was malformed.", e);
             } catch (NullPointerException e) {
-                DebugTool.logError(TAG, "Invalid HTTPRequest object in bulk data.");
-                e.printStackTrace();
+                DebugTool.logError(TAG, "Invalid HTTPRequest object in bulk data.", e);
             }
         } else if (RequestType.HTTP.equals(this.getRequestType())) {
             tempHeaders = new Headers();
@@ -209,8 +207,7 @@ public class OnSystemRequest extends RPCNotification {
         try {
             result = httpJson.getString(KEY_BODY);
         } catch (JSONException e) {
-            DebugTool.logError(TAG, KEY_BODY + " key doesn't exist in bulk data.");
-            e.printStackTrace();
+            DebugTool.logError(TAG, KEY_BODY + " key doesn't exist in bulk data.", e);
         }
 
         return result;
@@ -224,8 +221,7 @@ public class OnSystemRequest extends RPCNotification {
             Hashtable<String, Object> httpHeadersHash = JsonRPCMarshaller.deserializeJSONObject(httpHeadersJson);
             result = new Headers(httpHeadersHash);
         } catch (JSONException e) {
-            DebugTool.logError(TAG, KEY_HEADERS + " key doesn't exist in bulk data.");
-            e.printStackTrace();
+            DebugTool.logError(TAG, KEY_HEADERS + " key doesn't exist in bulk data.", e);
         }
 
         return result;

--- a/base/src/main/java/com/smartdevicelink/transport/SiphonServer.java
+++ b/base/src/main/java/com/smartdevicelink/transport/SiphonServer.java
@@ -107,7 +107,7 @@ public class SiphonServer {
         try {
             SiphonServer.closeServer();
         } catch (IOException e) {
-            e.printStackTrace();
+            DebugTool.logError(TAG,"Error while trying to close siphon server", e);
         }
 
         return m_listenPort;

--- a/base/src/main/java/com/smartdevicelink/util/FileUtls.java
+++ b/base/src/main/java/com/smartdevicelink/util/FileUtls.java
@@ -74,7 +74,7 @@ public class FileUtls {
                 try {
                     return Files.readAllBytes(file.toPath());
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    DebugTool.logError(TAG,"Error trying to get file data", e);
                 }
             }
         }


### PR DESCRIPTION
Fixes #1687 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR


### Summary
This PR makes exception reporting consistent in that the library uses the `DebugTool` only to print out known exceptions that occur. This also gives the chance to add a little more description to the occurence. 

### Changelog

##### Enhancements
* `DebugTool.e()` is used instead of `e.printStackTrace()` to report/print exceptions


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
