### PR TITLE
1738 - Soft button manager image upload fix 

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -527,4 +527,17 @@ public class SoftButtonManagerTests {
         softButtonManager.setSoftButtonObjects(Arrays.asList(softButtonObject1, softButtonObject2));
         assertEquals("SoftButtonManager is uploading artwork, when graphic is not supported", 0, fileManagerUploadArtworksListenerCalledCounter);
     }
+
+    @Test
+    public void testSoftButtonManagerDynamicImageNotSupportedNoText() {
+        softButtonManager.isGraphicSupported = false;
+        fileManagerUploadArtworksListenerCalledCounter = 0;
+        internalInterfaceSendRPCListenerCalledCounter = 0;
+
+        SoftButtonState softButtonState = new SoftButtonState("testState", null, new SdlArtwork("image", FileType.GRAPHIC_PNG, 1, true));
+        SoftButtonObject softButtonObject = new SoftButtonObject("obj1", softButtonState, null);
+
+        softButtonManager.setSoftButtonObjects(Arrays.asList(softButtonObject));
+        assertEquals("SoftButtonManager is uploading artwork, when graphic is not supported", 0, fileManagerUploadArtworksListenerCalledCounter);
+    }
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -517,4 +517,14 @@ public class SoftButtonManagerTests {
 
         assertEquals(stateListUnique, softButtonObject.getStates());
     }
