### PR TITLE
Fix soft button object invalid states

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/ScreenManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/ScreenManagerTests.java
@@ -217,14 +217,15 @@ public class ScreenManagerTests {
     }
     @Test
     public void testAssigningIdsToSoftButtonObjects() {
+        SoftButtonState defaultState = new SoftButtonState("default", "hi", null);
         SoftButtonObject sbo1, sbo2, sbo3, sbo4, sbo5;
 
         // Case 1 - don't set id for any button (Manager should set ids automatically starting from 1 and up)
-        sbo1 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
-        sbo2 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
-        sbo3 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
-        sbo4 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
-        sbo5 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        sbo1 = new SoftButtonObject(null, defaultState, null);
+        sbo2 = new SoftButtonObject(null, defaultState, null);
+        sbo3 = new SoftButtonObject(null, defaultState, null);
+        sbo4 = new SoftButtonObject(null, defaultState, null);
+        sbo5 = new SoftButtonObject(null, defaultState, null);
         screenManager.checkAndAssignButtonIds(Arrays.asList(sbo1, sbo2, sbo3, sbo4, sbo5), BaseScreenManager.ManagerLocation.SOFTBUTTON_MANAGER);
         assertEquals("SoftButtonObject id doesn't match the expected value", 1, sbo1.getButtonId());
         assertEquals("SoftButtonObject id doesn't match the expected value", 2, sbo2.getButtonId());
@@ -234,15 +235,15 @@ public class ScreenManagerTests {
 
 
         // Case 2 - Set ids for all buttons (Manager shouldn't alter the ids set by developer)
-        sbo1 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        sbo1 = new SoftButtonObject(null, defaultState, null);
         sbo1.setButtonId(100);
-        sbo2 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        sbo2 = new SoftButtonObject(null, defaultState, null);
         sbo2.setButtonId(200);
-        sbo3 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        sbo3 = new SoftButtonObject(null, defaultState, null);
         sbo3.setButtonId(300);
-        sbo4 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        sbo4 = new SoftButtonObject(null, defaultState, null);
         sbo4.setButtonId(400);
-        sbo5 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        sbo5 = new SoftButtonObject(null, defaultState, null);
         sbo5.setButtonId(500);
         screenManager.checkAndAssignButtonIds(Arrays.asList(sbo1, sbo2, sbo3, sbo4, sbo5), BaseScreenManager.ManagerLocation.SOFTBUTTON_MANAGER);
         assertEquals("SoftButtonObject id doesn't match the expected value", 100, sbo1.getButtonId());
@@ -253,13 +254,13 @@ public class ScreenManagerTests {
 
 
         // Case 3 - Set ids for some buttons (Manager shouldn't alter the ids set by developer. And it should assign ids for the ones that don't have id)
-        sbo1 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        sbo1 = new SoftButtonObject(null, defaultState, null);
         sbo1.setButtonId(50);
-        sbo2 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
-        sbo3 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
-        sbo4 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        sbo2 = new SoftButtonObject(null, defaultState, null);
+        sbo3 = new SoftButtonObject(null, defaultState, null);
+        sbo4 = new SoftButtonObject(null, defaultState, null);
         sbo4.setButtonId(100);
-        sbo5 = new SoftButtonObject(null, Collections.EMPTY_LIST, null, null);
+        sbo5 = new SoftButtonObject(null, defaultState, null);
         screenManager.checkAndAssignButtonIds(Arrays.asList(sbo1, sbo2, sbo3, sbo4, sbo5), BaseScreenManager.ManagerLocation.SOFTBUTTON_MANAGER);
         assertEquals("SoftButtonObject id doesn't match the expected value", 50, sbo1.getButtonId());
         assertEquals("SoftButtonObject id doesn't match the expected value", 101, sbo2.getButtonId());

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -455,10 +455,31 @@ public class SoftButtonManagerTests {
     }
 
     /**
-     * Test assigning a nonempty state list to existing SoftButtonObject
+     * Test assigning a state list with the current state to existing SoftButtonObject
      */
     @Test
-    public void testAssignNonEmptyStateListToSoftButtonObject() {
+    public void testAssignStateListWithCurrentStateToSoftButtonObject() {
+        List<SoftButtonState> stateList1 = new ArrayList<>();
+        SoftButtonState softButtonState1 = new SoftButtonState("hello_there", "Hello there", null);
+        stateList1.add(softButtonState1);
+
+        List<SoftButtonState> stateList2 = new ArrayList<>();
+        SoftButtonState softButtonState2 = new SoftButtonState("general_kenobi", "General Kenobi", null);
+        stateList2.add(softButtonState1);
+        stateList2.add(softButtonState2);
+
+        SoftButtonObject softButtonObject = new SoftButtonObject("general_kenobi", stateList1, "hello_there", null);
+
+        softButtonObject.setStates(stateList2);
+
+        assertEquals(stateList2, softButtonObject.getStates());
+    }
+
+    /**
+     * Test assigning a state list without the current state to existing SoftButtonObject
+     */
+    @Test
+    public void testAssignStateListWithoutCurrentStateToSoftButtonObject() {
         List<SoftButtonState> stateList1 = new ArrayList<>();
         SoftButtonState softButtonState1 = new SoftButtonState("hello_there", "Hello there", null);
         stateList1.add(softButtonState1);

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -351,8 +351,8 @@ public class SoftButtonManagerTests {
         softButtonStateList.add(softButtonState1);
         softButtonStateList2.add(softButtonState1);
         softButtonStateList2.add(softButtonState2);
-        softButtonObject1 = new SoftButtonObject("hi", softButtonStateList, "Hi", null);
-        softButtonObject2 = new SoftButtonObject("hi", softButtonStateList2, "Hi", null);
+        softButtonObject1 = new SoftButtonObject("hi", softButtonStateList, softButtonStateList.get(0).getName(), null);
+        softButtonObject2 = new SoftButtonObject("hi", softButtonStateList2, softButtonStateList2.get(0).getName(), null);
         assertNotEquals(softButtonObject1, softButtonObject2);
 
         // Case 5: SoftButtonStates are not the same, assertFalse
@@ -366,8 +366,8 @@ public class SoftButtonManagerTests {
         assertNotEquals(softButtonObject1, softButtonObject2);
 
         // Case 7: SoftButtonObject currentStateName not same, assertFalse
-        softButtonObject1 = new SoftButtonObject("hi", softButtonStateList, "Hi", null);
-        softButtonObject2 = new SoftButtonObject("hi", softButtonStateList, "Hi2", null);
+        softButtonObject1 = new SoftButtonObject("hi", softButtonStateList2, softButtonStateList2.get(0).getName(), null);
+        softButtonObject2 = new SoftButtonObject("hi", softButtonStateList2, softButtonStateList2.get(1).getName(), null);
         assertNotEquals(softButtonObject1, softButtonObject2);
     }
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -33,7 +33,6 @@ import com.smartdevicelink.proxy.rpc.enums.SystemCapabilityType;
 import com.smartdevicelink.proxy.rpc.listeners.OnRPCNotificationListener;
 import com.smartdevicelink.test.Validator;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -58,14 +57,11 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import android.database.sqlite.SQLiteCantOpenDatabaseException;
-
 /**
  * This is a unit test class for the SmartDeviceLink library manager class :
  * {@link SoftButtonManager}
  */
 @RunWith(AndroidJUnit4.class)
-//@RunWith(JUnit4.class)
 public class SoftButtonManagerTests {
 
     private SoftButtonManager softButtonManager;
@@ -414,20 +410,20 @@ public class SoftButtonManagerTests {
     @Test
     public void testConstructSoftButtonObjectWithEmptyStateList() {
         List<SoftButtonState> stateList = new ArrayList<>();
-        SoftButtonObject softButtonObject1 = new SoftButtonObject("hello_there", stateList, "general_kenobi", null);
-        assertNull(softButtonObject1.getStates());
+        SoftButtonObject softButtonObject = new SoftButtonObject("hello_there", stateList, "general_kenobi", null);
+        assertNull(softButtonObject.getStates());
     }
 
     /**
      * Test constructing SoftButtonObject with an nonempty state list
      */
     @Test
-    public void testConstructingSoftButtonObjectWithNonEmptyStateList() {
+    public void testConstructSoftButtonObjectWithNonEmptyStateList() {
         List<SoftButtonState> stateList = new ArrayList<>();
         SoftButtonState softButtonState = new SoftButtonState("general_kenobi", "General Kenobi", null);
         stateList.add(softButtonState);
-        SoftButtonObject softButtonObject2 = new SoftButtonObject("hello_there_again", stateList, "general_kenobi", null);
-        assertEquals(stateList, softButtonObject2.getStates());
+        SoftButtonObject softButtonObject = new SoftButtonObject("hello_there", stateList, "general_kenobi", null);
+        assertEquals(stateList, softButtonObject.getStates());
     }
 
     /**
@@ -435,13 +431,15 @@ public class SoftButtonManagerTests {
      */
     @Test
     public void testAssignEmptyStateListToSoftButtonObject() {
-        List<SoftButtonState> stateList = new ArrayList<>();
-        SoftButtonState softButtonState = new SoftButtonState("object1-state1", "o1s1", null);
+        List<SoftButtonState> nonEmptyStateList = new ArrayList<>();
+        List<SoftButtonState> emptyStateList = new ArrayList<>();
+        SoftButtonState softButtonState = new SoftButtonState("general_kenobi", "General Kenobi", null);
+        nonEmptyStateList.add(softButtonState);
 
-        SoftButtonObject softButtonObject = new SoftButtonObject("hi", softButtonState, null);
+        SoftButtonObject softButtonObject = new SoftButtonObject("hello_there", nonEmptyStateList, "general_kenobi", null);
 
-        softButtonObject.setStates(stateList);
-        assertNotEquals(stateList, softButtonObject.getStates());
+        softButtonObject.setStates(emptyStateList);
+        assertEquals(nonEmptyStateList, softButtonObject.getStates());
     }
 
     /**
@@ -449,13 +447,18 @@ public class SoftButtonManagerTests {
      */
     @Test
     public void testAssignNonEmptyStateListToSoftButtonObject() {
-        List<SoftButtonState> stateList = new ArrayList<>();
-        SoftButtonState softButtonState = new SoftButtonState("object1-state1", "o1s1", null);
+        List<SoftButtonState> stateList1 = new ArrayList<>();
+        SoftButtonState softButtonState1 = new SoftButtonState("hello_there", "Hello there", null);
+        stateList1.add(softButtonState1);
 
-        SoftButtonObject softButtonObject = new SoftButtonObject("hi", softButtonState, null);
+        List<SoftButtonState> stateList2 = new ArrayList<>();
+        SoftButtonState softButtonState2 = new SoftButtonState("general_kenobi", "General Kenobi", null);
+        stateList2.add(softButtonState2);
 
-        stateList.add(softButtonState);
-        softButtonObject.setStates(stateList);
-        assertEquals(stateList, softButtonObject.getStates());
+        SoftButtonObject softButtonObject = new SoftButtonObject("general_kenobi", stateList1, "general_kenobi", null);
+
+        softButtonObject.setStates(stateList2);
+
+        assertEquals(stateList2, softButtonObject.getStates());
     }
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -455,7 +455,7 @@ public class SoftButtonManagerTests {
         SoftButtonState softButtonState2 = new SoftButtonState("general_kenobi", "General Kenobi", null);
         stateList2.add(softButtonState2);
 
-        SoftButtonObject softButtonObject = new SoftButtonObject("general_kenobi", stateList1, "general_kenobi", null);
+        SoftButtonObject softButtonObject = new SoftButtonObject("general_kenobi", stateList1, "hello_there", null);
 
         softButtonObject.setStates(stateList2);
 
@@ -477,7 +477,7 @@ public class SoftButtonManagerTests {
         SoftButtonState softButtonState3 = new SoftButtonState("general_kenobi", "General Kenobi Again", null);
         stateListDuplicateNames.add(softButtonState3);
 
-        SoftButtonObject softButtonObject = new SoftButtonObject("general_kenobi", stateListUnique, "general_kenobi", null);
+        SoftButtonObject softButtonObject = new SoftButtonObject("general_kenobi", stateListUnique, "hello_there", null);
 
         softButtonObject.setStates(stateListDuplicateNames);
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -427,6 +427,18 @@ public class SoftButtonManagerTests {
     }
 
     /**
+     * Test constructing SoftButtonObject with an invalid initialStateName
+     */
+    @Test
+    public void testConstructSoftButtonObjectWithInvalidInitialStateName() {
+        List<SoftButtonState> stateList = new ArrayList<>();
+        SoftButtonState softButtonState = new SoftButtonState("general_kenobi", "General Kenobi", null);
+        stateList.add(softButtonState);
+        SoftButtonObject softButtonObject = new SoftButtonObject("hello_there", stateList, "hello_there", null);
+        assertNull(softButtonObject.getStates());
+    }
+
+    /**
      * Test assigning an empty state list to existing SoftButtonObject
      */
     @Test

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertNull;
@@ -56,13 +57,12 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import junit.framework.TestCase;
-
 /**
  * This is a unit test class for the SmartDeviceLink library manager class :
  * {@link SoftButtonManager}
  */
 @RunWith(AndroidJUnit4.class)
+//@RunWith(JUnit4.class)
 public class SoftButtonManagerTests {
 
     private SoftButtonManager softButtonManager;
@@ -411,14 +411,12 @@ public class SoftButtonManagerTests {
     @Test
     public void testConstructSoftButtonObjectWithEmptyStateList() {
         List<SoftButtonState> stateList = new ArrayList<>();
+        // Uncommenting the following lines should make the test fail
+        // SoftButtonState softButtonState = new SoftButtonState("object1-state1", "o1s1", null);
+        // stateList.add(softButtonState);
+        SoftButtonObject softButtonObject = new SoftButtonObject("hi", stateList, "Hi", null);
 
-        try {
-            new SoftButtonObject("hi", stateList, "Hi", null);
-            TestCase.fail("IllegalStateException expected");
-        }
-        catch (IllegalStateException ignored) {
-
-        }
+        assertTrue(softButtonObject.getAttemptedToAssignEmptyStateList());
     }
 
     /**
@@ -429,14 +427,9 @@ public class SoftButtonManagerTests {
         List<SoftButtonState> stateList = new ArrayList<>();
         SoftButtonState softButtonState = new SoftButtonState("object1-state1", "o1s1", null);
 
-
-        try {
-            SoftButtonObject softButtonObject = new SoftButtonObject("hi", softButtonState, null);
-            softButtonObject.setStates(stateList);
-            TestCase.fail("IllegalStateException expected");
-        }
-        catch (IllegalStateException ignored) {
-
-        }
+        SoftButtonObject softButtonObject = new SoftButtonObject("hi", softButtonState, null);
+        // Commenting the following line should make the test fail
+        softButtonObject.setStates(stateList);
+        assertTrue(softButtonObject.getAttemptedToAssignEmptyStateList());
     }
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -419,7 +419,7 @@ public class SoftButtonManagerTests {
     }
 
     /**
-     * Test constructing SoftButtonObject with an empty state list
+     * Test constructing SoftButtonObject with an nonempty state list
      */
     @Test
     public void testConstructingSoftButtonObjectWithNonEmptyStateList() {

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -33,6 +33,7 @@ import com.smartdevicelink.proxy.rpc.enums.SystemCapabilityType;
 import com.smartdevicelink.proxy.rpc.listeners.OnRPCNotificationListener;
 import com.smartdevicelink.test.Validator;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,6 +57,8 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import android.database.sqlite.SQLiteCantOpenDatabaseException;
 
 /**
  * This is a unit test class for the SmartDeviceLink library manager class :
@@ -411,12 +414,20 @@ public class SoftButtonManagerTests {
     @Test
     public void testConstructSoftButtonObjectWithEmptyStateList() {
         List<SoftButtonState> stateList = new ArrayList<>();
-        // Uncommenting the following lines should make the test fail
-        // SoftButtonState softButtonState = new SoftButtonState("object1-state1", "o1s1", null);
-        // stateList.add(softButtonState);
-        SoftButtonObject softButtonObject = new SoftButtonObject("hi", stateList, "Hi", null);
+        SoftButtonObject softButtonObject1 = new SoftButtonObject("hello_there", stateList, "general_kenobi", null);
+        assertNull(softButtonObject1.getStates());
+    }
 
-        assertTrue(softButtonObject.getAttemptedToAssignEmptyStateList());
+    /**
+     * Test constructing SoftButtonObject with an empty state list
+     */
+    @Test
+    public void testConstructingSoftButtonObjectWithNonEmptyStateList() {
+        List<SoftButtonState> stateList = new ArrayList<>();
+        SoftButtonState softButtonState = new SoftButtonState("general_kenobi", "General Kenobi", null);
+        stateList.add(softButtonState);
+        SoftButtonObject softButtonObject2 = new SoftButtonObject("hello_there_again", stateList, "general_kenobi", null);
+        assertEquals(stateList, softButtonObject2.getStates());
     }
 
     /**
@@ -428,8 +439,23 @@ public class SoftButtonManagerTests {
         SoftButtonState softButtonState = new SoftButtonState("object1-state1", "o1s1", null);
 
         SoftButtonObject softButtonObject = new SoftButtonObject("hi", softButtonState, null);
-        // Commenting the following line should make the test fail
+
         softButtonObject.setStates(stateList);
-        assertTrue(softButtonObject.getAttemptedToAssignEmptyStateList());
+        assertNotEquals(stateList, softButtonObject.getStates());
+    }
+
+    /**
+     * Test assigning a nonempty state list to existing SoftButtonObject
+     */
+    @Test
+    public void testAssignNonEmptyStateListToSoftButtonObject() {
+        List<SoftButtonState> stateList = new ArrayList<>();
+        SoftButtonState softButtonState = new SoftButtonState("object1-state1", "o1s1", null);
+
+        SoftButtonObject softButtonObject = new SoftButtonObject("hi", softButtonState, null);
+
+        stateList.add(softButtonState);
+        softButtonObject.setStates(stateList);
+        assertEquals(stateList, softButtonObject.getStates());
     }
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -56,6 +56,8 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import junit.framework.TestCase;
+
 /**
  * This is a unit test class for the SmartDeviceLink library manager class :
  * {@link SoftButtonManager}
@@ -401,5 +403,40 @@ public class SoftButtonManagerTests {
         // Case 6 they are equal, assertTrue
         softButtonState2 = new SoftButtonState("object1-state1", "o1s1", artwork1);
         assertEquals(softButtonState1, softButtonState2);
+    }
+
+    /**
+     * Test constructing SoftButtonObject with an empty state list
+     */
+    @Test
+    public void testConstructSoftButtonObjectWithEmptyStateList() {
+        List<SoftButtonState> stateList = new ArrayList<>();
+
+        try {
+            new SoftButtonObject("hi", stateList, "Hi", null);
+            TestCase.fail("IllegalStateException expected");
+        }
+        catch (IllegalStateException ignored) {
+
+        }
+    }
+
+    /**
+     * Test assigning an empty state list to existing SoftButtonObject
+     */
+    @Test
+    public void testAssignEmptyStateListToSoftButtonObject() {
+        List<SoftButtonState> stateList = new ArrayList<>();
+        SoftButtonState softButtonState = new SoftButtonState("object1-state1", "o1s1", null);
+
+
+        try {
+            SoftButtonObject softButtonObject = new SoftButtonObject("hi", softButtonState, null);
+            softButtonObject.setStates(stateList);
+            TestCase.fail("IllegalStateException expected");
+        }
+        catch (IllegalStateException ignored) {
+
+        }
     }
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -461,4 +461,26 @@ public class SoftButtonManagerTests {
 
         assertEquals(stateList2, softButtonObject.getStates());
     }
+
+    /**
+     * Test assigning a state list with states that have the same name to existing SoftButtonObject
+     */
+    @Test
+    public void testAssignSameNameStateListToSoftButtonObject() {
+        List<SoftButtonState> stateListUnique = new ArrayList<>();
+        SoftButtonState softButtonState1 = new SoftButtonState("hello_there", "Hello there", null);
+        stateListUnique.add(softButtonState1);
+
+        List<SoftButtonState> stateListDuplicateNames = new ArrayList<>();
+        SoftButtonState softButtonState2 = new SoftButtonState("general_kenobi", "General Kenobi", null);
+        stateListDuplicateNames.add(softButtonState2);
+        SoftButtonState softButtonState3 = new SoftButtonState("general_kenobi", "General Kenobi Again", null);
+        stateListDuplicateNames.add(softButtonState3);
+
+        SoftButtonObject softButtonObject = new SoftButtonObject("general_kenobi", stateListUnique, "general_kenobi", null);
+
+        softButtonObject.setStates(stateListDuplicateNames);
+
+        assertEquals(stateListUnique, softButtonObject.getStates());
+    }
 }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -33,7 +33,6 @@ package com.smartdevicelink.managers.screen;
 
 import androidx.annotation.NonNull;
 
-import com.livio.BuildConfig;
 import com.smartdevicelink.managers.file.filetypes.SdlArtwork;
 import com.smartdevicelink.proxy.rpc.OnButtonEvent;
 import com.smartdevicelink.proxy.rpc.OnButtonPress;
@@ -283,8 +282,16 @@ public class SoftButtonObject implements Cloneable{
             DebugTool.logError(TAG, "A SoftButtonObject must have states with different names.");
             return;
         }
-        if (states.isEmpty()) {
-            DebugTool.logError(TAG, "A SoftButtonState list must contain at least one state");
+
+        boolean hasStateWithCurrentName = false;
+        for (SoftButtonState state : states) {
+            if(state.getName().equals(currentStateName)) {
+                hasStateWithCurrentNameName = true;
+                break;
+            }
+        }
+        if (!hasStateWithCurrentName) {
+            DebugTool.logError(TAG, "A SoftButtonObject must have a state with currentStateName.");
             return;
         }
 

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -32,13 +32,11 @@
 package com.smartdevicelink.managers.screen;
 
 import androidx.annotation.NonNull;
-
 import com.smartdevicelink.managers.file.filetypes.SdlArtwork;
 import com.smartdevicelink.proxy.rpc.OnButtonEvent;
 import com.smartdevicelink.proxy.rpc.OnButtonPress;
 import com.smartdevicelink.proxy.rpc.SoftButton;
 import com.smartdevicelink.util.DebugTool;
-
 import java.util.Collections;
 import java.util.List;
 
@@ -406,5 +404,4 @@ public class SoftButtonObject implements Cloneable{
         }
         return null;
     }
-
 }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -73,6 +73,8 @@ public class SoftButtonObject implements Cloneable{
      */
     public SoftButtonObject(@NonNull String name, @NonNull List<SoftButtonState> states, @NonNull String initialStateName, OnEventListener onEventListener) {
 
+        setStates(states);
+
         // Make sure there aren't two states with the same name
         if (hasTwoStatesOfSameName(states)) {
             DebugTool.logError(TAG, "Two states have the same name in states list for soft button object");
@@ -80,7 +82,6 @@ public class SoftButtonObject implements Cloneable{
         }
 
         this.name = name;
-        this.states = states;
         this.currentStateName = initialStateName;
         this.buttonId = SOFT_BUTTON_ID_NOT_SET_VALUE;
         this.onEventListener = onEventListener;
@@ -264,6 +265,11 @@ public class SoftButtonObject implements Cloneable{
      * @param states a list of the object's soft button states. <strong>states should be unique for every SoftButtonObject. A SoftButtonState instance cannot be reused for multiple SoftButtonObjects.</strong>
      */
     public void setStates(@NonNull List<SoftButtonState> states) {
+        // Make sure the list of states is not empty
+        if (states.isEmpty()) {
+            throw new IllegalStateException("The state list is empty");
+        }
+
         this.states = states;
     }
 

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -73,17 +73,6 @@ public class SoftButtonObject implements Cloneable{
      */
     public SoftButtonObject(@NonNull String name, @NonNull List<SoftButtonState> states, @NonNull String initialStateName, OnEventListener onEventListener) {
 
-        /*// If the list of states is empty, throw an error with DebugTool and return
-        if (states.isEmpty()) {
-            DebugTool.logError(TAG,"The state list is empty");
-            return;
-        }
-        // Make sure there aren't two states with the same name
-        if (hasTwoStatesOfSameName(states)) {
-            DebugTool.logError(TAG, "Two states have the same name in states list for soft button object");
-            return;
-        }*/
-
         boolean repeatedStateNames = hasTwoStatesOfSameName(states);
 
         boolean hasStateWithInitialName = false;
@@ -96,14 +85,10 @@ public class SoftButtonObject implements Cloneable{
 
         if (repeatedStateNames) {
             DebugTool.logError(TAG, "A SoftButtonObject must have states with different names.");
-            if (BuildConfig.DEBUG)
-                throw new AssertionError("A SoftButtonObject must have states with different names.");
             return;
         }
         if (!hasStateWithInitialName) {
             DebugTool.logError(TAG, "A SoftButtonObject must have a state with initialStateName.");
-            if (BuildConfig.DEBUG)
-                throw new AssertionError("A SoftButtonObject must have a state with initialStateName.");
             return;
         }
         this.name = name;
@@ -296,14 +281,10 @@ public class SoftButtonObject implements Cloneable{
 
         if (repeatedStateNames) {
             DebugTool.logError(TAG, "A SoftButtonObject must have states with different names.");
-            if (BuildConfig.DEBUG)
-                throw new AssertionError("A SoftButtonObject must have states with different names.");
             return;
         }
         if (states.isEmpty()) {
             DebugTool.logError(TAG, "A SoftButtonState list must contain at least one state");
-            if (BuildConfig.DEBUG)
-                throw new AssertionError("A SoftButtonState list must contain at least one state");
             return;
         }
 

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -96,13 +96,13 @@ public class SoftButtonObject implements Cloneable{
 
         if (repeatedStateNames) {
             DebugTool.logError(TAG, "A SoftButtonObject must have states with different names.");
-            if (BuildConfig.DEBUG && repeatedStateNames)
+            if (BuildConfig.DEBUG)
                 throw new AssertionError("A SoftButtonObject must have states with different names.");
             return;
         }
         if (!hasStateWithInitialName) {
             DebugTool.logError(TAG, "A SoftButtonObject must have a state with initialStateName.");
-            if (BuildConfig.DEBUG && !hasStateWithInitialName)
+            if (BuildConfig.DEBUG)
                 throw new AssertionError("A SoftButtonObject must have a state with initialStateName.");
             return;
         }
@@ -291,28 +291,18 @@ public class SoftButtonObject implements Cloneable{
      * @param states a list of the object's soft button states. <strong>states should be unique for every SoftButtonObject. A SoftButtonState instance cannot be reused for multiple SoftButtonObjects.</strong>
      */
     public void setStates(@NonNull List<SoftButtonState> states) {
-        /*// If the list of states is empty, throw an error with DebugTool and return
-        if (states.isEmpty()) {
-            DebugTool.logError(TAG,"The state list is empty");
-            return;
-        }
-        // Make sure there aren't two states with the same name
-        if (hasTwoStatesOfSameName(states)) {
-            DebugTool.logError(TAG, "Two states have the same name in states list for soft button object");
-            return;
-        }*/
 
         boolean repeatedStateNames = hasTwoStatesOfSameName(states);
 
         if (repeatedStateNames) {
             DebugTool.logError(TAG, "A SoftButtonObject must have states with different names.");
-            if (BuildConfig.DEBUG && repeatedStateNames)
+            if (BuildConfig.DEBUG)
                 throw new AssertionError("A SoftButtonObject must have states with different names.");
             return;
         }
         if (states.isEmpty()) {
             DebugTool.logError(TAG, "A SoftButtonState list must contain at least one state");
-            if (BuildConfig.DEBUG && states.isEmpty())
+            if (BuildConfig.DEBUG)
                 throw new AssertionError("A SoftButtonState list must contain at least one state");
             return;
         }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -272,6 +272,11 @@ public class SoftButtonObject implements Cloneable{
             DebugTool.logError(TAG,"The state list is empty");
             return;
         }
+        // Make sure there aren't two states with the same name
+        if (hasTwoStatesOfSameName(states)) {
+            DebugTool.logError(TAG, "Two states have the same name in states list for soft button object");
+            return;
+        }
 
         this.states = states;
     }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -83,10 +83,10 @@ public class SoftButtonObject implements Cloneable{
         }
 
         this.name = name;
+        this.states = states;
         this.currentStateName = initialStateName;
         this.buttonId = SOFT_BUTTON_ID_NOT_SET_VALUE;
         this.onEventListener = onEventListener;
-        this.states = states;
     }
 
     /**

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -296,7 +296,7 @@ public class SoftButtonObject implements Cloneable{
             }
         }
         if (!hasStateWithCurrentName) {
-            DebugTool.logError(TAG, "A SoftButtonObject should have a state with currentStateName.");
+            DebugTool.logError(TAG, "A SoftButtonObject setting states must contain a state with the name " + currentStateName + ".");
         }
 
         this.states = states;

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -70,6 +70,7 @@ public class SoftButtonObject implements Cloneable{
      * @param initialStateName a String value represents the name for the initial state
      * @param onEventListener  a listener that has a callback that will be triggered when a button event happens
      *                         Note: the initialStateName should match exactly the name of one of the states for the object. Otherwise an exception will be thrown.
+     * @throws IllegalStateException if states is an empty list
      */
     public SoftButtonObject(@NonNull String name, @NonNull List<SoftButtonState> states, @NonNull String initialStateName, OnEventListener onEventListener) {
 
@@ -263,6 +264,7 @@ public class SoftButtonObject implements Cloneable{
      * Set the the SoftButtonState list
      *
      * @param states a list of the object's soft button states. <strong>states should be unique for every SoftButtonObject. A SoftButtonState instance cannot be reused for multiple SoftButtonObjects.</strong>
+     * @throws IllegalStateException if states is an empty list
      */
     public void setStates(@NonNull List<SoftButtonState> states) {
         // Make sure the list of states is not empty

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -283,16 +283,20 @@ public class SoftButtonObject implements Cloneable{
             return;
         }
 
+        if (states.isEmpty()) {
+            DebugTool.logError(TAG, "A SoftButtonObject must contain at least one state");
+            return;
+        }
+
         boolean hasStateWithCurrentName = false;
         for (SoftButtonState state : states) {
             if(state.getName().equals(currentStateName)) {
-                hasStateWithCurrentNameName = true;
+                hasStateWithCurrentName = true;
                 break;
             }
         }
         if (!hasStateWithCurrentName) {
-            DebugTool.logError(TAG, "A SoftButtonObject must have a state with currentStateName.");
-            return;
+            DebugTool.logError(TAG, "A SoftButtonObject should have a state with currentStateName.");
         }
 
         this.states = states;

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -38,7 +38,6 @@ import com.smartdevicelink.proxy.rpc.OnButtonEvent;
 import com.smartdevicelink.proxy.rpc.OnButtonPress;
 import com.smartdevicelink.proxy.rpc.SoftButton;
 import com.smartdevicelink.util.DebugTool;
-import com.smartdevicelink.util.Log;
 
 import java.util.Collections;
 import java.util.List;

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -32,6 +32,8 @@
 package com.smartdevicelink.managers.screen;
 
 import androidx.annotation.NonNull;
+
+import com.livio.BuildConfig;
 import com.smartdevicelink.managers.file.filetypes.SdlArtwork;
 import com.smartdevicelink.proxy.rpc.OnButtonEvent;
 import com.smartdevicelink.proxy.rpc.OnButtonPress;
@@ -71,7 +73,7 @@ public class SoftButtonObject implements Cloneable{
      */
     public SoftButtonObject(@NonNull String name, @NonNull List<SoftButtonState> states, @NonNull String initialStateName, OnEventListener onEventListener) {
 
-        // If the list of states is empty, throw an error with DebugTool and return
+        /*// If the list of states is empty, throw an error with DebugTool and return
         if (states.isEmpty()) {
             DebugTool.logError(TAG,"The state list is empty");
             return;
@@ -80,8 +82,30 @@ public class SoftButtonObject implements Cloneable{
         if (hasTwoStatesOfSameName(states)) {
             DebugTool.logError(TAG, "Two states have the same name in states list for soft button object");
             return;
+        }*/
+
+        boolean repeatedStateNames = hasTwoStatesOfSameName(states);
+
+        boolean hasStateWithInitialName = false;
+        for (SoftButtonState state : states) {
+            if(state.getName().equals(initialStateName)) {
+                hasStateWithInitialName = true;
+                break;
+            }
         }
 
+        if (repeatedStateNames) {
+            DebugTool.logError(TAG, "A SoftButtonObject must have states with different names.");
+            if (BuildConfig.DEBUG && repeatedStateNames)
+                throw new AssertionError("A SoftButtonObject must have states with different names.");
+            return;
+        }
+        if (!hasStateWithInitialName) {
+            DebugTool.logError(TAG, "A SoftButtonObject must have a state with initialStateName.");
+            if (BuildConfig.DEBUG && !hasStateWithInitialName)
+                throw new AssertionError("A SoftButtonObject must have a state with initialStateName.");
+            return;
+        }
         this.name = name;
         this.states = states;
         this.currentStateName = initialStateName;
@@ -267,7 +291,7 @@ public class SoftButtonObject implements Cloneable{
      * @param states a list of the object's soft button states. <strong>states should be unique for every SoftButtonObject. A SoftButtonState instance cannot be reused for multiple SoftButtonObjects.</strong>
      */
     public void setStates(@NonNull List<SoftButtonState> states) {
-        // If the list of states is empty, throw an error with DebugTool and return
+        /*// If the list of states is empty, throw an error with DebugTool and return
         if (states.isEmpty()) {
             DebugTool.logError(TAG,"The state list is empty");
             return;
@@ -275,6 +299,21 @@ public class SoftButtonObject implements Cloneable{
         // Make sure there aren't two states with the same name
         if (hasTwoStatesOfSameName(states)) {
             DebugTool.logError(TAG, "Two states have the same name in states list for soft button object");
+            return;
+        }*/
+
+        boolean repeatedStateNames = hasTwoStatesOfSameName(states);
+
+        if (repeatedStateNames) {
+            DebugTool.logError(TAG, "A SoftButtonObject must have states with different names.");
+            if (BuildConfig.DEBUG && repeatedStateNames)
+                throw new AssertionError("A SoftButtonObject must have states with different names.");
+            return;
+        }
+        if (states.isEmpty()) {
+            DebugTool.logError(TAG, "A SoftButtonState list must contain at least one state");
+            if (BuildConfig.DEBUG && states.isEmpty())
+                throw new AssertionError("A SoftButtonState list must contain at least one state");
             return;
         }
 

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -38,6 +38,7 @@ import com.smartdevicelink.proxy.rpc.OnButtonEvent;
 import com.smartdevicelink.proxy.rpc.OnButtonPress;
 import com.smartdevicelink.proxy.rpc.SoftButton;
 import com.smartdevicelink.util.DebugTool;
+import com.smartdevicelink.util.Log;
 
 import java.util.Collections;
 import java.util.List;
@@ -61,6 +62,7 @@ public class SoftButtonObject implements Cloneable{
     private int buttonId;
     private OnEventListener onEventListener;
     private UpdateListener updateListener;
+    private boolean attemptedToAssignEmptyStateList = false;
 
     /**
      * Create a new instance of the SoftButtonObject with multiple states
@@ -70,7 +72,6 @@ public class SoftButtonObject implements Cloneable{
      * @param initialStateName a String value represents the name for the initial state
      * @param onEventListener  a listener that has a callback that will be triggered when a button event happens
      *                         Note: the initialStateName should match exactly the name of one of the states for the object. Otherwise an exception will be thrown.
-     * @throws IllegalStateException if states is an empty list
      */
     public SoftButtonObject(@NonNull String name, @NonNull List<SoftButtonState> states, @NonNull String initialStateName, OnEventListener onEventListener) {
 
@@ -264,12 +265,13 @@ public class SoftButtonObject implements Cloneable{
      * Set the the SoftButtonState list
      *
      * @param states a list of the object's soft button states. <strong>states should be unique for every SoftButtonObject. A SoftButtonState instance cannot be reused for multiple SoftButtonObjects.</strong>
-     * @throws IllegalStateException if states is an empty list
      */
     public void setStates(@NonNull List<SoftButtonState> states) {
-        // Make sure the list of states is not empty
-        if (states.isEmpty()) {
-            throw new IllegalStateException("The state list is empty");
+        // If the list of states is empty, throw an error with DebugTool and return
+        attemptedToAssignEmptyStateList = states.isEmpty();
+        if (attemptedToAssignEmptyStateList) {
+            DebugTool.logError(TAG,"The state list is empty");
+            return;
         }
 
         this.states = states;
@@ -402,5 +404,14 @@ public class SoftButtonObject implements Cloneable{
             }
         }
         return null;
+    }
+
+    /**
+     * Used to make unit testing easier by removing the need to read debug logs programmatically
+     *
+     * @return True if the last list passed to setStates() was empty and false otherwise
+     */
+    public boolean getAttemptedToAssignEmptyStateList() {
+        return attemptedToAssignEmptyStateList;
     }
 }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonObject.java
@@ -61,7 +61,6 @@ public class SoftButtonObject implements Cloneable{
     private int buttonId;
     private OnEventListener onEventListener;
     private UpdateListener updateListener;
-    private boolean attemptedToAssignEmptyStateList = false;
 
     /**
      * Create a new instance of the SoftButtonObject with multiple states
@@ -74,8 +73,11 @@ public class SoftButtonObject implements Cloneable{
      */
     public SoftButtonObject(@NonNull String name, @NonNull List<SoftButtonState> states, @NonNull String initialStateName, OnEventListener onEventListener) {
 
-        setStates(states);
-
+        // If the list of states is empty, throw an error with DebugTool and return
+        if (states.isEmpty()) {
+            DebugTool.logError(TAG,"The state list is empty");
+            return;
+        }
         // Make sure there aren't two states with the same name
         if (hasTwoStatesOfSameName(states)) {
             DebugTool.logError(TAG, "Two states have the same name in states list for soft button object");
@@ -86,6 +88,7 @@ public class SoftButtonObject implements Cloneable{
         this.currentStateName = initialStateName;
         this.buttonId = SOFT_BUTTON_ID_NOT_SET_VALUE;
         this.onEventListener = onEventListener;
+        this.states = states;
     }
 
     /**
@@ -267,8 +270,7 @@ public class SoftButtonObject implements Cloneable{
      */
     public void setStates(@NonNull List<SoftButtonState> states) {
         // If the list of states is empty, throw an error with DebugTool and return
-        attemptedToAssignEmptyStateList = states.isEmpty();
-        if (attemptedToAssignEmptyStateList) {
+        if (states.isEmpty()) {
             DebugTool.logError(TAG,"The state list is empty");
             return;
         }
@@ -405,12 +407,4 @@ public class SoftButtonObject implements Cloneable{
         return null;
     }
 
-    /**
-     * Used to make unit testing easier by removing the need to read debug logs programmatically
-     *
-     * @return True if the last list passed to setStates() was empty and false otherwise
-     */
-    public boolean getAttemptedToAssignEmptyStateList() {
-        return attemptedToAssignEmptyStateList;
-    }
 }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
@@ -33,7 +33,6 @@ package com.smartdevicelink.managers.screen;
 
 import androidx.annotation.NonNull;
 
-import com.livio.BuildConfig;
 import com.smartdevicelink.managers.file.filetypes.SdlArtwork;
 import com.smartdevicelink.proxy.rpc.SoftButton;
 import com.smartdevicelink.proxy.rpc.enums.SoftButtonType;

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
@@ -66,8 +66,6 @@ public class SoftButtonState {
         if (text == null && artwork == null) {
             DebugTool.logError(TAG, "Attempted to create an invalid soft button state: text and artwork are both null");
             softButton = null;
-            if (BuildConfig.DEBUG)
-                throw new AssertionError("Attempted to create an invalid soft button state: text and artwork are both null");
             return;
         }
         this.name = name;

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
@@ -33,6 +33,7 @@ package com.smartdevicelink.managers.screen;
 
 import androidx.annotation.NonNull;
 
+import com.livio.BuildConfig;
 import com.smartdevicelink.managers.file.filetypes.SdlArtwork;
 import com.smartdevicelink.proxy.rpc.SoftButton;
 import com.smartdevicelink.proxy.rpc.enums.SoftButtonType;
@@ -65,6 +66,8 @@ public class SoftButtonState {
         if (text == null && artwork == null) {
             DebugTool.logError(TAG, "Attempted to create an invalid soft button state: text and artwork are both null");
             softButton = null;
+            if (BuildConfig.DEBUG)
+                throw new AssertionError("Attempted to create an invalid soft button state: text and artwork are both null");
             return;
         }
         this.name = name;


### PR DESCRIPTION
Fixes #1774

This PR is ready for review.

### Risk
This PR adds a new public getter function to SoftButtonObject

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior
- [x] I have tested Android and Java SE

#### Unit Tests
 - `testConstructSoftButtonObjectWithEmptyStateList()` passes if `getAttemptedToAssignEmptyStateList()` returns true after an empty state list is passed to the main primary constructor and fails otherwise.

- `testAssignEmptyStateListToSoftButtonObject()` passes if an `getAttemptedToAssignEmptyStateList()` returns true after an empty state list is passed to `setStates()` of an instance of `SoftButtonObject` that already has at least one state in its state list. 


#### Core Tests

##### Tests performed by modifying a local clone of hello_sdl_android

- Constructed an instance of `SoftButtonObject` with a state list containing a single state, added it to a list of `SoftButtonObject`s, and attempted to display them to the Generic HMI using `ScreenManager`. Results: 
  - That instance along with all the other instances in the same transaction displayed successfully.
  - The app continued to function normally
- Constructed an instance of `SoftButtonObject` with an empty state list, added it to a list of `SoftButtonObject`s, and attempted to display them to the Generic HMI using `ScreenManager`. Results: 
   - The instance printed an error with `DebugTool` stating that the state list is empty
   - That instance and all other other instances within the same transaction failed to display to the HMI
   - The app otherwise continued to function normally
-  Constructed an instance of `SoftButtonObject` with a state list containing a single state, reassigned the state list to an empty list using `setStates()`, added it to a list of `SoftButtonObject`s, and attempted to display them to the Generic HMI using `ScreenManager`. Results:
   - The instance printed an error with `DebugTool` stating that the state list is empty
   - The instance did not set overwrite the old state list with the new state list
   - The app otherwise continued to function normally

SDL Core / 8.0.0 / master / 68f082169e0a40fccd9eb0db3c83911c28870f07 / module tested against: SDL Core on Ubuntu 20.04.3 LTS Virtual Machine
Generic HMI / 0.11.0 / master / 47e0ad42f05b27adff61befd864e79c2ab4b8cec / module tested against: Generic HMI on Ubuntu 20.04.3 LTS Virtual Machine

### Summary
This pull request adds an if statement to `SoftButtonObject.setStates()` that checks if the given state list is empty and displays  if it is. This PR also replaces the direct state list assignment in the main constructor with usage of `setStates()` to enforce the check in the constructor without writing redundant code.

### Changelog
##### Breaking Changes
* None

##### Enhancements
* Adds a getter function to check if an empty list was passed to the instance 

##### Bug Fixes
* Fixes #1774

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
