### PR TITLE
Update SecurityQueryPayload to include json data

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/protocol/SecurityQueryPayloadTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/protocol/SecurityQueryPayloadTests.java
@@ -120,4 +120,12 @@ public class SecurityQueryPayloadTests {
         assertEquals(0, bqh.getJsonSize());
         assertEquals(null, bqh.getJsonData());
     }
+
+    @Test
+    public void testNullBulkData() {
+        SecurityQueryPayload bqh = createDummyBqh();
+        bqh.setBulkData(null);
+        assertEquals(0, bqh.getBulkDataSize());
+        assertEquals(null, bqh.getBulkData());
+    }
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/protocol/SecurityQueryPayloadTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/protocol/SecurityQueryPayloadTests.java
@@ -25,7 +25,7 @@ public class SecurityQueryPayloadTests {
         bqh.setQueryID(SecurityQueryID.SEND_HANDSHAKE_DATA);
         bqh.setQueryType(SecurityQueryType.REQUEST);
         bqh.setBulkData(null);
-        bqh.setJsonSize(0);
+        bqh.setJsonData(null);
         return bqh;
     }
 
@@ -66,9 +66,9 @@ public class SecurityQueryPayloadTests {
         dummyBqh.setQueryType(SecurityQueryType.REQUEST);
         dummyBqh.setQueryID(SecurityQueryID.SEND_HANDSHAKE_DATA);
         dummyBqh.setCorrelationID(3);
-        dummyBqh.setJsonSize(0);
+        dummyBqh.setJsonData(new byte[0]);
 
-        byte[] assembledHeader = dummyBqh.assembleHeaderBytes();
+        byte[] assembledHeader = dummyBqh.assembleSecurityQueryPayload(0);
         assertEquals(dummyBqh.getQueryType(), SecurityQueryType.valueOf(assembledHeader[0]));
         byte[] queryIDFromHeader = new byte[3];
         System.arraycopy(assembledHeader, 1, queryIDFromHeader, 0, 3);
@@ -81,7 +81,7 @@ public class SecurityQueryPayloadTests {
     public void testAssemblyAndParse() {
         SecurityQueryPayload bqh = createDummyBqh();
 
-        byte[] bqhBytes = bqh.assembleHeaderBytes();
+        byte[] bqhBytes = bqh.assembleSecurityQueryPayload(0);
         assertNotNull(bqhBytes);
 
         SecurityQueryPayload parsedBqh = SecurityQueryPayload.parseBinaryQueryHeader(bqhBytes);
@@ -99,7 +99,7 @@ public class SecurityQueryPayloadTests {
     public void testCorruptHeader() {
         SecurityQueryPayload bqh = createDummyBqh();
 
-        byte[] bqhBytes = bqh.assembleHeaderBytes();
+        byte[] bqhBytes = bqh.assembleSecurityQueryPayload(0);
 
         assertNotNull(safeParse(bqhBytes));
 
@@ -114,13 +114,10 @@ public class SecurityQueryPayloadTests {
     }
 
     @Test
-    public void testJsonSetException() {
-        try {
-            SecurityQueryPayload bqh = createDummyBqh();
-            bqh.setJsonData(null);
-            fail("Setting JSON data to null should have thrown an exception");
-        } catch (Exception e) {
-            //Pass
-        }
+    public void testNullJsonData() {
+        SecurityQueryPayload bqh = createDummyBqh();
+        bqh.setJsonData(null);
+        assertEquals(0, bqh.getJsonSize());
+        assertEquals(null, bqh.getJsonData());
     }
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/protocol/SecurityQueryPayloadTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/protocol/SecurityQueryPayloadTests.java
@@ -68,7 +68,7 @@ public class SecurityQueryPayloadTests {
         dummyBqh.setCorrelationID(3);
         dummyBqh.setJsonData(new byte[0]);
 
-        byte[] assembledHeader = dummyBqh.assembleSecurityQueryPayload(0);
+        byte[] assembledHeader = dummyBqh.assembleBinaryData();
         assertEquals(dummyBqh.getQueryType(), SecurityQueryType.valueOf(assembledHeader[0]));
         byte[] queryIDFromHeader = new byte[3];
         System.arraycopy(assembledHeader, 1, queryIDFromHeader, 0, 3);
@@ -81,7 +81,7 @@ public class SecurityQueryPayloadTests {
     public void testAssemblyAndParse() {
         SecurityQueryPayload bqh = createDummyBqh();
 
-        byte[] bqhBytes = bqh.assembleSecurityQueryPayload(0);
+        byte[] bqhBytes = bqh.assembleBinaryData();
         assertNotNull(bqhBytes);
 
         SecurityQueryPayload parsedBqh = SecurityQueryPayload.parseBinaryQueryHeader(bqhBytes);
@@ -99,7 +99,7 @@ public class SecurityQueryPayloadTests {
     public void testCorruptHeader() {
         SecurityQueryPayload bqh = createDummyBqh();
 
-        byte[] bqhBytes = bqh.assembleSecurityQueryPayload(0);
+        byte[] bqhBytes = bqh.assembleBinaryData();
 
         assertNotNull(safeParse(bqhBytes));
 

--- a/base/src/main/java/com/smartdevicelink/protocol/SecurityQueryPayload.java
+++ b/base/src/main/java/com/smartdevicelink/protocol/SecurityQueryPayload.java
@@ -85,14 +85,23 @@ public class SecurityQueryPayload {
     }
 
     public byte[] assembleSecurityQueryPayload(int payloadSize) {
-        byte[] payLoad = new byte[SECURITY_QUERY_HEADER_SIZE + payloadSize];
-        System.arraycopy(assembleHeaderBytes(), 0, payLoad, 0, SECURITY_QUERY_HEADER_SIZE);
-
+        byte[] payLoad = new byte[SECURITY_QUERY_HEADER_SIZE];
         if (_securityQueryID == SecurityQueryID.SEND_INTERNAL_ERROR && _securityQueryType == SecurityQueryType.NOTIFICATION) {
+            payLoad = new byte[SECURITY_QUERY_HEADER_SIZE + payloadSize + 1];
             System.arraycopy(_jsonData, 0, payLoad, SECURITY_QUERY_HEADER_SIZE, _jsonSize);
+            byte[] errorCode = new byte[1];
+            if (this._errorCode != null) {
+                errorCode[0] = _errorCode.getValue();
+            } else {
+                errorCode[0] = SecurityQueryErrorCode.ERROR_UNKNOWN_INTERNAL_ERROR.getValue();
+            }
+            System.arraycopy(errorCode, 0, payLoad, payLoad.length - 1, 1);
         } else if (_securityQueryID == SecurityQueryID.SEND_HANDSHAKE_DATA && _securityQueryType == SecurityQueryType.RESPONSE) {
+            payLoad = new byte[SECURITY_QUERY_HEADER_SIZE + payloadSize];
             System.arraycopy(_bulkData, 0, payLoad, SECURITY_QUERY_HEADER_SIZE, payloadSize);
         }
+
+        System.arraycopy(assembleHeaderBytes(), 0, payLoad, 0, SECURITY_QUERY_HEADER_SIZE);
 
         return payLoad;
     }

--- a/base/src/main/java/com/smartdevicelink/protocol/SecurityQueryPayload.java
+++ b/base/src/main/java/com/smartdevicelink/protocol/SecurityQueryPayload.java
@@ -84,7 +84,20 @@ public class SecurityQueryPayload {
         return msg;
     }
 
-    public byte[] assembleHeaderBytes() {
+    public byte[] assembleSecurityQueryPayload(int payloadSize) {
+        byte[] payLoad = new byte[SECURITY_QUERY_HEADER_SIZE + payloadSize];
+        System.arraycopy(assembleHeaderBytes(), 0, payLoad, 0, SECURITY_QUERY_HEADER_SIZE);
+
+        if (_securityQueryID == SecurityQueryID.SEND_INTERNAL_ERROR && _securityQueryType == SecurityQueryType.NOTIFICATION) {
+            System.arraycopy(_jsonData, 0, payLoad, SECURITY_QUERY_HEADER_SIZE, _jsonSize);
+        } else if (_securityQueryID == SecurityQueryID.SEND_HANDSHAKE_DATA && _securityQueryType == SecurityQueryType.RESPONSE) {
+            System.arraycopy(_bulkData, 0, payLoad, SECURITY_QUERY_HEADER_SIZE, payloadSize);
+        }
+
+        return payLoad;
+    }
+
+    private byte[] assembleHeaderBytes() {
         // From the properties, create a data buffer
         // Query Type - first 8 bits
         // Query ID - next 24 bits
@@ -126,7 +139,7 @@ public class SecurityQueryPayload {
         return _jsonSize;
     }
 
-    public void setJsonSize(int _jsonSize) {
+    private void setJsonSize(int _jsonSize) {
         this._jsonSize = _jsonSize;
     }
 
@@ -143,6 +156,12 @@ public class SecurityQueryPayload {
     }
 
     public void setJsonData(byte[] _jsonData) {
+        if (_jsonData == null) {
+            this._jsonSize = 0;
+            this._jsonData = null;
+            return;
+        }
+        this._jsonSize = _jsonData.length;
         this._jsonData = new byte[this._jsonSize];
         System.arraycopy(_jsonData, 0, this._jsonData, 0, _jsonSize);
     }

--- a/base/src/main/java/com/smartdevicelink/session/BaseSdlSession.java
+++ b/base/src/main/java/com/smartdevicelink/session/BaseSdlSession.java
@@ -254,8 +254,8 @@ public abstract class BaseSdlSession implements ISdlProtocol, ISecurityInitializ
             byte[] jsonData;
             JSONObject jsonObject = new JSONObject();
             try {
-                jsonObject.put("id", 254);
-                jsonObject.put("text", "Error value for testing");
+                jsonObject.put("id", SecurityQueryErrorCode.ERROR_UNKNOWN_INTERNAL_ERROR.getValue());
+                jsonObject.put("text", SecurityQueryErrorCode.ERROR_UNKNOWN_INTERNAL_ERROR.getName());
                 jsonData = jsonObject.toString().getBytes();
             } catch (JSONException e) {
                 DebugTool.logError(TAG, "JSON exception when constructing handshake error Notification");

--- a/base/src/main/java/com/smartdevicelink/session/BaseSdlSession.java
+++ b/base/src/main/java/com/smartdevicelink/session/BaseSdlSession.java
@@ -239,7 +239,7 @@ public abstract class BaseSdlSession implements ISdlProtocol, ISecurityInitializ
             return;
         }
 
-        iNumBytes = sdlSecurity.runHandshake(data, dataToRead);
+        iNumBytes = null;
 
         // Assemble a security query payload header for our response
         SecurityQueryPayload responseHeader = new SecurityQueryPayload();

--- a/base/src/main/java/com/smartdevicelink/session/BaseSdlSession.java
+++ b/base/src/main/java/com/smartdevicelink/session/BaseSdlSession.java
@@ -239,7 +239,7 @@ public abstract class BaseSdlSession implements ISdlProtocol, ISecurityInitializ
             return;
         }
 
-        iNumBytes = null;
+        iNumBytes = sdlSecurity.runHandshake(data, dataToRead);
 
         // Assemble a security query payload header for our response
         SecurityQueryPayload responseHeader = new SecurityQueryPayload();


### PR DESCRIPTION
Fixes #1753

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Unit Tests
Updated SecurityQuery Unit Tests

#### Core Tests
Verify Encryption Still works.
---and---
Force sendHandshake to fail and verify the library has the json payload set with the error message information

Core version / branch / commit hash / module tested against: Core 8.0
HMI name / version / branch / commit hash / module tested against: Sdl HMI 5.6

### Summary
This PR updates SecurityQueryPayload implementation to make sure the JSON data and error Byte are set when responding with an error notification to Core

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