+
+    @Test
+    public void testSoftButtonManagerGraphicNotSupported() {
+        softButtonManager.isGraphicSupported = false;
+        fileManagerUploadArtworksListenerCalledCounter = 0;
+        internalInterfaceSendRPCListenerCalledCounter = 0;
+
+        softButtonManager.setSoftButtonObjects(Arrays.asList(softButtonObject1, softButtonObject2));
+        assertEquals("SoftButtonManager is uploading artwork, when graphic is not supported", 0, fileManagerUploadArtworksListenerCalledCounter);
+    }
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -140,7 +140,7 @@ public class SoftButtonManagerTests {
         taskmaster.start();
         when(internalInterface.getTaskmaster()).thenReturn(taskmaster);
         softButtonManager = new SoftButtonManager(internalInterface, fileManager);
-        softButtonManager.isGraphicSupported = true;
+        softButtonManager.isDynamicGraphicSupported = true;
 
 
         // When internalInterface.sendRPC() is called inside SoftButtonManager:
@@ -520,7 +520,7 @@ public class SoftButtonManagerTests {
 
     @Test
     public void testSoftButtonManagerGraphicNotSupported() {
-        softButtonManager.isGraphicSupported = false;
+        softButtonManager.isDynamicGraphicSupported = false;
         fileManagerUploadArtworksListenerCalledCounter = 0;
         internalInterfaceSendRPCListenerCalledCounter = 0;
 
@@ -530,7 +530,7 @@ public class SoftButtonManagerTests {
 
     @Test
     public void testSoftButtonManagerDynamicImageNotSupportedNoText() {
-        softButtonManager.isGraphicSupported = false;
+        softButtonManager.isDynamicGraphicSupported = false;
         fileManagerUploadArtworksListenerCalledCounter = 0;
         internalInterfaceSendRPCListenerCalledCounter = 0;
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -140,6 +140,7 @@ public class SoftButtonManagerTests {
         taskmaster.start();
         when(internalInterface.getTaskmaster()).thenReturn(taskmaster);
         softButtonManager = new SoftButtonManager(internalInterface, fileManager);
+        softButtonManager.isGraphicSupported = true;
 
 
         // When internalInterface.sendRPC() is called inside SoftButtonManager:

--- a/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
@@ -103,9 +103,8 @@ abstract class BaseSoftButtonManager extends BaseSubManager {
         this.batchQueue = new ArrayList<>();
 
         if (internalInterface.getSystemCapabilityManager() != null) {
-             displayCapabilities = (DisplayCapabilities) this.internalInterface.getSystemCapabilityManager().getCapability(SystemCapabilityType.DISPLAY, null, false);
+            displayCapabilities = (DisplayCapabilities) this.internalInterface.getSystemCapabilityManager().getCapability(SystemCapabilityType.DISPLAY, null, false);
         }
-
         isGraphicSupported = (displayCapabilities != null && displayCapabilities.getGraphicSupported() != null) ? displayCapabilities.getGraphicSupported() : false;
 
         this.updateListener = new SoftButtonObject.UpdateListener() {

--- a/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
@@ -71,9 +71,9 @@ abstract class BaseSoftButtonManager extends BaseSubManager {
     private static final String TAG = "BaseSoftButtonManager";
     private final WeakReference<FileManager> fileManager;
     SoftButtonCapabilities softButtonCapabilities;
+    boolean isGraphicSupported;
     private CopyOnWriteArrayList<SoftButtonObject> softButtonObjects;
     private HMILevel currentHMILevel;
-    private boolean isGraphicSupported;
     private DisplayCapabilities displayCapabilities;
     private final OnSystemCapabilityListener onDisplayCapabilityListener;
     private final OnRPCNotificationListener onHMIStatusListener, onButtonPressListener, onButtonEventListener;

--- a/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
@@ -74,7 +74,6 @@ abstract class BaseSoftButtonManager extends BaseSubManager {
     boolean isGraphicSupported;
     private CopyOnWriteArrayList<SoftButtonObject> softButtonObjects;
     private HMILevel currentHMILevel;
-    private DisplayCapabilities displayCapabilities;
     private final OnSystemCapabilityListener onDisplayCapabilityListener;
     private final OnRPCNotificationListener onHMIStatusListener, onButtonPressListener, onButtonEventListener;
     private Queue transactionQueue;
@@ -101,11 +100,11 @@ abstract class BaseSoftButtonManager extends BaseSubManager {
         this.currentHMILevel = null;
         this.transactionQueue = newTransactionQueue();
         this.batchQueue = new ArrayList<>();
-
+        DisplayCapabilities displayCapabilities = null;
         if (internalInterface.getSystemCapabilityManager() != null) {
             displayCapabilities = (DisplayCapabilities) this.internalInterface.getSystemCapabilityManager().getCapability(SystemCapabilityType.DISPLAY, null, false);
         }
-        isGraphicSupported = (displayCapabilities != null && displayCapabilities.getGraphicSupported() != null) ? displayCapabilities.getGraphicSupported() : false;
+        isGraphicSupported = (displayCapabilities != null && displayCapabilities.getGraphicSupported() != null) ? displayCapabilities.getGraphicSupported() : true;
 
         this.updateListener = new SoftButtonObject.UpdateListener() {
             @Override

--- a/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/BaseSoftButtonManager.java
@@ -71,7 +71,7 @@ abstract class BaseSoftButtonManager extends BaseSubManager {
     private static final String TAG = "BaseSoftButtonManager";
     private final WeakReference<FileManager> fileManager;
     SoftButtonCapabilities softButtonCapabilities;
-    boolean isGraphicSupported;
+    boolean isDynamicGraphicSupported;
     private CopyOnWriteArrayList<SoftButtonObject> softButtonObjects;
     private HMILevel currentHMILevel;
     private final OnSystemCapabilityListener onDisplayCapabilityListener;
@@ -104,7 +104,7 @@ abstract class BaseSoftButtonManager extends BaseSubManager {
         if (internalInterface.getSystemCapabilityManager() != null) {
             displayCapabilities = (DisplayCapabilities) this.internalInterface.getSystemCapabilityManager().getCapability(SystemCapabilityType.DISPLAY, null, false);
         }
-        isGraphicSupported = (displayCapabilities != null && displayCapabilities.getGraphicSupported() != null) ? displayCapabilities.getGraphicSupported() : true;
+        isDynamicGraphicSupported = (displayCapabilities != null && displayCapabilities.getGraphicSupported() != null) ? displayCapabilities.getGraphicSupported() : true;
 
         this.updateListener = new SoftButtonObject.UpdateListener() {
             @Override
@@ -158,7 +158,7 @@ abstract class BaseSoftButtonManager extends BaseSubManager {
 
                 // Auto-send an updated Show if we have new capabilities
                 if (softButtonObjects != null && !softButtonObjects.isEmpty() && softButtonCapabilities != null && !softButtonCapabilitiesEquals(oldSoftButtonCapabilities, softButtonCapabilities)) {
-                    SoftButtonReplaceOperation operation = new SoftButtonReplaceOperation(internalInterface, fileManager, softButtonCapabilities, softButtonObjects, getCurrentMainField1(), isGraphicSupported);
+                    SoftButtonReplaceOperation operation = new SoftButtonReplaceOperation(internalInterface, fileManager, softButtonCapabilities, softButtonObjects, getCurrentMainField1(), isDynamicGraphicSupported);
                     transactionQueue.add(operation, false);
                 }
             }
@@ -317,7 +317,7 @@ abstract class BaseSoftButtonManager extends BaseSubManager {
         this.softButtonObjects = softButtonObjects;
 
         // We only need to pass the first softButtonCapabilities in the array due to the fact that all soft button capabilities are the same (i.e. there is no way to assign a softButtonCapabilities to a specific soft button).
-        SoftButtonReplaceOperation operation = new SoftButtonReplaceOperation(internalInterface, fileManager.get(), softButtonCapabilities, softButtonObjects, getCurrentMainField1(), isGraphicSupported);
+        SoftButtonReplaceOperation operation = new SoftButtonReplaceOperation(internalInterface, fileManager.get(), softButtonCapabilities, softButtonObjects, getCurrentMainField1(), isDynamicGraphicSupported);
 
         if (batchUpdates) {
             batchQueue.clear();

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonReplaceOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonReplaceOperation.java
@@ -306,7 +306,6 @@ class SoftButtonReplaceOperation extends Task {
     }
 
     private boolean supportsSoftButtonImages() {
-        Log.i("Julian", "supportsSoftButtonImages: isGraphicSupported" + isGraphicSupported);
         return softButtonCapabilities != null && Boolean.TRUE.equals(isGraphicSupported) && Boolean.TRUE.equals(softButtonCapabilities.getImageSupported());
     }
 

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonReplaceOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonReplaceOperation.java
@@ -30,14 +30,16 @@ class SoftButtonReplaceOperation extends Task {
     private final SoftButtonCapabilities softButtonCapabilities;
     private final CopyOnWriteArrayList<SoftButtonObject> softButtonObjects;
     private String currentMainField1;
+    private Boolean isGraphicSupported;
 
-    SoftButtonReplaceOperation(ISdl internalInterface, FileManager fileManager, SoftButtonCapabilities softButtonCapabilities, CopyOnWriteArrayList<SoftButtonObject> softButtonObjects, String currentMainField1) {
+    SoftButtonReplaceOperation(ISdl internalInterface, FileManager fileManager, SoftButtonCapabilities softButtonCapabilities, CopyOnWriteArrayList<SoftButtonObject> softButtonObjects, String currentMainField1, Boolean isGraphicSupported) {
         super("SoftButtonReplaceOperation");
         this.internalInterface = new WeakReference<>(internalInterface);
         this.fileManager = new WeakReference<>(fileManager);
         this.softButtonCapabilities = softButtonCapabilities;
         this.softButtonObjects = softButtonObjects;
         this.currentMainField1 = currentMainField1;
+        this.isGraphicSupported = isGraphicSupported;
     }
 
     @Override
@@ -304,7 +306,8 @@ class SoftButtonReplaceOperation extends Task {
     }
 
     private boolean supportsSoftButtonImages() {
-        return softButtonCapabilities != null && Boolean.TRUE.equals(softButtonCapabilities.getImageSupported());
+        Log.i("Julian", "supportsSoftButtonImages: isGraphicSupported" + isGraphicSupported);
+        return softButtonCapabilities != null && Boolean.TRUE.equals(isGraphicSupported) && Boolean.TRUE.equals(softButtonCapabilities.getImageSupported());
     }
 
     void setCurrentMainField1(String currentMainField1) {

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonReplaceOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonReplaceOperation.java
@@ -276,15 +276,18 @@ class SoftButtonReplaceOperation extends Task {
                 return;
             }
 
-            // We should create a new softButtonObject rather than modifying the original one
-            SoftButton textAndStaticImageOnlySoftButton = new SoftButton(SoftButtonType.SBT_TEXT, softButton.getSoftButtonID());
-            if (softButton.getImage() != null && softButton.getImage().getImageType() == ImageType.STATIC) {
+
+            if (softButton.getImage() != null && softButton.getImage().getImageType() == ImageType.DYNAMIC) {
+                // We should create a new softButtonObject rather than modifying the original one
+                SoftButton textAndStaticImageOnlySoftButton = new SoftButton(SoftButtonType.SBT_TEXT, softButton.getSoftButtonID());
+                textAndStaticImageOnlySoftButton.setText(softButton.getText());
+                textAndStaticImageOnlySoftButton.setSystemAction(softButton.getSystemAction());
+                textAndStaticImageOnlySoftButton.setIsHighlighted(softButton.getIsHighlighted());
                 textAndStaticImageOnlySoftButton.setImage(softButton.getImage());
+                textButtons.add(textAndStaticImageOnlySoftButton);
+            } else {
+                textButtons.add(softButton);
             }
-            textAndStaticImageOnlySoftButton.setText(softButton.getText());
-            textAndStaticImageOnlySoftButton.setSystemAction(softButton.getSystemAction());
-            textAndStaticImageOnlySoftButton.setIsHighlighted(softButton.getIsHighlighted());
-            textButtons.add(textAndStaticImageOnlySoftButton);
         }
 
         Show show = new Show();

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonReplaceOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonReplaceOperation.java
@@ -56,7 +56,7 @@ class SoftButtonReplaceOperation extends Task {
         // Check the state of our images
         if (!supportsSoftButtonImages()) {
             // We don't support images at all
-            DebugTool.logInfo(TAG, "Soft button images are not supported. Attempting to send text-only soft buttons. If any button does not contain text, no buttons will be sent.");
+            DebugTool.logWarning(TAG, "Soft button images are not supported. Attempting to send text-only soft buttons. If any button does not contain text, no buttons will be sent.");
 
             // Send text buttons if all the soft buttons have text
             sendCurrentStateTextOnlySoftButtons(new CompletionListener() {

--- a/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonReplaceOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/SoftButtonReplaceOperation.java
@@ -31,16 +31,16 @@ class SoftButtonReplaceOperation extends Task {
     private final SoftButtonCapabilities softButtonCapabilities;
     private final CopyOnWriteArrayList<SoftButtonObject> softButtonObjects;
     private String currentMainField1;
-    private Boolean isGraphicSupported;
+    private Boolean isDynamicGraphicSupported;
 
-    SoftButtonReplaceOperation(ISdl internalInterface, FileManager fileManager, SoftButtonCapabilities softButtonCapabilities, CopyOnWriteArrayList<SoftButtonObject> softButtonObjects, String currentMainField1, Boolean isGraphicSupported) {
+    SoftButtonReplaceOperation(ISdl internalInterface, FileManager fileManager, SoftButtonCapabilities softButtonCapabilities, CopyOnWriteArrayList<SoftButtonObject> softButtonObjects, String currentMainField1, Boolean isDynamicGraphicSupported) {
         super("SoftButtonReplaceOperation");
         this.internalInterface = new WeakReference<>(internalInterface);
         this.fileManager = new WeakReference<>(fileManager);
         this.softButtonCapabilities = softButtonCapabilities;
         this.softButtonObjects = softButtonObjects;
         this.currentMainField1 = currentMainField1;
-        this.isGraphicSupported = isGraphicSupported;
+        this.isDynamicGraphicSupported = isDynamicGraphicSupported;
     }
 
     @Override
@@ -379,7 +379,7 @@ class SoftButtonReplaceOperation extends Task {
     }
 
     private boolean supportsDynamicSoftButtonImages() {
-        return softButtonCapabilities != null && Boolean.TRUE.equals(isGraphicSupported) && Boolean.TRUE.equals(softButtonCapabilities.getImageSupported());
+        return softButtonCapabilities != null && Boolean.TRUE.equals(isDynamicGraphicSupported) && Boolean.TRUE.equals(softButtonCapabilities.getImageSupported());
     }
 
     private boolean supportsSoftButtonImages() {


### PR DESCRIPTION
Fixes #1738 

This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
Unit tests were updated with the new parameter and one test was added in SoftButtonManagerTest

#### Core Tests
Tested sending a softbutton with an image, verifying that the image displays.

```
        SoftButtonState softButtonState = new SoftButtonState("artworkTest", "Button", new SdlArtwork("testArtwork1", FileType.GRAPHIC_PNG, R.drawable.ic_sdl, true));

        SoftButtonObject softButtonObject = new SoftButtonObject("jk", softButtonState, new SoftButtonObject.OnEventListener() {
            @Override
            public void onPress(SoftButtonObject softButtonObject, OnButtonPress onButtonPress) {
            }

            @Override
            public void onEvent(SoftButtonObject softButtonObject, OnButtonEvent onButtonEvent) {

            }
        });
        sdlManager.getScreenManager().setSoftButtonObjects(Collections.singletonList(softButtonObject));
```

Core version / branch / commit hash / module tested against: Core 8.1, Manticore and Sync 3
HMI name / version / branch / commit hash / module tested against: Generic_HMI

### Summary
This PR works around a bug when connecting to Sync 2.0 head units that causes the app to attempt to upload a dynamic soft button images that will never work. This wastes bandwidth and time.

The issue happens because Sync 2.0 doesn't support softButtonCapabilities, so the library assumes all capabilities are available. However, Sync 2.0 does report that all graphics are unsupported in RAIR.displayCapabilities.graphicSupported.

Static images are supported by Sync 2.0 and should still upload on softbuttons.

### Changelog
##### Bug Fixes
* Fixes attempted uploads of image data on SDL 2.0

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
