### PR TITLE
Fix MenuManager sending secondary image with menuCells when menuCommandSecondaryImage is not supported

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/MenuManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/MenuManagerTests.java
@@ -43,7 +43,6 @@ import com.smartdevicelink.managers.file.filetypes.SdlArtwork;
 import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.proxy.RPCRequest;
 import com.smartdevicelink.proxy.RPCResponse;
-import com.smartdevicelink.proxy.rpc.ImageField;
 import com.smartdevicelink.proxy.rpc.OnCommand;
 import com.smartdevicelink.proxy.rpc.OnHMIStatus;
 import com.smartdevicelink.proxy.rpc.SdlMsgVersion;
@@ -51,7 +50,6 @@ import com.smartdevicelink.proxy.rpc.SetGlobalProperties;
 import com.smartdevicelink.proxy.rpc.WindowCapability;
 import com.smartdevicelink.proxy.rpc.enums.FileType;
 import com.smartdevicelink.proxy.rpc.enums.HMILevel;
-import com.smartdevicelink.proxy.rpc.enums.ImageFieldName;
 import com.smartdevicelink.proxy.rpc.enums.MenuLayout;
 import com.smartdevicelink.proxy.rpc.enums.SystemContext;
 import com.smartdevicelink.proxy.rpc.enums.TriggerSource;
@@ -65,7 +63,6 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -163,21 +160,6 @@ public class MenuManagerTests {
         assertNotNull(menuManager.hmiListener);
         assertNotNull(menuManager.commandListener);
         assertNotNull(menuManager.onDisplaysCapabilityListener);
-
-        menuManager.defaultMainWindowCapability = new WindowCapability();
-
-        List<MenuLayout> menuLayouts = Arrays.asList(MenuLayout.LIST, MenuLayout.TILES);
-        menuManager.defaultMainWindowCapability.setMenuLayoutsAvailable(menuLayouts);
-        List<ImageField> imageFields = new ArrayList<>();
-        ImageField menuCommandSecondaryImage = new ImageField();
-        menuCommandSecondaryImage.setName(ImageFieldName.menuCommandSecondaryImage);
-        ImageField menuSubMenuSecondaryImage = new ImageField();
-        menuSubMenuSecondaryImage.setName(ImageFieldName.menuSubMenuSecondaryImage);
-        imageFields.add(menuCommandSecondaryImage);
-        imageFields.add(menuSubMenuSecondaryImage);
-        menuManager.defaultMainWindowCapability.setImageFields(imageFields);
-
-
 
     }
 
