### PR TITLE
Update Handler constructors from deprecated versions

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
@@ -337,9 +337,6 @@ public class VirtualDisplayEncoder {
             Looper.prepare();
 
             // create a Handler for this thread
-            if (Looper.myLooper() == null) {
-                Looper.prepare();
-            }
             mHandler = new Handler(Looper.myLooper()) {
                 public void handleMessage(Message msg) {
                     switch (msg.what) {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
@@ -337,6 +337,9 @@ public class VirtualDisplayEncoder {
             Looper.prepare();
 
             // create a Handler for this thread
+            if (Looper.myLooper() == null) {
+                Looper.prepare();
+            }
             mHandler = new Handler(Looper.myLooper()) {
                 public void handleMessage(Message msg) {
                     switch (msg.what) {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
@@ -337,7 +337,7 @@ public class VirtualDisplayEncoder {
             Looper.prepare();
 
             // create a Handler for this thread
-            mHandler = new Handler() {
+            mHandler = new Handler(Looper.myLooper()) {
                 public void handleMessage(Message msg) {
                     switch (msg.what) {
                         case MSG_TICK: {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
@@ -38,6 +38,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.graphics.Bitmap;
 import android.os.Handler;
+import android.os.Looper;
 
 import androidx.annotation.RestrictTo;
 
@@ -227,7 +228,7 @@ public class LockScreenManager extends BaseSubManager {
                                         mLockScreenShouldBeAutoDismissed = false;
                                     }
                                     if (!receivedFirstDDNotification) {
-                                        new Handler().postDelayed(new Runnable() {
+                                        new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
                                             @Override
                                             public void run() {
                                                 launchLockScreenActivity();

--- a/android/sdl_android/src/main/java/com/smartdevicelink/protocol/heartbeat/HeartbeatMonitor.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/protocol/heartbeat/HeartbeatMonitor.java
@@ -155,7 +155,7 @@ public class HeartbeatMonitor implements IHeartbeatMonitor {
                         Looper.prepare();
                         mHeartbeatThreadLooper = Looper.myLooper();
 
-                        mHeartbeatThreadHandler = new Handler(Looper.getMainLooper());
+                        mHeartbeatThreadHandler = new Handler(mHeartbeatThreadLooper);
                         mIsAckReceived = true;
                         isHeartbeatReceived = true;
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/protocol/heartbeat/HeartbeatMonitor.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/protocol/heartbeat/HeartbeatMonitor.java
@@ -155,7 +155,7 @@ public class HeartbeatMonitor implements IHeartbeatMonitor {
                         Looper.prepare();
                         mHeartbeatThreadLooper = Looper.myLooper();
 
-                        mHeartbeatThreadHandler = new Handler(Looper.myLooper());
+                        mHeartbeatThreadHandler = new Handler(Looper.getMainLooper());
                         mIsAckReceived = true;
                         isHeartbeatReceived = true;
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/protocol/heartbeat/HeartbeatMonitor.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/protocol/heartbeat/HeartbeatMonitor.java
@@ -155,7 +155,7 @@ public class HeartbeatMonitor implements IHeartbeatMonitor {
                         Looper.prepare();
                         mHeartbeatThreadLooper = Looper.myLooper();
 
-                        mHeartbeatThreadHandler = new Handler();
+                        mHeartbeatThreadHandler = new Handler(Looper.myLooper());
                         mIsAckReceived = true;
                         isHeartbeatReceived = true;
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
@@ -348,7 +348,7 @@ public class MultiplexBluetoothTransport extends MultiplexBaseTransport {
     }
 
     private void timerDelayRemoveDialog(final BluetoothSocket sock) {
-        timeOutHandler = new Handler();
+        timeOutHandler = new Handler(Looper.getMainLooper());
         socketRunnable = new Runnable() {
             public void run() {
                 //Log.e(TAG, "BLUETOOTH SOCKET CONNECT TIMEOUT - ATTEMPT TO CLOSE SOCKET");

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
@@ -348,7 +348,10 @@ public class MultiplexBluetoothTransport extends MultiplexBaseTransport {
     }
 
     private void timerDelayRemoveDialog(final BluetoothSocket sock) {
-        timeOutHandler = new Handler(Looper.getMainLooper());
+        if (Looper.myLooper() == null) {
+            Looper.prepare();
+        }
+        timeOutHandler = new Handler(Looper.myLooper());
         socketRunnable = new Runnable() {
             public void run() {
                 //Log.e(TAG, "BLUETOOTH SOCKET CONNECT TIMEOUT - ATTEMPT TO CLOSE SOCKET");

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1410,7 +1410,7 @@ public class SdlRouterService extends Service {
     public void resetForegroundTimeOut(long delay) {
         synchronized (FOREGROUND_NOTIFICATION_LOCK) {
             if (foregroundTimeoutHandler == null) {
-                foregroundTimeoutHandler = new Handler();
+                foregroundTimeoutHandler = new Handler(Looper.getMainLooper());
             }
             if (foregroundTimeoutRunnable == null) {
                 foregroundTimeoutRunnable = new Runnable() {
@@ -2501,7 +2501,7 @@ public class SdlRouterService extends Service {
      * This method is used to check for the newest version of this class to make sure the latest and greatest is up and running.
      */
     private void startAltTransportTimer() {
-        altTransportTimerHandler = new Handler();
+        altTransportTimerHandler = new Handler(Looper.getMainLooper());
         altTransportTimerRunnable = new Runnable() {
             public void run() {
                 altTransportTimerHandler = null;
@@ -3057,7 +3057,7 @@ public class SdlRouterService extends Service {
             this.messenger = messenger;
             this.sessionIds = new Vector<Long>();
             this.queues = new ConcurrentHashMap<>();
-            queueWaitHandler = new Handler();
+            queueWaitHandler = new Handler(Looper.getMainLooper());
             registeredTransports = new SparseArray<ArrayList<TransportType>>();
             awaitingSession = new Vector<>();
             setDeathNote(); //messaging Version

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1410,7 +1410,10 @@ public class SdlRouterService extends Service {
     public void resetForegroundTimeOut(long delay) {
         synchronized (FOREGROUND_NOTIFICATION_LOCK) {
             if (foregroundTimeoutHandler == null) {
-                foregroundTimeoutHandler = new Handler(Looper.getMainLooper());
+                if (Looper.myLooper() == null) {
+                    Looper.prepare();
+                }
+                foregroundTimeoutHandler = new Handler(Looper.myLooper());
             }
             if (foregroundTimeoutRunnable == null) {
                 foregroundTimeoutRunnable = new Runnable() {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -2504,7 +2504,10 @@ public class SdlRouterService extends Service {
      * This method is used to check for the newest version of this class to make sure the latest and greatest is up and running.
      */
     private void startAltTransportTimer() {
-        altTransportTimerHandler = new Handler(Looper.getMainLooper());
+        if (Looper.myLooper() == null) {
+            Looper.prepare();
+        }
+        altTransportTimerHandler = new Handler(Looper.myLooper());
         altTransportTimerRunnable = new Runnable() {
             public void run() {
                 altTransportTimerHandler = null;
@@ -3060,7 +3063,10 @@ public class SdlRouterService extends Service {
             this.messenger = messenger;
             this.sessionIds = new Vector<Long>();
             this.queues = new ConcurrentHashMap<>();
-            queueWaitHandler = new Handler(Looper.getMainLooper());
+            if (Looper.myLooper() == null) {
+                Looper.prepare();
+            }
+            queueWaitHandler = new Handler(Looper.myLooper());
             registeredTransports = new SparseArray<ArrayList<TransportType>>();
             awaitingSession = new Vector<>();
             setDeathNote(); //messaging Version

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/TransportManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/TransportManager.java
@@ -415,6 +415,9 @@ public class TransportManager extends TransportManagerBase {
                 contextWeakReference.get().registerReceiver(legacyDisconnectReceiver, intentFilter);
             }
         } else {
+            if (Looper.myLooper() == null) {
+                Looper.prepare();
+            }
             new Handler(Looper.myLooper()).postDelayed(new Runnable() {
                 @Override
                 public void run() {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/TransportManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/TransportManager.java
@@ -402,10 +402,10 @@ public class TransportManager extends TransportManagerBase {
             return; //Already in legacy mode
         }
 
+        if (Looper.myLooper() == null) {
+            Looper.prepare();
+        }
         if (transportListener.onLegacyModeEnabled(info)) {
-            if (Looper.myLooper() == null) {
-                Looper.prepare();
-            }
             legacyBluetoothHandler = new LegacyBluetoothHandler(this);
             legacyBluetoothTransport = new MultiplexBluetoothTransport(legacyBluetoothHandler);
             if (contextWeakReference.get() != null) {
@@ -415,9 +415,6 @@ public class TransportManager extends TransportManagerBase {
                 contextWeakReference.get().registerReceiver(legacyDisconnectReceiver, intentFilter);
             }
         } else {
-            if (Looper.myLooper() == null) {
-                Looper.prepare();
-            }
             new Handler(Looper.myLooper()).postDelayed(new Runnable() {
                 @Override
                 public void run() {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/TransportManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/TransportManager.java
@@ -415,7 +415,7 @@ public class TransportManager extends TransportManagerBase {
                 contextWeakReference.get().registerReceiver(legacyDisconnectReceiver, intentFilter);
             }
         } else {
-            new Handler().postDelayed(new Runnable() {
+            new Handler(Looper.myLooper()).postDelayed(new Runnable() {
                 @Override
                 public void run() {
                     transportListener.onError(info + " - Legacy mode unacceptable; shutting down.");


### PR DESCRIPTION
Fixes #1696

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [X] I have tested Android

#### Unit Tests
N/A

#### Core Tests
Smoke Test app still connects and videoStreaming still works

### Summary
The Handler constructor with no parameters has now been depreacted. To avoid using deprecated methods this PR will update the Handler constructors to take a Looper as a parameter. In the VirtualDisplayEncoder if we receive a message terminate then we quit the looper, in this case we will use myLooper rather than getMainLooper as we cannot quit the main thread.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
