### PR TITLE
Fix to avoid deleting and setting identical voice commands

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/VoiceCommandManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/VoiceCommandManagerTests.java
@@ -182,7 +182,7 @@ public class VoiceCommandManagerTests {
 
         // Fake onCommand - we want to make sure that we can pass back onCommand events to our VoiceCommand Objects
         OnCommand onCommand = new OnCommand();
-        onCommand.setCmdID(command3.getCommandId());
+        onCommand.setCmdID(voiceCommandManager.getVoiceCommands().get(voiceCommandManager.getVoiceCommands().indexOf(command3)).getCommandId());
         onCommand.setTriggerSource(TriggerSource.TS_VR); // these are voice commands
         commandListener.onNotified(onCommand); // send off the notification
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/VoiceCommandManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/VoiceCommandManagerTests.java
@@ -39,6 +39,7 @@ import com.smartdevicelink.managers.BaseSubManager;
 import com.smartdevicelink.managers.CompletionListener;
 import com.smartdevicelink.managers.ISdl;
 import com.smartdevicelink.protocol.enums.FunctionID;
+import com.smartdevicelink.proxy.RPCRequest;
 import com.smartdevicelink.proxy.rpc.OnCommand;
 import com.smartdevicelink.proxy.rpc.OnHMIStatus;
 import com.smartdevicelink.proxy.rpc.enums.HMILevel;
@@ -55,6 +56,7 @@ import org.mockito.stubbing.Answer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
 import static junit.framework.TestCase.assertEquals;
@@ -175,6 +177,8 @@ public class VoiceCommandManagerTests {
     public void testUpdatingCommands() {
         // Send a new single command, and test that its listener works, as it gets called from the VCM
         voiceCommandManager.setVoiceCommands(Collections.singletonList(command3));
+        HashMap<RPCRequest, String> errorObject = new HashMap<>();
+        voiceCommandManager.updateOperation.voiceCommandListener.updateVoiceCommands(voiceCommandManager.voiceCommands, errorObject);
 
         // Fake onCommand - we want to make sure that we can pass back onCommand events to our VoiceCommand Objects
         OnCommand onCommand = new OnCommand();

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/VoiceCommandUpdateOperationTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/VoiceCommandUpdateOperationTests.java
@@ -8,7 +8,6 @@ import com.smartdevicelink.proxy.rpc.AddCommand;
 import com.smartdevicelink.proxy.rpc.AddCommandResponse;
 import com.smartdevicelink.proxy.rpc.DeleteCommand;
 import com.smartdevicelink.proxy.rpc.DeleteCommandResponse;
-import com.smartdevicelink.proxy.rpc.ListFiles;
 import com.smartdevicelink.proxy.rpc.listeners.OnMultipleRequestListener;
 import com.smartdevicelink.util.DebugTool;
 
@@ -76,20 +75,6 @@ public class VoiceCommandUpdateOperationTests {
     List<VoiceCommand> deleteList = new ArrayList<>();
     List<VoiceCommand> addList = new ArrayList<>();
 
-    private Answer<Void> onListFilesSuccess = new Answer<Void>() {
-        @Override
-        public Void answer(InvocationOnMock invocation) {
-            Object[] args = invocation.getArguments();
-            RPCRequest message = (RPCRequest) args[0];
-            if (message instanceof ListFiles) {
-                int correlationId = message.getCorrelationID();
-                DeleteCommandResponse deleteCommandResponse = new DeleteCommandResponse();
-                deleteCommandResponse.setSuccess(true);
-                message.getOnRPCResponseListener().onResponse(correlationId, deleteCommandResponse);
-            }
-            return null;
-        }
-    };
 
     @Before
     public void setup() {

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/VoiceCommandUpdateOperationTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/VoiceCommandUpdateOperationTests.java
@@ -294,4 +294,29 @@ public class VoiceCommandUpdateOperationTests {
 
         verify(listenerSpy, times(1)).updateVoiceCommands(any(List.class), any(HashMap.class));
     }
+
+
+
+    @Test
+    public void testVoiceCommandsInListNotInSecondList() {
+        VoiceCommand command1 = new VoiceCommand(Collections.singletonList("Command 1"), null);
+        VoiceCommand command2 = new VoiceCommand(Collections.singletonList("Command 2"), null);
+        VoiceCommand command3 = new VoiceCommand(Collections.singletonList("Command 3"), null);
+
+        VoiceCommand command1Clone = new VoiceCommand(Collections.singletonList("Command 1"), null);
+
+        List<VoiceCommand> voiceCommandList = new ArrayList<>();
+        voiceCommandList.add(command1);
+        voiceCommandList.add(command2);
+
+        List<VoiceCommand> voiceCommandList2 = new ArrayList<>();
+        voiceCommandList2.add(command1Clone);
+        voiceCommandList2.add(command3);
+        VoiceCommandUpdateOperation voiceCommandUpdateOperation = new VoiceCommandUpdateOperation(internalInterface,null,null,null);
+
+        List<VoiceCommand> differencesList = voiceCommandUpdateOperation.voiceCommandsInListNotInSecondList(voiceCommandList, voiceCommandList2);
+        assertEquals(differencesList.size(), 1);
+
+    }
+
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/VoiceCommandUpdateOperationTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/VoiceCommandUpdateOperationTests.java
@@ -8,12 +8,14 @@ import com.smartdevicelink.proxy.rpc.AddCommand;
 import com.smartdevicelink.proxy.rpc.AddCommandResponse;
 import com.smartdevicelink.proxy.rpc.DeleteCommand;
 import com.smartdevicelink.proxy.rpc.DeleteCommandResponse;
+import com.smartdevicelink.proxy.rpc.ListFiles;
 import com.smartdevicelink.proxy.rpc.listeners.OnMultipleRequestListener;
 import com.smartdevicelink.util.DebugTool;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -73,6 +75,21 @@ public class VoiceCommandUpdateOperationTests {
 
     List<VoiceCommand> deleteList = new ArrayList<>();
     List<VoiceCommand> addList = new ArrayList<>();
+
+    private Answer<Void> onListFilesSuccess = new Answer<Void>() {
+        @Override
+        public Void answer(InvocationOnMock invocation) {
+            Object[] args = invocation.getArguments();
+            RPCRequest message = (RPCRequest) args[0];
+            if (message instanceof ListFiles) {
+                int correlationId = message.getCorrelationID();
+                DeleteCommandResponse deleteCommandResponse = new DeleteCommandResponse();
+                deleteCommandResponse.setSuccess(true);
+                message.getOnRPCResponseListener().onResponse(correlationId, deleteCommandResponse);
+            }
+            return null;
+        }
+    };
 
     @Before
     public void setup() {
@@ -316,7 +333,28 @@ public class VoiceCommandUpdateOperationTests {
 
         List<VoiceCommand> differencesList = voiceCommandUpdateOperation.voiceCommandsInListNotInSecondList(voiceCommandList, voiceCommandList2);
         assertEquals(differencesList.size(), 1);
+    }
 
+    @Test
+    public void testDelete() {
+        internalInterface = mock(ISdl.class);
+
+        VoiceCommand command1 = new VoiceCommand(Collections.singletonList("Command 1"), null);
+        VoiceCommand command2 = new VoiceCommand(Collections.singletonList("Command 2"), null);
+
+        VoiceCommand command1Clone = new VoiceCommand(Collections.singletonList("Command 1"), null);
+        VoiceCommand command3 = new VoiceCommand(Collections.singletonList("Command 3"), null);
+
+        List<VoiceCommand> voiceCommandList = new ArrayList<>();
+        voiceCommandList.add(command1);
+        voiceCommandList.add(command2);
+
+        List<VoiceCommand> voiceCommandList2 = new ArrayList<>();
+        voiceCommandList2.add(command1Clone);
+        voiceCommandList2.add(command3);
+        VoiceCommandUpdateOperation voiceCommandUpdateOperation = new VoiceCommandUpdateOperation(internalInterface, voiceCommandList, voiceCommandList2, null);
+        voiceCommandUpdateOperation.onExecute();
+        verify(internalInterface, times(1)).sendRPCs(ArgumentMatchers.<DeleteCommand>anyList(), any(OnMultipleRequestListener.class));
     }
 
 }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
@@ -56,7 +56,7 @@ import java.util.List;
 
 abstract class BaseVoiceCommandManager extends BaseSubManager {
     private static final String TAG = "BaseVoiceCommandManager";
-    List<VoiceCommand> voiceCommands, currentVoiceCommands, originalVoiceCommands;
+    List<VoiceCommand> voiceCommands, currentVoiceCommands;
 
     int lastVoiceCommandId;
     private static final int voiceCommandIdMin = 1900000000;
@@ -132,12 +132,18 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
     public void setVoiceCommands(List<VoiceCommand> voiceCommands) {
 
         // we actually need voice commands to set.
-        if (voiceCommands == null || voiceCommands.equals(this.originalVoiceCommands)) {
-            DebugTool.logInfo(TAG, "Voice commands list was null or matches the current voice commands");
+        if (voiceCommands == null) {
+            DebugTool.logInfo(TAG, "Voice commands list was null");
             return;
         }
 
-        List<VoiceCommand> validatedVoiceCommands = removeEmptyVoiceCommands(voiceCommands);
+        // Clone voice commands
+        this.voiceCommands = new ArrayList<>();
+        for (VoiceCommand voiceCommand : voiceCommands) {
+            this.voiceCommands.add(voiceCommand.clone());
+        }
+
+        List<VoiceCommand> validatedVoiceCommands = removeEmptyVoiceCommands(this.voiceCommands);
 
         if (validatedVoiceCommands.size() == 0) {
             DebugTool.logError(TAG, "New voice commands are invalid, skipping...");
@@ -147,10 +153,9 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
         if (!isVoiceCommandsUnique(validatedVoiceCommands)) {
             DebugTool.logError(TAG, "Not all voice command strings are unique across all voice commands. Voice commands will not be set.");
             return;
+
         }
 
-        this.originalVoiceCommands = new ArrayList<>(voiceCommands);
-        this.voiceCommands = validatedVoiceCommands;
         updateIdsOnVoiceCommands(this.voiceCommands);
 
         cleanTransactionQueue();

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
@@ -145,7 +145,7 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
 
         List<VoiceCommand> validatedVoiceCommands = removeEmptyVoiceCommands(this.voiceCommands);
 
-        if (validatedVoiceCommands.size() == 0) {
+        if (validatedVoiceCommands.size() == 0 && voiceCommands.size() > 0) {
             DebugTool.logError(TAG, "New voice commands are invalid, skipping...");
             return;
         }
@@ -153,7 +153,6 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
         if (!isVoiceCommandsUnique(validatedVoiceCommands)) {
             DebugTool.logError(TAG, "Not all voice command strings are unique across all voice commands. Voice commands will not be set.");
             return;
-
         }
 
         updateIdsOnVoiceCommands(this.voiceCommands);

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
@@ -182,7 +182,7 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
                 continue;
             }
             VoiceCommandUpdateOperation vcOperation = (VoiceCommandUpdateOperation) operation;
-            vcOperation.oldVoiceCommands = newCurrentVoiceCommands;
+            vcOperation.setOldVoiceCommands(newCurrentVoiceCommands);
         }
     }
 
@@ -217,8 +217,8 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
             @Override
             public void onNotified(RPCNotification notification) {
                 OnCommand onCommand = (OnCommand) notification;
-                if (voiceCommands != null && voiceCommands.size() > 0) {
-                    for (VoiceCommand command : voiceCommands) {
+                if (currentVoiceCommands != null && currentVoiceCommands.size() > 0) {
+                    for (VoiceCommand command : currentVoiceCommands) {
                         if (onCommand.getCmdID() == command.getCommandId()) {
                             if (command.getVoiceCommandSelectionListener() != null) {
                                 command.getVoiceCommandSelectionListener().onVoiceCommandSelected();

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
@@ -140,6 +140,9 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
         // Clone voice commands
         this.voiceCommands = new ArrayList<>();
         for (VoiceCommand voiceCommand : voiceCommands) {
+            if (voiceCommand == null) {
+                continue;
+            }
             this.voiceCommands.add(voiceCommand.clone());
         }
 
@@ -147,13 +150,17 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
 
         if (validatedVoiceCommands.size() == 0 && voiceCommands.size() > 0) {
             DebugTool.logError(TAG, "New voice commands are invalid, skipping...");
+            this.voiceCommands = null;
             return;
         }
 
         if (!isVoiceCommandsUnique(validatedVoiceCommands)) {
             DebugTool.logError(TAG, "Not all voice command strings are unique across all voice commands. Voice commands will not be set.");
+            this.voiceCommands = null;
             return;
         }
+
+        this.voiceCommands = validatedVoiceCommands;
 
         updateIdsOnVoiceCommands(this.voiceCommands);
 

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/VoiceCommand.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/VoiceCommand.java
@@ -36,11 +36,13 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 
+import com.smartdevicelink.util.DebugTool;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
-public class VoiceCommand {
+public class VoiceCommand implements Cloneable {
 
     /**
      * The strings the user can say to activate this voice command
@@ -161,5 +163,23 @@ public class VoiceCommand {
         if (!(o instanceof VoiceCommand)) return false;
         // return comparison
         return hashCode() == o.hashCode();
+    }
+
+    /**
+     * Creates a deep copy of the object
+     *
+     * @return deep copy of the object, null if an exception occurred
+     */
+    @Override
+    public VoiceCommand clone() {
+        try {
+            VoiceCommand clone = (VoiceCommand) super.clone();
+            return clone;
+        } catch (CloneNotSupportedException e) {
+            if (DebugTool.isDebugEnabled()) {
+                throw new RuntimeException("Clone not supported by super class");
+            }
+        }
+        return null;
     }
 }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/VoiceCommand.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/VoiceCommand.java
@@ -140,9 +140,8 @@ public class VoiceCommand {
     @Override
     public int hashCode() {
         int result = 1;
-        result += Integer.rotateLeft(getCommandId(), 1);
         for (int i = 0; i < this.getVoiceCommands().size(); i++) {
-            result += ((getVoiceCommands().get(i) == null) ? 0 : Integer.rotateLeft(getVoiceCommands().get(i).hashCode(), i + 2));
+            result += ((getVoiceCommands().get(i) == null) ? 0 : Integer.rotateLeft(getVoiceCommands().get(i).hashCode(), i + 1));
         }
         return result;
     }
@@ -158,7 +157,7 @@ public class VoiceCommand {
         if (o == null) return false;
         // if this is the same memory address, it's the same
         if (this == o) return true;
-        // if this is not an instance of SoftButtonObject, not the same
+        // if this is not an instance of VoiceCommand, not the same
         if (!(o instanceof VoiceCommand)) return false;
         // return comparison
         return hashCode() == o.hashCode();

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/VoiceCommandUpdateOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/VoiceCommandUpdateOperation.java
@@ -53,6 +53,15 @@ class VoiceCommandUpdateOperation extends Task {
             onFinished();
             return;
         }
+        // Check if a voiceCommand has already been uploaded and update its VoiceCommandSelectionListener to
+        // prevent calling the wrong listener in a case where a voice command was uploaded and then its voiceCommandSelectionListener was updated in another upload.
+        if (pendingVoiceCommands != null && pendingVoiceCommands.size() > 0) {
+            for (VoiceCommand voiceCommand : pendingVoiceCommands) {
+                if (currentVoiceCommands.contains(voiceCommand)) {
+                    currentVoiceCommands.get(currentVoiceCommands.indexOf(voiceCommand)).setVoiceCommandSelectionListener(voiceCommand.getVoiceCommandSelectionListener());
+                }
+            }
+        }
 
         sendDeleteCurrentVoiceCommands(new CompletionListener() {
             @Override
@@ -169,7 +178,7 @@ class VoiceCommandUpdateOperation extends Task {
 
         if (voiceCommandsToAdd.size() == 0) {
             if (listener != null) {
-                listener.onComplete(true); // no voice commands to send doesnt mean that its an error
+                listener.onComplete(true); // no voice commands to send doesn't mean that its an error
             }
             return;
         }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/VoiceCommandUpdateOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/VoiceCommandUpdateOperation.java
@@ -22,7 +22,7 @@ class VoiceCommandUpdateOperation extends Task {
     private List<VoiceCommand> pendingVoiceCommands;
     private List<DeleteCommand> deleteVoiceCommands;
     private List<AddCommand> addCommandsToSend;
-    private VoiceCommandChangesListener voiceCommandListener;
+    VoiceCommandChangesListener voiceCommandListener;
     private List<VoiceCommand> currentVoiceCommands;
     private HashMap<RPCRequest, String> errorObject;
 


### PR DESCRIPTION
Fixes #1676 

This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
Unit test were added in `VoiceCommandUpdateOperationTests.java`

#### Core Tests
TEST:

Test 1:
VoiceCommandA = "command one"
VoiceCommandB = "command two"
Upload A and B on startup
VoiceCommandC = "command one"
VoiceCommandD = "command four"
Upload C and D in a menuSelection listener.
Verify Voice commands on HMI are "command one" and "command four"
Verify that when "command one" is selected the listener for VoiceCommandC is triggered.

Test2: 
Upload A on startup
VoiceCommandA = "command one"
Upload C in a menuSelection listener.
VoiceCommandC = "command one"

Verify that when "command one" is selected the listener for VoiceCommandC is triggered.

Test3:
Upload A on startup
VoiceCommandA = "command one"
After A is uploaded, modify VoiceCommandA to have a new listener and upload it in something like a menuSelectionListener
Verify that when "command one" is selected the updated listener is triggered.

Test 4:
VoiceCommandA = "command one"
VoiceCommandB = "command two"
Upload A and B.
After A is uploaded, modify VoiceCommandA to have a new listener and upload it in something like a menuSelectionListener.
Verify that VoiceCommandB("command two") is removed form the hmi.
Verify that when "command one" is selected the updated listener is triggered.

Test 5:
Upload A on startup
VoiceCommandA = "command one"
After A is uploaded, modify VoiceCommandA to : "command one changed"
Verify that "Command one" is deleted and "Command one changed appears.
REPEAT THIS TEST WITH A NEW LISTENER AS WELL.

Test 6:
Upload voiceCommadA on startup
VoiceCommandA = "command one"
After A is uploaded, upload an empty list for voiceCommands
Verify that voiceCommadA is removed

Core version / branch / commit hash / module tested against: [INSERT]
HMI name / version / branch / commit hash / module tested against: [INSERT]

### Summary
Modified logic in VoiceCommandManager to not check if voiceCommands are equal to old voice Commands since the new voiceCommands could have different listeners, and moved that logic to VoiceCommandUpdateOperation.
Now if you upload `VoiceCommands` and change a listener and upload them again, the command doesn't get resent to core, the listener just gets updated. 

Also added logic to not upload identical voiceCommands.

Added clone 

### Changelog
##### Enhancements
* Added logic to avoid deleting and setting identical voice commands

##### Bug Fixes
* Added clone method to 'VoiceCommand"  to allow VoiceCommandManger to properly clone voiceCommands.
* Fixed scenario where voiceCommands couldn't be removed by sending an empty list.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
