### PR TITLE
Fix NPE in SoftButtonReplaceOperation

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonReplaceOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonReplaceOperation.java
@@ -304,7 +304,7 @@ class SoftButtonReplaceOperation extends Task {
     }
 
     private boolean supportsSoftButtonImages() {
-        return softButtonCapabilities.getImageSupported();
+        return softButtonCapabilities != null ? Boolean.TRUE.equals(softButtonCapabilities.getImageSupported()) : false;
     }
 
     void setCurrentMainField1(String currentMainField1) {

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonReplaceOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonReplaceOperation.java
@@ -304,7 +304,7 @@ class SoftButtonReplaceOperation extends Task {
     }
 
     private boolean supportsSoftButtonImages() {
-        return softButtonCapabilities != null ? Boolean.TRUE.equals(softButtonCapabilities.getImageSupported()) : false;
+        return softButtonCapabilities != null && Boolean.TRUE.equals(softButtonCapabilities.getImageSupported());
     }
 
     void setCurrentMainField1(String currentMainField1) {


### PR DESCRIPTION
Fixes #1767 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Core Tests
Tested changing template and adding SoftButtons at the same time in a batch update.

Core version / branch / commit hash / module tested against: generic_hmi 0.11.0
HMI name / version / branch / commit hash / module tested against: core 8.0.0

### Summary
Add NPE check to softButtonReplaceOperation to check if the capability is null, as well as if the Image capability is null, and set it to false if either of those is true.

### Changelog
##### Bug Fixes
* Add NPE check to SoftButtonReplaceOperation.supportsSoftButtonImages

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
