### PR TITLE
Fix Mockito exception

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/video/HapticInterfaceManagerTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/video/HapticInterfaceManagerTest.java
@@ -21,6 +21,7 @@
  **************************************************************************************************/
 package com.smartdevicelink.managers.video;
 
+import android.content.Context;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
@@ -45,9 +46,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -222,36 +221,53 @@ public class HapticInterfaceManagerTest extends TestCase {
     }
 
     private View createViews() {
+        Context context = InstrumentationRegistry.getInstrumentation().getContext();
 
-        View view = mock(View.class);
-
-        ViewGroup parent1 = mock(ViewGroup.class);
-        ViewGroup parent2 = mock(ViewGroup.class);
-
-        when(parent1.getChildCount()).thenReturn(5);
-
-        when(parent1.getChildAt(0)).thenReturn(view);
-        when(parent1.getChildAt(1)).thenReturn(view);
-        when(parent1.getChildAt(2)).thenReturn(view);
-        when(parent1.getChildAt(3)).thenReturn(parent2);
-        when(parent1.getChildAt(4)).thenReturn(view);
-
-        when(parent2.getChildCount()).thenReturn(2);
-        when(parent2.getChildAt(0)).thenReturn(view);
-        when(parent2.getChildAt(1)).thenReturn(view);
-
-
-        doAnswer(new Answer<Boolean>() {
+        View view = new View(context) {
             private int count = 0;
 
             @Override
-            public Boolean answer(InvocationOnMock invocation) throws Throwable {
+            public boolean isClickable() {
                 int curCount = count++;
                 return (curCount >= 1) && (curCount <= 4);
             }
-        }).when(view).isClickable();
+        };
 
-        return parent1;
+        ViewGroup parent1 = new ViewGroup(context) {
+            @Override
+            protected void onLayout(boolean b, int i, int i1, int i2, int i3) {}
+
+            @Override
+            public View getChildAt(int index) {
+                return view;
+            }
+
+            @Override
+            public int getChildCount() {
+                return 2;
+            }
+        };
+
+        ViewGroup parent2 = new ViewGroup(context) {
+            @Override
+            protected void onLayout(boolean b, int i, int i1, int i2, int i3) {}
+
+            @Override
+            public View getChildAt(int index) {
+                if (index == 3) {
+                    return parent1;
+                } else {
+                    return view;
+                }
+            }
+
+            @Override
+            public int getChildCount() {
+                return 5;
+            }
+        };
+
+        return parent2;
     }
 
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/video/HapticInterfaceManagerTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/video/HapticInterfaceManagerTest.java
@@ -223,7 +223,7 @@ public class HapticInterfaceManagerTest extends TestCase {
     private View createViews() {
         Context context = InstrumentationRegistry.getInstrumentation().getContext();
 
-        View view = new View(context) {
+        final View view = new View(context) {
             private int count = 0;
 
             @Override
@@ -233,7 +233,7 @@ public class HapticInterfaceManagerTest extends TestCase {
             }
         };
 
-        ViewGroup parent1 = new ViewGroup(context) {
+        final ViewGroup parent1 = new ViewGroup(context) {
             @Override
             protected void onLayout(boolean b, int i, int i1, int i2, int i3) {}
 
@@ -248,7 +248,7 @@ public class HapticInterfaceManagerTest extends TestCase {
             }
         };
 
-        ViewGroup parent2 = new ViewGroup(context) {
+        final ViewGroup parent2 = new ViewGroup(context) {
             @Override
             protected void onLayout(boolean b, int i, int i1, int i2, int i3) {}
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/video/HapticInterfaceManagerTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/video/HapticInterfaceManagerTest.java
@@ -55,7 +55,6 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
There seems to be a strange issue with Mockito that happens randomly sometimes when the tests try to mock `View` or `ViewGroup` classes.
This PR rewrites `HapticInterfaceManagerTest.createViews()` to create the same views without mocking `View` or `ViewGroup` classes which makes the tests more reliable.  

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
