### PR TITLE
Fix auto restart video stream to ensure hmi level is streamable

### DIFF
--- a/android/sdl_android/src/main/java/com/android/grafika/gles/Texture2dProgram.java
+++ b/android/sdl_android/src/main/java/com/android/grafika/gles/Texture2dProgram.java
@@ -162,7 +162,7 @@ public class Texture2dProgram {
         if (mProgramHandle == 0) {
             throw new RuntimeException("Unable to create program");
         }
-        Log.e(TAG,"Created program " + mProgramHandle + " (" + programType + ")");
+        Log.i(TAG,"Created program " + mProgramHandle + " (" + programType + ")");
 
         // get locations of attributes and uniforms
 

--- a/android/sdl_android/src/main/java/com/android/grafika/gles/Texture2dProgram.java
+++ b/android/sdl_android/src/main/java/com/android/grafika/gles/Texture2dProgram.java
@@ -162,7 +162,7 @@ public class Texture2dProgram {
         if (mProgramHandle == 0) {
             throw new RuntimeException("Unable to create program");
         }
-        Log.i(TAG,"Created program " + mProgramHandle + " (" + programType + ")");
+        Log.e(TAG,"Created program " + mProgramHandle + " (" + programType + ")");
 
         // get locations of attributes and uniforms
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
@@ -262,6 +262,9 @@ public class VirtualDisplayEncoder {
      * @param Height
      */
     private void setupGLES(int Width, int Height) {
+        if (mEglCore != null) {
+            mEglCore.release();
+        }
         mEglCore = new EglCore(null, 0);
 
         // This 1x1 offscreen is created just to get the texture name (mTextureId).

--- a/android/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
@@ -251,6 +251,10 @@ public class VirtualDisplayEncoder {
                 inputSurface.release();
                 inputSurface = null;
             }
+            if (mEglCore != null) {
+                mEglCore.release();
+                mEglCore = null;
+            }
         } catch (Exception ex) {
             DebugTool.logError(TAG, "shutDown() failed");
         }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -154,13 +154,17 @@ public class VideoStreamManager extends BaseVideoStreamManager {
         public void onServiceEnded(SdlSession session, SessionType type) {
             if (SessionType.NAV.equals(type)) {
                 if (remoteDisplay != null) {
-                    stopStreaming(withPendingRestart);
+                    if (withPendingRestart && isHMIStateVideoStreamCapable(currentOnHMIStatus)) {
+                        stopStreaming(withPendingRestart);
+                    } else {
+                        stopStreaming();
+                    }
                 }
                 stateMachine.transitionToState(StreamingStateMachine.NONE);
                 transitionToState(SETTING_UP);
-
-                if (withPendingRestart) {
+                if (withPendingRestart && isHMIStateVideoStreamCapable(currentOnHMIStatus)) {
                     VideoStreamManager manager = VideoStreamManager.this;
+
                     manager.internalInterface.startVideoService(manager.getLastCachedStreamingParameters(), manager.isEncrypted, withPendingRestart);
                 }
             }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -164,7 +164,6 @@ public class VideoStreamManager extends BaseVideoStreamManager {
                 transitionToState(SETTING_UP);
                 if (withPendingRestart && isHMIStateVideoStreamCapable(currentOnHMIStatus)) {
                     VideoStreamManager manager = VideoStreamManager.this;
-
                     manager.internalInterface.startVideoService(manager.getLastCachedStreamingParameters(), manager.isEncrypted, withPendingRestart);
                 }
             }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/video/VideoStreamManager.java
@@ -202,6 +202,10 @@ public class VideoStreamManager extends BaseVideoStreamManager {
                 if (hasStarted && (isHMIStateVideoStreamCapable(prevOnHMIStatus)) && (!isHMIStateVideoStreamCapable(currentOnHMIStatus))) {
                     stopVideoStream();
                 }
+                if (withPendingRestart && hasStarted && (!isHMIStateVideoStreamCapable(prevOnHMIStatus)) && (isHMIStateVideoStreamCapable(currentOnHMIStatus))) {
+                    VideoStreamManager manager = VideoStreamManager.this;
+                    manager.internalInterface.startVideoService(manager.getLastCachedStreamingParameters(), manager.isEncrypted, withPendingRestart);
+                }
             }
         }
     };


### PR DESCRIPTION
Fixes #1807 

This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Core Tests
Test:
Start a video stream to sdl_hmi
Using voice commands exit out of the app
Open app on HMI

Result:
You should be prompted by hmi to start streaming, click ok and video should stream.

Core 8.1 with sdl_hmi

### Summary
Adds check to VideoStreamManager to check if HMI level is streamable before restarting video streaming, and added behavior for the stream to auto-restart when hmi is in a streamable state

### Changelog
##### Bug Fixes
* Fixes video stream manager form going into an unrecoverable state when it tries to start video streaming in a nonstreamable state


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
