### PR TITLE
Add Bluetooth adapter available check in RouterService for spp error notification 

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1942,7 +1942,7 @@ public class SdlRouterService extends Service {
                     bluetoothTransport.setStateManually(MultiplexBluetoothTransport.STATE_NONE);
                     bluetoothTransport = null;
                 }
-                if (errorBundle != null && errorBundle.getByte(MultiplexBaseTransport.ERROR_REASON_KEY) == MultiplexBaseTransport.REASON_SPP_ERROR) {
+                if (errorBundle != null && errorBundle.getByte(MultiplexBaseTransport.ERROR_REASON_KEY) == MultiplexBaseTransport.REASON_SPP_ERROR && bluetoothAvailable()) {
                     notifySppError();
                 }
                 break;


### PR DESCRIPTION
Fixes #1661

This PR is **[ready]** for review.

### Risk
This PR makes **[no / minor / major]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Unit Tests
n/a

#### Core Tests
Run test 9.008 in the 5.3 SDL_Android Test Plan on sheet Multiplexing Security Tests.

Core version / branch / commit hash / module tested against: Synce 3.0
HMI name / version / branch / commit hash / module tested against: Sync 3.0

### Summary
Added Bluetooth adapter available check to RouterService for spp error notification. This prevents a rare edge case where when having connected Bluetooth and USB, you keep turning on and off Bluetooth, you can get the spp error notification.

### Changelog
##### Bug Fixes
* [Added Bluetooth adapter available check to RouterService for spp error notification.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
