### PR TITLE
Reduces impact of #1813 by catching the exception

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/PoliciesFetcher.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/PoliciesFetcher.java
@@ -40,6 +40,7 @@ import com.smartdevicelink.proxy.rpc.enums.FileType;
 import com.smartdevicelink.proxy.rpc.enums.RequestType;
 import com.smartdevicelink.util.DebugTool;
 
+import javax.net.ssl.SSLPeerUnverifiedException;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -159,15 +160,19 @@ class PoliciesFetcher {
                 return null;
             }
 
-            DataOutputStream wr = new DataOutputStream(urlConnection.getOutputStream());
-            if (RequestType.HTTP.equals(msg.getRequestType())) {
-                wr.write(msg.getBulkData());
-            } else {
-                wr.writeBytes(valid_json);
-            }
+            try {
+                DataOutputStream wr = new DataOutputStream(urlConnection.getOutputStream());
+                if (RequestType.HTTP.equals(msg.getRequestType())) {
+                    wr.write(msg.getBulkData());
+                } else {
+                    wr.writeBytes(valid_json);
+                }
 
-            wr.flush();
-            wr.close();
+                wr.flush();
+                wr.close();
+            } catch (SSLPeerUnverifiedException exception) {
+                exception.printStackTrace();
+            }
 
 
             long BeforeTime = System.currentTimeMillis();


### PR DESCRIPTION
Fixes #1813 

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR 
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [ ] I have tested Android, Java SE, and Java EE

#### Unit Tests
- Existing CI Unit Tests

#### Core Tests
[List of tests performed against Core and behaviors verified]

Core version / branch / commit hash / module tested against: [INSERT]
HMI name / version / branch / commit hash / module tested against: [INSERT]

### Summary
This PR wraps the creation and usage of the `DataOutputStream` in `PoliciesFetcher` causing the exception in #1813 with a try-catch block.

### Changelog
##### Breaking Changes
N/A

##### Enhancements
N/A

##### Bug Fixes
* Fixes #1813 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
