### PR TITLE
Make sure errorCode is not cut off

### DIFF
--- a/base/src/main/java/com/smartdevicelink/protocol/SecurityQueryPayload.java
+++ b/base/src/main/java/com/smartdevicelink/protocol/SecurityQueryPayload.java
@@ -61,12 +61,7 @@ public class SecurityQueryPayload {
 
             //Get the binaryData after the header (after 96 bits) and the jsonData size
             if (binHeader.length - _jsonSize - SECURITY_QUERY_HEADER_SIZE > 0) {
-                byte[] _bulkData;
-                if (msg.getQueryType() == SecurityQueryType.NOTIFICATION && msg.getQueryID() == SecurityQueryID.SEND_INTERNAL_ERROR) {
-                    _bulkData = new byte[binHeader.length - _jsonSize - SECURITY_QUERY_HEADER_SIZE - 1];
-                } else {
-                    _bulkData = new byte[binHeader.length - _jsonSize - SECURITY_QUERY_HEADER_SIZE];
-                }
+                byte[] _bulkData = new byte[binHeader.length - _jsonSize - SECURITY_QUERY_HEADER_SIZE];
                 System.arraycopy(binHeader, SECURITY_QUERY_HEADER_SIZE + _jsonSize, _bulkData, 0, _bulkData.length);
                 msg.setBulkData(_bulkData);
             }


### PR DESCRIPTION
Fixes #1790 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [X] I have tested Android, Java SE, and Java EE

#### Unit Tests
N/A

#### Core Tests
Attempt to test Encrypted Video Streaming using an app with the app ID wrong_app_id and the default security lib
Observe this log when Encrypted Video Stream Fails
Security Query module internal error: INVALID_CERT

Core version / branch / commit hash / module tested against: release/8.1.0
HMI name / version / branch / commit hash / module tested against: Generic HMI release/0.12.0

### Summary
There was a condition where we were cutting the bulk short by 1 byte. This should not happen so that condition was removed and the bulkdata will now be set to the appropriate size.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
