### PR TITLE
Add onClose callbacks after LCM clean() calls

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
@@ -390,6 +390,7 @@ abstract class BaseLifecycleManager {
                             msg.setCorrelationID(UNREGISTER_APP_INTERFACE_CORRELATION_ID);
                             sendRPCMessagePrivate(msg, true);
                             clean();
+                            onClose("RPC spec version not supported: " + rpcSpecVersion.toString(), null, SdlDisconnectedReason.MINIMUM_RPC_VERSION_HIGHER_THAN_SUPPORTED);
                             return;
                         }
                         if (!didCheckSystemInfo && lifecycleListener != null) {
@@ -405,6 +406,7 @@ abstract class BaseLifecycleManager {
                                     msg.setCorrelationID(UNREGISTER_APP_INTERFACE_CORRELATION_ID);
                                     sendRPCMessagePrivate(msg, true);
                                     clean();
+                                    onClose("System not supported", null, SdlDisconnectedReason.DEFAULT);
                                     return;
                                 }
                             }
@@ -491,6 +493,7 @@ abstract class BaseLifecycleManager {
                         if (!onAppInterfaceUnregistered.getReason().equals(AppInterfaceUnregisteredReason.LANGUAGE_CHANGE)) {
                             DebugTool.logInfo(TAG, "on app interface unregistered");
                             clean();
+                            onClose("OnAppInterfaceUnregistered received from head unit", null, SdlDisconnectedReason.APP_INTERFACE_UNREG);
                         } else {
                             DebugTool.logInfo(TAG, "re-registering for language change");
                             cycle(SdlDisconnectedReason.LANGUAGE_CHANGE);
@@ -499,6 +502,7 @@ abstract class BaseLifecycleManager {
                     case UNREGISTER_APP_INTERFACE:
                         DebugTool.logInfo(TAG, "unregister app interface");
                         clean();
+                        onClose("UnregisterAppInterface response received from head unit", null, SdlDisconnectedReason.APP_INTERFACE_UNREG);
                         break;
                 }
             }
@@ -936,6 +940,7 @@ abstract class BaseLifecycleManager {
                 DebugTool.logWarning(TAG, String.format("Disconnecting from head unit, the configured minimum protocol version %s is greater than the supported protocol version %s", minimumProtocolVersion, getProtocolVersion()));
                 session.endService(SessionType.RPC);
                 clean();
+                onClose("Protocol version not supported: " + version, null, SdlDisconnectedReason.MINIMUM_PROTOCOL_VERSION_HIGHER_THAN_SUPPORTED);
                 return;
             }
 
@@ -946,6 +951,7 @@ abstract class BaseLifecycleManager {
                     DebugTool.logWarning(TAG, "Disconnecting from head unit, the system info was not accepted.");
                     session.endService(SessionType.RPC);
                     clean();
+                    onClose("System not supported", null, SdlDisconnectedReason.DEFAULT);
                     return;
                 }
                 //If the vehicle is acceptable, init security lib


### PR DESCRIPTION
Fixes #1697 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android


#### Core Tests

Tests performed:
- Minimum protocol version check fail
- Minimum RPC version check fail
- `SystemInfo` check fail
- Sending an `UnregisterAppInterface` and receiving a response
- Receiving an `OnAppInterfaceUnregistered` notification. (Triggered via SDL_HMI ignition cycle)


Test code can be used to trigger an `OnAppInterfaceUnregistered` from the library. In the `BaseLifecycleManager` where RPCs are received, after the RAI processes the following code can be added to trigger a sending of the notification. 

```java
new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
    @Override
    public void run() {
        Log.d(TAG, "Sending OnAppInterfaceUnregistered. Icon may not clear from IVI, but service on phone should end. ");
        OnAppInterfaceUnregistered onAppInterfaceUnregistered = new OnAppInterfaceUnregistered();
        onAppInterfaceUnregistered.setReason(AppInterfaceUnregisteredReason.IGNITION_OFF);
        onReceived(onAppInterfaceUnregistered);
    }
}, 5000);
```


### Summary

There exists a timing issue where the LCM can call for the lower layers to shutdown which will cause a flag to be set in the TransportManager that prevents the `onTransportDisconnected` callback from being triggered. Because of this, no layers above the `TransportManager` are notified. Simply adding the `onClose` call in the LCM after the calls to `clean()` the LCM will trigger the necessary callbacks. 

### Changelog

##### Bug Fixes
* onDestroy of the SdlManagerListener will now be triggered in cases outside of transport disconnect.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
