### PR TITLE
Add timeout units to Javadoc comments

### DIFF
--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/ScrollableMessage.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/ScrollableMessage.java
@@ -70,7 +70,7 @@ import java.util.List;
  * 		<tr>
  * 			<td>timeout</td>
  * 			<td>Integer</td>
- * 			<td>App defined timeout.  Indicates how long of a timeout from the last action (i.e. scrolling message resets timeout).</td>
+ * 			<td>App defined timeout.  Indicates how long of a timeout in milliseconds from the last action (i.e. scrolling message resets timeout).</td>
  *                 <td>N</td>
  *                 <td>minValue=1000; maxValue=65535; defValue=30000</td>
  * 			<td>SmartDevice Link 1.0 </td>
@@ -166,10 +166,10 @@ public class ScrollableMessage extends RPCRequest {
     }
 
     /**
-     * Sets an App defined timeout. Indicates how long of a timeout from the
+     * Sets an App defined timeout. Indicates how long of a timeout in milliseconds from the
      * last action
      *
-     * @param timeout an Integer value representing an App defined timeout
+     * @param timeout an Integer value representing an App defined timeout in milliseconds
      *                <p></p>
      *                <b>Notes</b>:Minval=0; Maxval=65535;Default=30000
      */
@@ -179,9 +179,9 @@ public class ScrollableMessage extends RPCRequest {
     }
 
     /**
-     * Gets an App defined timeout
+     * Gets an App defined timeout in milliseconds
      *
-     * @return Integer -an Integer value representing an App defined timeout
+     * @return Integer -an Integer value representing an App defined timeout in milliseconds
      */
     public Integer getTimeout() {
         return getInteger(KEY_TIMEOUT);

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/Slider.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/Slider.java
@@ -95,7 +95,7 @@ import java.util.List;
  * 		<tr>
  * 			<td>timeout</td>
  * 			<td>String</td>
- * 			<td>App defined timeout.  Indicates how long of a timeout from the last action (i.e. sliding control resets timeout). If omitted, the value is set to 10000.</td>
+ * 			<td>App defined timeout.  Indicates how long of a timeout in milliseconds from the last action (i.e. sliding control resets timeout). If omitted, the value is set to 10000.</td>
  *                 <td>N</td>
  * 			<td>Minvalue=0; Maxvalue=65535; Defvalue= 10000</td>
  * 			<td>SmartDeviceLink 2.0</td>
@@ -255,9 +255,9 @@ public class Slider extends RPCRequest {
     }
 
     /**
-     * Sets an App defined timeout
+     * Sets an App defined timeout in milliseconds
      *
-     * @param timeout an Integer value representing an App defined timeout
+     * @param timeout an Integer value representing an App defined timeout in milliseconds
      *                <p></p>
      *                <b>Notes: </b>Minvalue=0; Maxvalue=65535; Defvalue=10000
      */
@@ -267,9 +267,9 @@ public class Slider extends RPCRequest {
     }
 
     /**
-     * Gets an App defined timeout
+     * Gets an App defined timeout in milliseconds
      *
-     * @return Integer -an Integer value representing an App defined timeout
+     * @return Integer -an Integer value representing an App defined timeout in milliseconds
      */
     public Integer getTimeout() {
         return getInteger(KEY_TIMEOUT);


### PR DESCRIPTION
Fixes #1775

This PR is ready for review.

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR - N/A
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [ ] I have tested Android, Java SE, and Java EE

#### Unit Tests
N/A - This PR only changes documentation, not runnable code.

#### Core Tests
N/A - This PR only changes documentation, not runnable code.

Core version / branch / commit hash / module tested against: N/A
HMI name / version / branch / commit hash / module tested against: N/A

### Summary
This PR adds the units (milliseconds) to the Javadoc comments related to timeouts in `ScrollableMessage`

### Changelog
##### Breaking Changes
* None

##### Enhancements
* Better documentation

##### Bug Fixes
* Fixes #1775

### Tasks Remaining:
* None

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
