### PR TITLE
Android 12 Catch ForegroundServiceStartNotAllowedException 

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -32,8 +32,10 @@
 
 package com.smartdevicelink.transport;
 
+import android.annotation.SuppressLint;
 import android.app.ActivityManager;
 import android.app.ActivityManager.RunningServiceInfo;
+import android.app.ForegroundServiceStartNotAllowedException;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothProfile;
@@ -284,6 +286,8 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver {
 
         } catch (SecurityException e) {
             DebugTool.logError(TAG, "Security exception, process is bad");
+        } catch (@SuppressLint({"NewApi", "LocalSuppress"}) ForegroundServiceStartNotAllowedException e) {
+            DebugTool.logError(TAG, "Not allowed to start service in Foreground");
         }
     }
 
@@ -481,6 +485,8 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver {
         } catch (SecurityException e) {
             DebugTool.logError(TAG, "Security exception, process is bad");
             // This service could not be started
+        } catch (@SuppressLint({"NewApi", "LocalSuppress"}) ForegroundServiceStartNotAllowedException e) {
+            DebugTool.logError(TAG, "Not allowed to start service in Foreground");
         }
     }
 


### PR DESCRIPTION
Fixes #1815 

This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Core Tests
Tested against Sync 3.0 with Android 12 device and Android 9 device.
Android 12 device: 
I was able to replicate the issue by using a delayed handler. I had to put the try-catch inside of the handler to catch it.

```
                final Handler handler = new Handler(Looper.getMainLooper());
                handler.postDelayed(new Runnable() {
                    @Override
                    public void run() {
                        try {
                            serviceIntent.putExtra(FOREGROUND_EXTRA, true);
                            DebugTool.logInfo(TAG, "Attempting to startForegroundService - " + System.currentTimeMillis());
                            setForegroundExceptionHandler(); //Prevent ANR in case the OS takes too long to start the service
                            context.startForegroundService(serviceIntent);
                        } catch (ForegroundServiceStartNotAllowedException e) {
                            Log.e(TAG, "ForegroundServiceStartNotAllowedException herer");
                        }

                    }
                }, 25000);
```

To catch it where it is now we can do that by throwing the exception where we call  `context.startForegroundService(serviceIntent);` You will also need to add `@RequiresApi(api = Build.VERSION_CODES.S)` when testing it this way.

```
throw new ForegroundServiceStartNotAllowedException("msg");
```

Android 9 device:
Connected Hello sdl without the modifications above to ensure that the code ran as intended. 

### Summary
Android 12 may throw a  `ForegroundServiceStartNotAllowedException` if we try to start the router service after a certain amount of time from receiving a broadcast that requires the `BLUETOOTH_CONNECT` or `BLUETOOTH_SCAN` permission. In testing, I saw it happen between 20 to 25 seconds. 

### Changelog
##### Bug Fixes
* Catch `ForegroundServiceStartNotAllowedException` in two places in `SdlBroadcastReceiver`.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
