### PR TITLE
Fix PredefinedLayout.NON_MEDIA not found in templatesAvailable

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lifecycle/SystemCapabilityManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lifecycle/SystemCapabilityManagerTests.java
@@ -942,6 +942,31 @@ public class SystemCapabilityManagerTests {
         assertNull(systemCapabilityManager.getWindowCapability(PredefinedWindows.PRIMARY_WIDGET.getValue()));
     }
 
+    /**
+     * Test that when we receive template "NON_MEDIA" it gets converted to "NON-MEDIA"
+     */
+    @Test
+    public void testSyncNonMediaBug() {
+        InternalSDLInterface iSDL = new InternalSDLInterface();
+        SystemCapabilityManager systemCapabilityManager = createSampleManager(iSDL);
+        OnRPCListener dlRpcListener = iSDL.rpcListeners.get(FunctionID.SET_DISPLAY_LAYOUT.getId()).get(0);
+
+        DisplayCapabilities displayCapabilities = new DisplayCapabilities();
+        displayCapabilities.setGraphicSupported(true);
+        List<String> templatesAvailable = new ArrayList<>();
+        templatesAvailable.add("NON_MEDIA");
+        templatesAvailable.add("MEDIA");
+        displayCapabilities.setTemplatesAvailable(templatesAvailable);
+
+        SetDisplayLayoutResponse newLayout = new SetDisplayLayoutResponse();
+        newLayout.setDisplayCapabilities(displayCapabilities);
+        newLayout.setSuccess(true);
+        newLayout.setResultCode(Result.SUCCESS);
+        dlRpcListener.onReceived(newLayout);
+
+        assertTrue(systemCapabilityManager.getDefaultMainWindowCapability().getTemplatesAvailable().contains("NON-MEDIA"));
+    }
+
     private class InternalSDLInterface implements ISdl {
         private final Object RPC_LISTENER_LOCK = new Object();
         SparseArray<CopyOnWriteArrayList<OnRPCListener>> rpcListeners = new SparseArray<>();

--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseSystemCapabilityManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseSystemCapabilityManager.java
@@ -133,8 +133,16 @@ abstract class BaseSystemCapabilityManager {
             return Collections.singletonList(displayCapability);
         }
 
+        // HAX: Issue #1705, Ford Sync bug returning incorrect template name for "NON-MEDIA" (https://github.com/smartdevicelink/sdl_java_suite/issues/1705).
+        List<String> templatesAvailable = display.getTemplatesAvailable();
+        for (int i = 0; i < templatesAvailable.size(); i++) {
+            if (templatesAvailable.get(i).equals("NON_MEDIA")) {
+                templatesAvailable.set(i, "NON-MEDIA");
+                break;
+            }
+        }
         // copy all available display capabilities
-        defaultWindowCapability.setTemplatesAvailable(display.getTemplatesAvailable());
+        defaultWindowCapability.setTemplatesAvailable(templatesAvailable);
         defaultWindowCapability.setNumCustomPresetsAvailable(display.getNumCustomPresetsAvailable());
         defaultWindowCapability.setTextFields(display.getTextFields());
         defaultWindowCapability.setImageFields(display.getImageFields());


### PR DESCRIPTION
Fixes #1705 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
Unit test were added in SystemCapabilityManagerTests.java

#### Core Tests

Tested that if the HMI gives us NON_MEDIA as a template, the library converts it to "NON-MEDIA"
with: 

```
sdlManager.getSystemCapabilityManager().getDefaultMainWindowCapability().getTemplatesAvailable().contains("NON-MEDIA");
```

Core version / branch / commit hash / module tested against: 7.1.1, 
HMI name / version / branch / commit hash / module tested against: Generic_HMI 0.10.0

### Summary
Added "NON-MEDIA" to templatesAvailable In a case where sync's response for templatesAvailable had "NON_MEDIA" instead

### Changelog
##### Bug Fixes
* Added "NON-MEDIA" to templatesAvailable In a case where sync's response for templatesAvailable had "NON_MEDIA" instead


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
