### PR TITLE
Prevent NPE in SdlDeviceListener

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/utl/SdlDeviceListener.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/utl/SdlDeviceListener.java
@@ -262,6 +262,7 @@ public class SdlDeviceListener {
                 if (sdlListener.bluetoothTransport != null) {
                     sdlListener.bluetoothTransport.stop();
                     sdlListener.bluetoothTransport = null;
+                    sdlListener.bluetoothHandler = null;
                 }
                 sdlListener.timeoutHandler.removeCallbacks(sdlListener.timeoutRunner);
             }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/utl/SdlDeviceListener.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/utl/SdlDeviceListener.java
@@ -259,8 +259,10 @@ public class SdlDeviceListener {
             AndroidTools.saveVehicleType(sdlListener.contextWeakReference.get(), vehicleType, sdlListener.connectedDevice.getAddress());
             boolean keepConnectionOpen = sdlListener.callback.onTransportConnected(sdlListener.contextWeakReference.get(), sdlListener.connectedDevice);
             if (!keepConnectionOpen) {
-                sdlListener.bluetoothTransport.stop();
-                sdlListener.bluetoothTransport = null;
+                if (sdlListener.bluetoothTransport != null) {
+                    sdlListener.bluetoothTransport.stop();
+                    sdlListener.bluetoothTransport = null;
+                }
                 sdlListener.timeoutHandler.removeCallbacks(sdlListener.timeoutRunner);
             }
         }


### PR DESCRIPTION
Fixes #1780

This PR is **[not ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [X] I have tested Android, Java SE, and Java EE

#### Unit Tests
N/A

#### Core Tests
[List of tests performed against Core and behaviors verified]

Core version / branch / commit hash / module tested against: [INSERT]
HMI name / version / branch / commit hash / module tested against: [INSERT]

### Summary
In `SdlDeviceListener` the `bluetoothTransport` and `bluetoothHandler` are only initialized if the device has not connected previously. In the event that the device has connected before the `bluetoothTransport` is not initialized because we get the relevant data from the shared preferences. If this is the case `bluetoothTransport` will not be initialized and will be null. If this is the case the `vehicleInfo` will be retrieved from the shared preferences instead and the logic to retrieve the vehicleData from the startServiceACK is not needed.

in `SdlDeviceListener` the `onPacketRead` method will be called when the StartServiceACK is received. This will later call `notifyConnection` which will try to stop the `bluetoothTransport` if the RFCOMM channel should not remain open. If this is the case after stoping the `bluetoothTransport` it will then be set to null. When this happens we should also set the `bluetoothHandler` to null as we no longer want its `handleMessages` method to be called. This will prevent the case where `notifyConnection` is called while the `bluetoothTransport` is null

In `onPacketRead` we are already performing a null check before writing to the `bluetoohTransport`. Since it is possible that `bluetoothTransport` is null when `notifyConnection` is called we should also check for null before calling `bluetoothTransport.stop()`.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