@@ -543,6 +525,10 @@ public class MenuManagerTests {
         menuManager.currentHMILevel = HMILevel.HMI_FULL;
         menuManager.currentSystemContext = SystemContext.SYSCTXT_MAIN;
         menuManager.sdlMsgVersion = new SdlMsgVersion(6, 0);
+        menuManager.defaultMainWindowCapability = new WindowCapability();
+
+        List<MenuLayout> menuLayouts = Arrays.asList(MenuLayout.LIST, MenuLayout.TILES);
+        menuManager.defaultMainWindowCapability.setMenuLayoutsAvailable(menuLayouts);
 
         MenuConfiguration menuConfigurationTest = new MenuConfiguration(MenuLayout.LIST, MenuLayout.LIST);
         menuManager.setMenuConfiguration(menuConfigurationTest);

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/MenuManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/MenuManagerTests.java
@@ -43,6 +43,7 @@ import com.smartdevicelink.managers.file.filetypes.SdlArtwork;
 import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.proxy.RPCRequest;
 import com.smartdevicelink.proxy.RPCResponse;
+import com.smartdevicelink.proxy.rpc.ImageField;
 import com.smartdevicelink.proxy.rpc.OnCommand;
 import com.smartdevicelink.proxy.rpc.OnHMIStatus;
 import com.smartdevicelink.proxy.rpc.SdlMsgVersion;
@@ -50,6 +51,7 @@ import com.smartdevicelink.proxy.rpc.SetGlobalProperties;
 import com.smartdevicelink.proxy.rpc.WindowCapability;
 import com.smartdevicelink.proxy.rpc.enums.FileType;
 import com.smartdevicelink.proxy.rpc.enums.HMILevel;
+import com.smartdevicelink.proxy.rpc.enums.ImageFieldName;
 import com.smartdevicelink.proxy.rpc.enums.MenuLayout;
 import com.smartdevicelink.proxy.rpc.enums.SystemContext;
 import com.smartdevicelink.proxy.rpc.enums.TriggerSource;
@@ -63,6 +65,7 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -160,6 +163,21 @@ public class MenuManagerTests {
         assertNotNull(menuManager.hmiListener);
         assertNotNull(menuManager.commandListener);
         assertNotNull(menuManager.onDisplaysCapabilityListener);
+
+        menuManager.defaultMainWindowCapability = new WindowCapability();
+
+        List<MenuLayout> menuLayouts = Arrays.asList(MenuLayout.LIST, MenuLayout.TILES);
+        menuManager.defaultMainWindowCapability.setMenuLayoutsAvailable(menuLayouts);
+        List<ImageField> imageFields = new ArrayList<>();
+        ImageField menuCommandSecondaryImage = new ImageField();
+        menuCommandSecondaryImage.setName(ImageFieldName.menuCommandSecondaryImage);
+        ImageField menuSubMenuSecondaryImage = new ImageField();
+        menuSubMenuSecondaryImage.setName(ImageFieldName.menuSubMenuSecondaryImage);
+        imageFields.add(menuCommandSecondaryImage);
+        imageFields.add(menuSubMenuSecondaryImage);
+        menuManager.defaultMainWindowCapability.setImageFields(imageFields);
+
+
 
     }
 
@@ -525,10 +543,6 @@ public class MenuManagerTests {
         menuManager.currentHMILevel = HMILevel.HMI_FULL;
         menuManager.currentSystemContext = SystemContext.SYSCTXT_MAIN;
         menuManager.sdlMsgVersion = new SdlMsgVersion(6, 0);
-        menuManager.defaultMainWindowCapability = new WindowCapability();
-
-        List<MenuLayout> menuLayouts = Arrays.asList(MenuLayout.LIST, MenuLayout.TILES);
-        menuManager.defaultMainWindowCapability.setMenuLayoutsAvailable(menuLayouts);
 
         MenuConfiguration menuConfigurationTest = new MenuConfiguration(MenuLayout.LIST, MenuLayout.LIST);
         menuManager.setMenuConfiguration(menuConfigurationTest);

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseMenuManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseMenuManager.java
@@ -1041,7 +1041,7 @@ abstract class BaseMenuManager extends BaseSubManager {
             command.setVrCommands(null);
         }
         command.setCmdIcon((cell.getIcon() != null && shouldHaveArtwork) ? cell.getIcon().getImageRPC() : null);
-        command.setSecondaryImage((cell.getSecondaryArtwork() != null && shouldHaveArtwork && !(fileManager.get() != null && fileManager.get().fileNeedsUpload(cell.getSecondaryArtwork()))) ? cell.getSecondaryArtwork().getImageRPC() : null);
+        command.setSecondaryImage((cell.getSecondaryArtwork() != null && shouldHaveArtwork && hasImageFieldOfName(ImageFieldName.menuCommandSecondaryImage) && !(fileManager.get() != null && fileManager.get().fileNeedsUpload(cell.getSecondaryArtwork()))) ? cell.getSecondaryArtwork().getImageRPC() : null);
 
         return command;
     }
@@ -1065,7 +1065,7 @@ abstract class BaseMenuManager extends BaseSubManager {
             subMenu.setMenuLayout(menuConfiguration.getSubMenuLayout());
         }
         subMenu.setMenuIcon((shouldHaveArtwork && (cell.getIcon() != null && cell.getIcon().getImageRPC() != null)) ? cell.getIcon().getImageRPC() : null);
-        subMenu.setSecondaryImage((shouldHaveArtwork && !(fileManager.get() != null && fileManager.get().fileNeedsUpload(cell.getSecondaryArtwork())) && (cell.getSecondaryArtwork() != null && cell.getSecondaryArtwork().getImageRPC() != null)) ? cell.getSecondaryArtwork().getImageRPC() : null);
+        subMenu.setSecondaryImage((shouldHaveArtwork && hasImageFieldOfName(ImageFieldName.menuSubMenuSecondaryImage) && !(fileManager.get() != null && fileManager.get().fileNeedsUpload(cell.getSecondaryArtwork())) && (cell.getSecondaryArtwork() != null && cell.getSecondaryArtwork().getImageRPC() != null)) ? cell.getSecondaryArtwork().getImageRPC() : null);
         return subMenu;
     }
 


### PR DESCRIPTION
Fixes #1688 

This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE


#### Core Tests
Remove ImageFilds `menuCommandSecondaryImage` and `menuSubMenuSecondaryImage` from generic HMI as a supported field. To do this you need to remove all instances of them in `src/js/controllers/DisplayCapabilities.js` and rebuild the hmi

Test 1:
Step 1. With ImageField "menuCommandSecondaryImage" removed as a supported field from generic_hmi, Upload a menu with a normal cell that uses the same image for primary and secondary.

Verify: Only primary image is uploaded on menuCell.

Test 2:
With ImageField "menuSubMenuSecondaryImage" removed as a supported field from generic_hmi, Upload a menu with a menu cell that has subCells that uses the same image for primary and secondary.

Verify: Only primary image is uploaded on menuCell.


Core version / branch / commit hash / module tested against: Core 7.1
HMI name / version / branch / commit hash / module tested against: generic_hmi 0.10.0

### Summary
Fix MenuManager sending a secondary image with menuCells when menuCommandSecondaryImage is not supported by HMI if file had previously uploaded

### Changelog
##### Bug Fixes
* Fix MenuManager sending a secondary image with menuCells when menuCommandSecondaryImage is not supported by HMI if file had previously uploaded


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
