### PR TITLE
Fix LCM to close down properly

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -238,7 +238,7 @@ public class SdlManager extends BaseSdlManager {
     @Override
     public synchronized void dispose() {
         int state = getState();
-        if(state == BaseSubManager.SHUTDOWN || state == BaseSubManager.ERROR) {
+        if (state == BaseSubManager.SHUTDOWN || state == BaseSubManager.ERROR) {
             DebugTool.logInfo(TAG, "SdlManager already disposed");
             return;
         }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -237,6 +237,11 @@ public class SdlManager extends BaseSdlManager {
     @SuppressLint("NewApi")
     @Override
     public synchronized void dispose() {
+        int state = getState();
+        if(state == BaseSubManager.SHUTDOWN || state == BaseSubManager.ERROR) {
+            DebugTool.logInfo(TAG, "SdlManager already disposed");
+            return;
+        }
         if (this.permissionManager != null) {
             this.permissionManager.dispose();
         }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -414,7 +414,7 @@ public class SdlManager extends BaseSdlManager {
 
         @Override
         public void stop() {
-            lifecycleManager.getInternalInterface(SdlManager.this).start();
+            lifecycleManager.getInternalInterface(SdlManager.this).stop();
         }
 
         @Override

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -32,6 +32,8 @@
 
 package com.smartdevicelink.managers.lifecycle;
 
+import static com.smartdevicelink.managers.BaseSubManager.SETTING_UP;
+
 import android.content.Context;
 
 import androidx.annotation.RestrictTo;
@@ -90,11 +92,12 @@ public class LifecycleManager extends BaseLifecycleManager {
     @Override
     void cycle(SdlDisconnectedReason disconnectedReason) {
         clean(true);
-        initialize();
         if (!SdlDisconnectedReason.LEGACY_BLUETOOTH_MODE_ENABLED.equals(disconnectedReason) && !SdlDisconnectedReason.PRIMARY_TRANSPORT_CYCLE_REQUEST.equals(disconnectedReason)) {
             //We don't want to alert higher if we are just cycling for legacy bluetooth
             onClose("Sdl Proxy Cycled", new SdlException("Sdl Proxy Cycled", SdlExceptionCause.SDL_PROXY_CYCLED), disconnectedReason);
         }
+        transitionToState(SETTING_UP);
+        initialize();
         synchronized (SESSION_LOCK) {
             if (session != null) {
                 try {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -89,7 +89,7 @@ public class LifecycleManager extends BaseLifecycleManager {
 
     @Override
     void cycle(SdlDisconnectedReason disconnectedReason) {
-        clean();
+        clean(true);
         initialize();
         if (!SdlDisconnectedReason.LEGACY_BLUETOOTH_MODE_ENABLED.equals(disconnectedReason) && !SdlDisconnectedReason.PRIMARY_TRANSPORT_CYCLE_REQUEST.equals(disconnectedReason)) {
             //We don't want to alert higher if we are just cycling for legacy bluetooth

--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
@@ -1284,7 +1284,7 @@ abstract class BaseLifecycleManager {
 
     void clean(boolean sendUnregisterAppInterface) {
         int state = getState();
-        if(state == SHUTDOWN || state == ERROR) {
+        if (state == SHUTDOWN || state == ERROR) {
             DebugTool.logInfo(TAG, "No need to clean, LCM is already cleaned: " + state);
             return;
         }

--- a/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -157,6 +157,12 @@ public class SdlManager extends BaseSdlManager {
 
     @Override
     public void dispose() {
+        int state = getState();
+        if(state == BaseSubManager.SHUTDOWN || state == BaseSubManager.ERROR) {
+            DebugTool.logInfo(TAG, "SdlManager already disposed");
+            return;
+        }
+
         if (this.permissionManager != null) {
             this.permissionManager.dispose();
         }

--- a/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -158,7 +158,7 @@ public class SdlManager extends BaseSdlManager {
     @Override
     public void dispose() {
         int state = getState();
-        if(state == BaseSubManager.SHUTDOWN || state == BaseSubManager.ERROR) {
+        if (state == BaseSubManager.SHUTDOWN || state == BaseSubManager.ERROR) {
             DebugTool.logInfo(TAG, "SdlManager already disposed");
             return;
         }

--- a/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -203,7 +203,7 @@ public class SdlManager extends BaseSdlManager {
 
         @Override
         public void stop() {
-            lifecycleManager.getInternalInterface(SdlManager.this).start();
+            lifecycleManager.getInternalInterface(SdlManager.this).stop();
         }
 
         @Override

--- a/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -57,7 +57,7 @@ public class LifecycleManager extends BaseLifecycleManager {
 
     @Override
     void cycle(SdlDisconnectedReason disconnectedReason) {
-        clean();
+        clean(true);
         if (session != null) {
             try {
                 session.startSession();

--- a/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -58,6 +58,7 @@ public class LifecycleManager extends BaseLifecycleManager {
     @Override
     void cycle(SdlDisconnectedReason disconnectedReason) {
         clean(true);
+        initialize();
         if (session != null) {
             try {
                 session.startSession();

--- a/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -39,6 +39,8 @@ import com.smartdevicelink.proxy.rpc.enums.SdlDisconnectedReason;
 import com.smartdevicelink.session.SdlSession;
 import com.smartdevicelink.transport.BaseTransportConfig;
 
+import static com.smartdevicelink.managers.BaseSubManager.SETTING_UP;
+
 /**
  * The lifecycle manager creates a central point for all SDL session logic to converge. It should only be used by
  * the library itself. Usage outside the library is not permitted and will not be protected for in the future.
@@ -58,6 +60,7 @@ public class LifecycleManager extends BaseLifecycleManager {
     @Override
     void cycle(SdlDisconnectedReason disconnectedReason) {
         clean(true);
+        transitionToState(SETTING_UP);
         initialize();
         if (session != null) {
             try {


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against TDK and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE


### Summary
This PR fixes some issues where the library is shutting down but the app wasn't unregistered from the IVI properly. It also fixes a SYNG 4 bug that caused incorrect app closing after a reregister.

### Changelog

##### Bug Fixes
* Fixed properly sending an UnregisterAppInterface when the LCM is shutting down
* Removed redundant code that closed the RPC service before cleaning the whole LCM
* Removed code from the UnregisterAppInterface response listener that caused issues with SYNC 4.
* Added a missing init call in the Java SE LCM


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
