### PR TITLE
Update LCM to workaround Sync 3 bug with media capabilities 

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
@@ -52,6 +52,7 @@ import com.smartdevicelink.proxy.RPCMessage;
 import com.smartdevicelink.proxy.RPCNotification;
 import com.smartdevicelink.proxy.RPCRequest;
 import com.smartdevicelink.proxy.RPCResponse;
+import com.smartdevicelink.proxy.rpc.DisplayCapabilities;
 import com.smartdevicelink.proxy.rpc.GenericResponse;
 import com.smartdevicelink.proxy.rpc.OnAppInterfaceUnregistered;
 import com.smartdevicelink.proxy.rpc.OnButtonEvent;
@@ -61,6 +62,8 @@ import com.smartdevicelink.proxy.rpc.OnSystemRequest;
 import com.smartdevicelink.proxy.rpc.RegisterAppInterface;
 import com.smartdevicelink.proxy.rpc.RegisterAppInterfaceResponse;
 import com.smartdevicelink.proxy.rpc.SdlMsgVersion;
+import com.smartdevicelink.proxy.rpc.SetDisplayLayout;
+import com.smartdevicelink.proxy.rpc.SetDisplayLayoutResponse;
 import com.smartdevicelink.proxy.rpc.SubscribeButton;
 import com.smartdevicelink.proxy.rpc.SystemRequest;
 import com.smartdevicelink.proxy.rpc.TTSChunk;
@@ -73,6 +76,7 @@ import com.smartdevicelink.proxy.rpc.enums.ButtonName;
 import com.smartdevicelink.proxy.rpc.enums.FileType;
 import com.smartdevicelink.proxy.rpc.enums.HMILevel;
 import com.smartdevicelink.proxy.rpc.enums.Language;
+import com.smartdevicelink.proxy.rpc.enums.PredefinedLayout;
 import com.smartdevicelink.proxy.rpc.enums.RequestType;
 import com.smartdevicelink.proxy.rpc.enums.Result;
 import com.smartdevicelink.proxy.rpc.enums.SdlDisconnectedReason;
@@ -132,6 +136,8 @@ abstract class BaseLifecycleManager {
     BaseTransportConfig _transportConfig;
     private Taskmaster taskmaster;
     private boolean didCheckSystemInfo = false;
+    String lastDisplayLayoutRequestTemplate;
+    DisplayCapabilities initialMediaCapabilities;
 
     BaseLifecycleManager(AppConfig appConfig, BaseTransportConfig config, LifecycleListener listener) {
         this.appConfig = appConfig;
@@ -404,6 +410,10 @@ abstract class BaseLifecycleManager {
                             }
                             //If the vehicle is acceptable and this is the first check, init security lib
                             setSecurityLibraryIfAvailable(vehicleType);
+                        }
+                        // HAX: Issue #1690, Ford Sync bug returning incorrect display capabilities (https://github.com/smartdevicelink/sdl_java_suite/issues/1690). Store the initial capabilities if we are a media app so that we can use them in the future.
+                        if (appConfig.appType.contains(AppHMIType.MEDIA)) {
+                            initialMediaCapabilities = raiResponse.getDisplayCapabilities();
                         }
                         systemCapabilityManager.parseRAIResponse(raiResponse);
                         break;
@@ -825,6 +835,10 @@ abstract class BaseLifecycleManager {
                         addOnRPCResponseListener(listener, corrId);
                     }
                 }
+                // HAX: Issue #1690, Ford Sync bug returning incorrect display capabilities (https://github.com/smartdevicelink/sdl_java_suite/issues/1690). Save the next desired layout type to the update capabilities when the SetDisplayLayout response is received
+                if (FunctionID.SET_DISPLAY_LAYOUT.toString().equals(message.getFunctionName())) {
+                    lastDisplayLayoutRequestTemplate = ((SetDisplayLayout)message).getDisplayLayout();
+                }
             } else if (RPCMessage.KEY_RESPONSE.equals(message.getMessageType())) { // Response Specifics
                 RPCResponse response = (RPCResponse) message;
                 pm.setRPCType((byte) 0x01);
@@ -855,6 +869,16 @@ abstract class BaseLifecycleManager {
         }
     }
 
+    // HAX: Issue #1690, Ford Sync bug returning incorrect display capabilities (https://github.com/smartdevicelink/sdl_java_suite/issues/1690). Use the initial capabilities from RAIR instead of the incorrect ones that are included in SetDisplayLayoutResponse.
+    void fixIncorrectDisplayCapabilities(RPCMessage rpc) {
+        if (RPCMessage.KEY_RESPONSE.equals(rpc.getMessageType()) && rpc.getFunctionName().equals(FunctionID.SET_DISPLAY_LAYOUT.toString()) &&
+                initialMediaCapabilities != null && lastDisplayLayoutRequestTemplate.equals(PredefinedLayout.MEDIA.toString())) {
+
+            SetDisplayLayoutResponse setDisplayLayoutResponse = (SetDisplayLayoutResponse) rpc;
+            setDisplayLayoutResponse.setDisplayCapabilities(initialMediaCapabilities);
+        }
+    }
+
     /* *******************************************************************************************************
      **************************************** ISdlSessionListener START **************************************
      *********************************************************************************************************/
@@ -874,6 +898,8 @@ abstract class BaseLifecycleManager {
                 DebugTool.logInfo(TAG, "RPC received - " + messageType);
 
                 rpc.format(rpcSpecVersion, true);
+
+                fixIncorrectDisplayCapabilities(rpc);
 
                 BaseLifecycleManager.this.onRPCReceived(rpc);
 
@@ -1197,6 +1223,8 @@ abstract class BaseLifecycleManager {
     void clean() {
         firstTimeFull = true;
         currentHMIStatus = null;
+        lastDisplayLayoutRequestTemplate = null;
+        initialMediaCapabilities = null;
         if (rpcListeners != null) {
             rpcListeners.clear();
         }


### PR DESCRIPTION
Fixes #1690

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Unit Tests
Added unit tests to test the workaround logic 

#### Core Tests
On Sync 3.0:

1. Connect a media app, it will start on the media template
2. Change the layout to something else, like textAndGraphic
3. Change the layout back to MEDIA
4. Try to show another image and confirm it appears 

Core version / branch / commit hash / module tested against: 7.1.1
HMI name / version / branch / commit hash / module tested against: Generic HMI 0.10.0

### Summary
This PR updates the `LifecycleManager` to replace the incorrect capabilities that are included in the `SetDisplayLayoutResponse` for MEDIA apps with the ones from `RegisterAppInterfaceResponse` as a workaround to fix a bug in SYNC3.

### Changelog
#### Bug Fixes
Workaround for a Ford Sync 3 bug where doing `SetDisplayLayout` to the MEDIA template would result in incorrect display capabilities being returned that claim the primaryGraphic is not supported.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
