### PR TITLE
Improve handling of unsupported resolutions

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
@@ -480,6 +480,27 @@ public class VirtualDisplayEncoder {
         // Create a MediaCodec encoder and configure it. Get a Surface we can use for recording into.
         try {
             mVideoEncoder = MediaCodec.createEncoderByType(videoMimeType);
+
+            int width = streamingParams.getResolution().getResolutionWidth();
+            int height = streamingParams.getResolution().getResolutionHeight();
+            int frameRate = streamingParams.getFrameRate();
+
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+                boolean streamSupported = mVideoEncoder.getCodecInfo()
+                    .getCapabilitiesForType(videoMimeType)
+                    .getVideoCapabilities()
+                    .areSizeAndRateSupported(width, height, frameRate);
+
+                if (!streamSupported) {
+                    String errorString = "Video streaming " + width + " by " + height + " at "
+                        + frameRate + "fps is unsupported on this device";
+
+                    DebugTool.logError(TAG, errorString);
+
+                    return null;
+                }
+            }
+
             mVideoEncoder.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE);
             Surface surface = mVideoEncoder.createInputSurface(); //prepared
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -145,14 +145,14 @@ public class VideoStreamManager extends BaseVideoStreamManager {
                 }
                 checkState();
                 boolean encoderStarted = startEncoder();
-                if(encoderStarted) {
+                if (encoderStarted) {
                     stateMachine.transitionToState(StreamingStateMachine.STARTED);
                     hasStarted = true;
                 } else {
                     DebugTool.logError(TAG, "Error starting video encoder");
                     stateMachine.transitionToState(StreamingStateMachine.ERROR);
                     withPendingRestart = false;
-                    if(session != null) {
+                    if (session != null) {
                         session.endService(SessionType.NAV);
                     }
                 }


### PR DESCRIPTION
Fixes #1803 

This PR is ready for review.

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android (These are Android only changes)

#### Unit Tests
Ran Existing CI Tests

#### Core Tests

Tested on Samsung Galaxy S21 5G, Android 12 using sdl_test_suite_java

1. Connect an Android SDL Navigation app to SDL Core with either sdl_hmi or generic_hmi
2. Start streaming a video to the HMI
3. Switch the video stream to a resolution lower than 320x240 (ex: 400x100)
4. Attempt to stream at a supported resolution

Expected results: The low resolution video fails to play, an error is printed. Afterwards, the supported resolution plays successfully

Observed results: The low resolution video fails to play, an error is printed. Afterwards, the supported resolution plays successfully

Core version / branch / commit hash / module tested against: SDL Core release/8.1.0 cbc9d3928fb3c4a8db6608e84bad67d2398a52e7
HMI name / version / branch / commit hash / module tested against:  SDL HMI release/5.7.0 cd2d250cba100d1e0dd354172d2e24c0bd3449fc


### Summary
Adds a check in `VirtualDisplayEncoder` for unsupported resolutions that makes the virtual display encoder fail to start, prints a more helpful error message, and propagates an exception to the video stream manager. Changes in `VideoStreamManager` now kill the video stream service when the encoder fails to start, allowing for subsequent streams to start after an encoder error.

### Changelog
##### Breaking Changes
None

##### Enhancements
None

##### Bug Fixes
Fixes #1803 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
