### PR TITLE
Fix potential NPE in LifecycleManager

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
@@ -876,7 +876,7 @@ abstract class BaseLifecycleManager {
     // HAX: Issue #1690, Ford Sync bug returning incorrect display capabilities (https://github.com/smartdevicelink/sdl_java_suite/issues/1690). Use the initial capabilities from RAIR instead of the incorrect ones that are included in SetDisplayLayoutResponse.
     void fixIncorrectDisplayCapabilities(RPCMessage rpc) {
         if (RPCMessage.KEY_RESPONSE.equals(rpc.getMessageType()) && rpc.getFunctionName().equals(FunctionID.SET_DISPLAY_LAYOUT.toString()) &&
-                initialMediaCapabilities != null && lastDisplayLayoutRequestTemplate.equals(PredefinedLayout.MEDIA.toString())) {
+                initialMediaCapabilities != null && PredefinedLayout.MEDIA.toString().equals(lastDisplayLayoutRequestTemplate)) {
 
             SetDisplayLayoutResponse setDisplayLayoutResponse = (SetDisplayLayoutResponse) rpc;
             setDisplayLayoutResponse.setDisplayCapabilities(initialMediaCapabilities);


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Core Tests
- Send a `SetDisplayLayout` without a template 
- Make sure the app doesn't crash

Core version / branch / commit hash / module tested against: 7.1.1

### Summary
This PR fixes a potential NPE in `LifecycleManager` if the app sends a `SetDisplayLayout` without setting a template. This scenario shouldn't happen in real life because a template is required but it shoud still not crash the app. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
