### PR TITLE
Make lockscreen show again after dismissal if a DD notification is received where DismissalEnabled is false

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lockscreen/LockScreenManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lockscreen/LockScreenManagerTests.java
@@ -1,6 +1,8 @@
 package com.smartdevicelink.managers.lockscreen;
 
 import android.content.Context;
+import android.content.Intent;
+import android.os.Looper;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -168,6 +170,36 @@ public class LockScreenManagerTests {
         onDDListener.onNotified(onDriverDistraction);
         assertFalse(lockScreenManager.enableDismissGesture);
         assertTrue(lockScreenManager.isLockscreenDismissible);
+    }
+
+    @Test
+    public void testShowingLockscreenAfterDismissibleFalse() {
+        if (Looper.myLooper() == null) {
+            Looper.prepare();
+        }
+        lockScreenManager.enableDismissGesture = true;
+        lockScreenManager.displayMode = LockScreenConfig.DISPLAY_MODE_ALWAYS;
+
+        // Send first notification (DD=OFF, Dismissible=true)
+        OnDriverDistraction onDriverDistraction = new OnDriverDistraction();
+        onDriverDistraction.setLockscreenDismissibility(true);
+        onDriverDistraction.setState(DriverDistractionState.DD_OFF);
+        onDDListener.onNotified(onDriverDistraction);
+
+        // Dismiss lock screen activity
+        lockScreenManager.mLockscreenDismissedReceiver.onReceive(null, new Intent(SDLLockScreenActivity.KEY_LOCKSCREEN_DISMISSED, null));
+
+        // Lock screen should be set to auto dismiss in future
+        assertTrue(lockScreenManager.mLockScreenShouldBeAutoDismissed);
+
+        // Send second notification (DD=On, Dismissible=false)
+        onDriverDistraction = new OnDriverDistraction();
+        onDriverDistraction.setLockscreenDismissibility(false);
+        onDriverDistraction.setState(DriverDistractionState.DD_ON);
+        onDDListener.onNotified(onDriverDistraction);
+
+        // Lock screen should be set to NOT auto dismiss in future
+        assertFalse(lockScreenManager.mLockScreenShouldBeAutoDismissed);
     }
 
 }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
@@ -87,9 +87,10 @@ public class LockScreenManager extends BaseSubManager {
     final int customView;
     int displayMode;
     Bitmap deviceLogo;
-    private boolean mLockScreenHasBeenDismissed, lockscreenDismissReceiverRegistered, receivedFirstDDNotification;
+    private boolean lockscreenDismissReceiverRegistered, receivedFirstDDNotification;
+    boolean mLockScreenShouldBeAutoDismissed;
     private String mLockscreenWarningMsg;
-    private BroadcastReceiver mLockscreenDismissedReceiver;
+    BroadcastReceiver mLockscreenDismissedReceiver;
     private final LockScreenDeviceIconManager mLockScreenDeviceIconManager;
     private String lastIntentUsed;
 
@@ -220,6 +221,11 @@ public class LockScreenManager extends BaseSubManager {
                                     // enable the dismissal. There is a delay added to allow time for the activity
                                     // time to completely start and handle the new intent. There seems to be odd behavior
                                     // in Android when startActivity is called multiple times too quickly.
+                                    if (previousDismissibleState) {
+                                        // If lockscreen was dismissible, got dismissed by the user, then became not dismissible, the lockscreen activity should be allowed to launch again
+                                        // https://github.com/smartdevicelink/sdl_java_suite/issues/1695
+                                        mLockScreenShouldBeAutoDismissed = false;
+                                    }
                                     if (!receivedFirstDDNotification) {
                                         new Handler().postDelayed(new Runnable() {
                                             @Override
@@ -296,7 +302,7 @@ public class LockScreenManager extends BaseSubManager {
             @Override
             public void onReceive(Context context, Intent intent) {
                 if (SDLLockScreenActivity.KEY_LOCKSCREEN_DISMISSED.equals(intent.getAction())) {
-                    mLockScreenHasBeenDismissed = true;
+                    mLockScreenShouldBeAutoDismissed = true;
                     lastIntentUsed = null;
                 }
             }
@@ -318,7 +324,7 @@ public class LockScreenManager extends BaseSubManager {
     private void launchLockScreenActivity() {
         synchronized (LOCKSCREEN_LAUNCH_LOCK) {
             // If the user has dismissed the lockscreen for this run or has disabled it, do not show it
-            if (mLockScreenHasBeenDismissed || displayMode == LockScreenConfig.DISPLAY_MODE_NEVER) {
+            if (mLockScreenShouldBeAutoDismissed || displayMode == LockScreenConfig.DISPLAY_MODE_NEVER) {
                 return;
             }
             // intent to open SDLLockScreenActivity


### PR DESCRIPTION
Fixes #1695 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Core Tests
1. Set lockscreen displayMode to ALWAYS
2. Send DriverDistraction to the app with `DD_OFF` and `lockScreenDismissalEnabled = true`
3. The user should be shown a dismissible lockscreen
4. Dismiss the lockScreen
5. Send DriverDistraction to the app with `DD_ON` and `lockScreenDismissalEnabled = false`
6. The lockscreen should be launched again without a dismiss message

Core version / branch / commit hash / module tested against: Core 7.1.1
HMI name / version / branch / commit hash / module tested against: 0.10.0

### Summary
This PR fixes an issue in `LockscreenManager` that prevents lockscreen from showing again after dismissal if a DD notification is received where `DismissalEnabled` is `false`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
