### PR TITLE
Add multiple checks to supportsSoftButtonImages()

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/screen/PresentAlertOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/PresentAlertOperation.java
@@ -416,6 +416,14 @@ public class PresentAlertOperation extends Task {
      * @return True if soft button images are currently supported; false if not.
      */
     private boolean supportsSoftButtonImages() {
+        if (currentWindowCapability == null ||
+            currentWindowCapability.getSoftButtonCapabilities() == null ||
+            currentWindowCapability.getSoftButtonCapabilities().size() == 0 ||
+            currentWindowCapability.getSoftButtonCapabilities().get(0) == null
+        ) {
+            return true;
+        }
+
         SoftButtonCapabilities softButtonCapabilities = currentWindowCapability.getSoftButtonCapabilities().get(0);
         return softButtonCapabilities.getImageSupported().booleanValue();
     }


### PR DESCRIPTION
Fixes #1800

This PR is ready for review.

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR - N/A
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android and Java SE

#### Unit Tests
N/A

#### Core Tests
On Core, I ran the following code in `testBlank()` of a local clone of sdl_test_suite_java and a modified local copy of sdl_java_suite in which `PresentAlertOperation.supportSoftButtonImages()` is public.

<details>
<summary>Test Code</summary>

```java
AlertView.Builder builder = new AlertView.Builder();

        builder.setText("Test Alert");

        AlertView view = builder.build();

        //test null capability
        try {
            WindowCapability windowCapability = null;
            //WindowCapability windowCapability = new WindowCapability();
            //windowCapability.setSoftButtonCapabilities(Collections.emptyList());
            //windowCapability.setSoftButtonCapabilities(Collections.singletonList(null));

            PresentAlertOperation presentAlertOperation = new PresentAlertOperation(null, view,
                windowCapability, null, null, 0, new AlertCompletionListener() {
                @Override
                public void onComplete(boolean success, Integer tryAgainTime) {
                    if (success) {
                        messageLogger.logInfo(TAG, "Alert successful", true);
                    } else {
                        messageLogger.logError(TAG, "Alert failed", true);
                    }
                }
            }, null);

            messageLogger.logInfo(TAG,
                "Supports soft button images: " + presentAlertOperation.supportsSoftButtonImages(),
                true);
        } catch (Exception e) {
            messageLogger.logError(TAG, "Null capability crash", true);
        }

        //test null list
        try {
            //WindowCapability windowCapability = null;
            WindowCapability windowCapability = new WindowCapability();
            //windowCapability.setSoftButtonCapabilities(Collections.emptyList());
            //windowCapability.setSoftButtonCapabilities(Collections.singletonList(null));

            PresentAlertOperation presentAlertOperation = new PresentAlertOperation(null, view,
                windowCapability, null, null, 0, new AlertCompletionListener() {
                @Override
                public void onComplete(boolean success, Integer tryAgainTime) {
                    if (success) {
                        messageLogger.logInfo(TAG, "Alert successful", true);
                    } else {
                        messageLogger.logError(TAG, "Alert failed", true);
                    }
                }
            }, null);

            messageLogger.logInfo(TAG,
                "Supports soft button images: " + presentAlertOperation.supportsSoftButtonImages(),
                true);
        } catch (Exception e) {
            messageLogger.logError(TAG, "Null list crash", true);
        }

        //test empty list
        try {
            //WindowCapability windowCapability = null;
            WindowCapability windowCapability = new WindowCapability();
            windowCapability.setSoftButtonCapabilities(Collections.emptyList());
            //windowCapability.setSoftButtonCapabilities(Collections.singletonList(null));

            PresentAlertOperation presentAlertOperation = new PresentAlertOperation(null, view,
                windowCapability, null, null, 0, new AlertCompletionListener() {
                @Override
                public void onComplete(boolean success, Integer tryAgainTime) {
                    if (success) {
                        messageLogger.logInfo(TAG, "Alert successful", true);
                    } else {
                        messageLogger.logError(TAG, "Alert failed", true);
                    }
                }
            }, null);

            messageLogger.logInfo(TAG,
                "Supports soft button images: " + presentAlertOperation.supportsSoftButtonImages(),
                true);
        } catch (Exception e) {
            messageLogger.logError(TAG, "Empty list crash", true);
        }

        //test null button capability crash
        try {
            //WindowCapability windowCapability = null;
            WindowCapability windowCapability = new WindowCapability();
            //windowCapability.setSoftButtonCapabilities(Collections.emptyList());
            windowCapability.setSoftButtonCapabilities(Collections.singletonList(null));

            PresentAlertOperation presentAlertOperation = new PresentAlertOperation(null, view,
                windowCapability, null, null, 0, new AlertCompletionListener() {
                @Override
                public void onComplete(boolean success, Integer tryAgainTime) {
                    if (success) {
                        messageLogger.logInfo(TAG, "Alert successful", true);
                    } else {
                        messageLogger.logError(TAG, "Alert failed", true);
                    }
                }
            }, null);

            messageLogger.logInfo(TAG,
                "Supports soft button images: " + presentAlertOperation.supportsSoftButtonImages(),
                true);
        } catch (Exception e) {
            messageLogger.logError(TAG, "Null button capability crash", true);
        }
```
</details>

Core version / branch / commit hash / module tested against: Core release/8.1.0 b30f01258aeea4ec4c9cde22e942f091ade1cbfb
HMI name / version / branch / commit hash / module tested against: Generic HMI release/0.12.0 3ec306d2521f5151c215e4d98d9a230d6c544d6e

### Summary
This PR adds null checks and a `List.size()` check to `PresentAlertOperation.supportsSoftButtonImages()`. These checks prevent crashes and returns true when soft button capabilities are unavailable. This new behavior improves alignment with the other SDL libraries.

### Changelog
##### Breaking Changes
* None

##### Enhancements
* None

##### Bug Fixes
* Fixes #1800 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
