### PR TITLE
Move keyboard listener to start of operation

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/PreloadPresentChoicesOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/PreloadPresentChoicesOperation.java
@@ -185,6 +185,7 @@ class PreloadPresentChoicesOperation extends Task {
             choiceId = 1;
             reachedMaxIds = false;
         }
+        addListeners();
 
         DebugTool.logInfo(TAG, "Choice Operation: Executing preload choices operation");
         // Enforce unique cells and remove cells that are already loaded
@@ -343,7 +344,6 @@ class PreloadPresentChoicesOperation extends Task {
             return;
         }
 
-        addListeners();
 
         if (keyboardListener != null && choiceSet.getCustomKeyboardConfiguration() != null) {
             keyboardProperties = choiceSet.getCustomKeyboardConfiguration();

--- a/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/PreloadPresentChoicesOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/PreloadPresentChoicesOperation.java
@@ -419,7 +419,7 @@ class PreloadPresentChoicesOperation extends Task {
     }
 
     private void presentChoiceSet(final CompletionListener listener) {
-        // add listeners if there is a keboard
+        // add listeners if there is a keyboard
         if (keyboardListener != null) {
             addListeners();
         }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/PreloadPresentChoicesOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/PreloadPresentChoicesOperation.java
@@ -185,7 +185,7 @@ class PreloadPresentChoicesOperation extends Task {
             choiceId = 1;
             reachedMaxIds = false;
         }
-        addListeners();
+
 
         DebugTool.logInfo(TAG, "Choice Operation: Executing preload choices operation");
         // Enforce unique cells and remove cells that are already loaded
@@ -419,6 +419,10 @@ class PreloadPresentChoicesOperation extends Task {
     }
 
     private void presentChoiceSet(final CompletionListener listener) {
+        // add listeners if there is a keboard
+        if (keyboardListener != null) {
+            addListeners();
+        }
         this.currentState = SDLPreloadPresentChoicesOperationState.PRESENTING_CHOICES;
         PerformInteraction pi = getPerformInteraction();
         pi.setOnRPCResponseListener(new OnRPCResponseListener() {


### PR DESCRIPTION
Fixes #1768 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
n/a

#### Core Tests
Tested sending a searchable `choiceSet` with autocomplete implemented, verifying that onUserDidSubmitInput is only called once per keypress. 

Core version / branch / commit hash / module tested against: Core 8.0.0
HMI name / version / branch / commit hash / module tested against: sdl_hmi 5.6.0

### Summary
This PR fixes an issue of multiple listeners being added for the keyboard in a searchable choicest which would result in multiple callbacks to the app's keyboard listener. 

### Changelog
##### Bug Fixes
* Changes were keyboard listeners are added in `PreloadPresentChoiceSetOperation` to prevent case where multiple listeners are added.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
