### PR TITLE
Fix for issue 1751: fixes a crasher when running on Android 12

### DIFF
--- a/android/hello_sdl_android/build.gradle
+++ b/android/hello_sdl_android/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     defaultConfig {
         applicationId "com.sdl.hellosdlandroid"
         minSdkVersion 16

--- a/android/sdl_android/build.gradle
+++ b/android/sdl_android/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1521,7 +1521,8 @@ public class SdlRouterService extends Service {
 
         // Create an intent that will be fired when the user clicks the notification.
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(SDL_NOTIFICATION_FAQS_PAGE));
-        PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent, 0);
+        int flag = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)? PendingIntent.FLAG_IMMUTABLE : 0;
+        PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent, flag);
         builder.setContentIntent(pendingIntent);
 
         if (chronometerLength > (FOREGROUND_TIMEOUT / 1000) && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {


### PR DESCRIPTION
Fixes #1751 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [ ] I have tested Android, Java SE, and Java EE

#### Unit Tests
I have run SdlRouterServiceTests.

#### Core Tests
n/a

Core version / branch / commit hash / module tested against: 7.0
HMI name / version / branch / commit hash / module tested against: our own HMI test suite

### Summary
This fixes a crasher when SDL app sets targetSdkVersion to 31, and running on Android 12.

### Changelog
##### Breaking Changes
* n/a

##### Enhancements
* n/a

##### Bug Fixes
* This fixes issue #1751 

### Tasks Remaining:
- n/a

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
