### PR TITLE
Fix IndexOutOfBoundsException in SdlRouterService

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -3319,7 +3319,7 @@ public class SdlRouterService extends Service {
                         try {
                             List<TransportType> transportTypes = (List<TransportType>) obj;
                             if (transportTypes != null) {
-                                if (transportTypes.get(0) != null) {
+                                if (transportTypes.size() > 0 && transportTypes.get(0) != null) {
                                     return transportTypes.get(0);
                                 }
                             }


### PR DESCRIPTION
Fixes #1741 

This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Core Tests
Tested connecting to tdk via Bluetooth having two other apps connect to test apps routerService

Core version / branch / commit hash / module tested against: Sync 3.0
HMI name / version / branch / commit hash / module tested against: Sync 3.0

### Summary
Fix IndexOutOfBoundsException that can happen in `SdlRouterService.getCompatPrimaryTransport()`

### Changelog
##### Bug Fixes
* Fit IndexOutOfBoundsException in SdlRouterService

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
