### PR TITLE
Add error logging when removing empty voice commands and voice command strings

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
@@ -217,21 +217,27 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
         List<VoiceCommand> validatedVoiceCommands = new ArrayList<>();
         for (VoiceCommand voiceCommand : voiceCommands) {
             if (voiceCommand == null) {
+                DebugTool.logError(TAG, "Null voice command removed");
                 continue;
             }
             List<String> voiceCommandStrings = new ArrayList<>();
             for (String voiceCommandString : voiceCommand.getVoiceCommands()) {
                 if (voiceCommandString == null) {
+                    DebugTool.logError(TAG, "Null voice command string removed");
                     continue;
                 }
                 String trimmedString = voiceCommandString.trim();
                 if (trimmedString.length() > 0) {
                     voiceCommandStrings.add(trimmedString);
+                } else {
+                    DebugTool.logError(TAG, "Empty voice command string removed");
                 }
             }
             if (voiceCommandStrings.size() > 0) {
                 voiceCommand.setVoiceCommands(voiceCommandStrings);
                 validatedVoiceCommands.add(voiceCommand);
+            } else {
+                DebugTool.logError(TAG, "Empty voice command removed");
             }
         }
         return validatedVoiceCommands;

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
@@ -217,27 +217,27 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
         List<VoiceCommand> validatedVoiceCommands = new ArrayList<>();
         for (VoiceCommand voiceCommand : voiceCommands) {
             if (voiceCommand == null) {
-                DebugTool.logError(TAG, "Null voice command removed");
+                DebugTool.logWarning(TAG, "Null voice command removed");
                 continue;
             }
             List<String> voiceCommandStrings = new ArrayList<>();
             for (String voiceCommandString : voiceCommand.getVoiceCommands()) {
                 if (voiceCommandString == null) {
-                    DebugTool.logError(TAG, "Null voice command string removed");
+                    DebugTool.logWarning(TAG, "Null voice command string removed");
                     continue;
                 }
                 String trimmedString = voiceCommandString.trim();
                 if (trimmedString.length() > 0) {
                     voiceCommandStrings.add(trimmedString);
                 } else {
-                    DebugTool.logError(TAG, "Empty voice command string removed");
+                    DebugTool.logWarning(TAG, "Empty voice command string removed");
                 }
             }
             if (voiceCommandStrings.size() > 0) {
                 voiceCommand.setVoiceCommands(voiceCommandStrings);
                 validatedVoiceCommands.add(voiceCommand);
             } else {
-                DebugTool.logError(TAG, "Empty voice command removed");
+                DebugTool.logWarning(TAG, "Empty voice command removed");
             }
         }
         return validatedVoiceCommands;

--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/BaseVoiceCommandManager.java
@@ -217,27 +217,27 @@ abstract class BaseVoiceCommandManager extends BaseSubManager {
         List<VoiceCommand> validatedVoiceCommands = new ArrayList<>();
         for (VoiceCommand voiceCommand : voiceCommands) {
             if (voiceCommand == null) {
-                DebugTool.logWarning(TAG, "Null voice command removed");
+                DebugTool.logWarning(TAG, "Voice command is null, it will not be uploaded");
                 continue;
             }
             List<String> voiceCommandStrings = new ArrayList<>();
             for (String voiceCommandString : voiceCommand.getVoiceCommands()) {
                 if (voiceCommandString == null) {
-                    DebugTool.logWarning(TAG, "Null voice command string removed");
+                    DebugTool.logWarning(TAG, "Removing null string from voice command");
                     continue;
                 }
                 String trimmedString = voiceCommandString.trim();
                 if (trimmedString.length() > 0) {
                     voiceCommandStrings.add(trimmedString);
                 } else {
-                    DebugTool.logWarning(TAG, "Empty voice command string removed");
+                    DebugTool.logWarning(TAG, "Empty string removed from voice command");
                 }
             }
             if (voiceCommandStrings.size() > 0) {
                 voiceCommand.setVoiceCommands(voiceCommandStrings);
                 validatedVoiceCommands.add(voiceCommand);
             } else {
-                DebugTool.logWarning(TAG, "Empty voice command removed");
+                DebugTool.logWarning(TAG, "Voice command will not be uploaded as it contained no valid strings");
             }
         }
         return validatedVoiceCommands;


### PR DESCRIPTION
Fixes #1798 

This PR is ready for review.

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR - N/A
- [x] I have tested this PR against Core and verified behavior
- [x] I have tested Android and Java SE

#### Unit Tests
N/A - This PR only adds logging

#### Core Tests
1. Create `VoiceCommand` containing no command strings
2. Attempt to send the `VoiceCommand` to an HMI using `VoiceCommandManager`
3. Observe debug logs

Expected Results: The `VoiceCommand` fails to send and a warning is logged

Observed Results: The `VoiceCommand` fails to send and a warning is logged

```markdown
- Ford TDK 3.4 (19353_DEVTEST_r133796)
- SDL Core v7.1.1 SDL HMI 5.5.1
- SDL Core v8.1.1 SDL HMI 5.7
```
### Summary
Adds more logging to `BaseVoiceCommandManager.removeEmptyVoiceCommands()`

### Changelog
##### Breaking Changes
* None

##### Enhancements
* None

##### Bug Fixes
* #1798 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
