### PR TITLE
Update android, javaSE & javaEE gradle setup to read version for one file 

### DIFF
--- a/android/sdl_android/build.gradle
+++ b/android/sdl_android/build.gradle
@@ -40,6 +40,8 @@ android {
     }
 }
 
+ext { VERSION_NAME = "$project.version" }
+
 dependencies {
     api fileTree(dir: 'libs', include: ['*.jar'])
     //api 'com.livio.taskmaster:taskmaster:0.6.0'

--- a/android/sdl_android/build.gradle
+++ b/android/sdl_android/build.gradle
@@ -40,7 +40,7 @@ android {
     }
 }
 
-ext { VERSION_NAME = "$project.version" }
+ext { VERSION_NAME = "$project.android.defaultConfig.versionName" }
 
 dependencies {
     api fileTree(dir: 'libs', include: ['*.jar'])

--- a/android/sdl_android/gradle.properties
+++ b/android/sdl_android/gradle.properties
@@ -1,6 +1,5 @@
 GROUP=com.smartdevicelink
 POM_ARTIFACT_ID=sdl_android
-VERSION_NAME=5.3.0
 
 POM_NAME=sdl_android
 POM_PACKAGING=aar

--- a/javaEE/javaEE/build.gradle
+++ b/javaEE/javaEE/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'java-library'
 
 group 'com.smartdevicelink'
 version new File(projectDir.path, ('/../../VERSION')).text.trim()
+ext { VERSION_NAME = "$project.version" }
 
 sourceCompatibility = 1.7
 

--- a/javaEE/javaEE/gradle.properties
+++ b/javaEE/javaEE/gradle.properties
@@ -1,6 +1,5 @@
 GROUP=com.smartdevicelink
 POM_ARTIFACT_ID=sdl_java_ee
-VERSION_NAME=5.3.0
 
 POM_NAME=sdl_java_ee
 POM_PACKAGING=jar

--- a/javaSE/javaSE/build.gradle
+++ b/javaSE/javaSE/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'java-library'
 
 group 'com.smartdevicelink'
 version new File(projectDir.path, ('/../../VERSION')).text.trim()
+ext { VERSION_NAME = "$project.version" }
 
 sourceCompatibility = 1.7
 

--- a/javaSE/javaSE/gradle.properties
+++ b/javaSE/javaSE/gradle.properties
@@ -1,6 +1,5 @@
 GROUP=com.smartdevicelink
 POM_ARTIFACT_ID=sdl_java_se
-VERSION_NAME=5.3.0
 
 POM_NAME=sdl_java_se
 POM_PACKAGING=jar


### PR DESCRIPTION
Fixes #1763 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE

### Summary
This PR updates the gradle setup for android, javaSE & javaEE to read the version from one single file called `VERSION` instead of having 4 different files that needed to be updated separately. 

### Testing Steps
1. Update the version in `VERSION` file to any unique version (like `5.3.0_xyz` for example) 
2. Run `./gradlew build` for javaSE
3. Upload the `JavaSE` binary to maven central staging 
4. Confirm that the generated `BuildConfig` and uploaded library still use the old version that was set in `gradle.properties`
5. Repeat the same steps for Android library 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
