### PR TITLE
Bugfix/issue 1824 Add missing DisplayCapabilities info and window ID

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lifecycle/SystemCapabilityManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lifecycle/SystemCapabilityManagerTests.java
@@ -176,7 +176,7 @@ public class SystemCapabilityManagerTests {
         convertedCapabilities.setImageFields(defaultMainWindow.getImageFields());
         convertedCapabilities.setTemplatesAvailable(defaultMainWindow.getTemplatesAvailable());
         convertedCapabilities.setNumCustomPresetsAvailable(defaultMainWindow.getNumCustomPresetsAvailable());
-        convertedCapabilities.setMediaClockFormats(new ArrayList<MediaClockFormat>()); // mandatory field but can be empty
+        convertedCapabilities.setMediaClockFormats(TestValues.GENERAL_MEDIACLOCKFORMAT_LIST); // mandatory field but can be empty
         convertedCapabilities.setGraphicSupported(defaultMainWindow.getImageTypeSupported().contains(ImageType.DYNAMIC));
         convertedCapabilities.setScreenParams(TestValues.GENERAL_SCREENPARAMS);
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lifecycle/SystemCapabilityManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/lifecycle/SystemCapabilityManagerTests.java
@@ -178,6 +178,7 @@ public class SystemCapabilityManagerTests {
         convertedCapabilities.setNumCustomPresetsAvailable(defaultMainWindow.getNumCustomPresetsAvailable());
         convertedCapabilities.setMediaClockFormats(new ArrayList<MediaClockFormat>()); // mandatory field but can be empty
         convertedCapabilities.setGraphicSupported(defaultMainWindow.getImageTypeSupported().contains(ImageType.DYNAMIC));
+        convertedCapabilities.setScreenParams(TestValues.GENERAL_SCREENPARAMS);
 
         return convertedCapabilities;
     }

--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseSystemCapabilityManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseSystemCapabilityManager.java
@@ -256,10 +256,10 @@ abstract class BaseSystemCapabilityManager {
             int currentWindowID = windowCapability.getWindowID() != null ? windowCapability.getWindowID() : PredefinedWindows.DEFAULT_WINDOW.getValue();
             if (currentWindowID == windowID) {
                 // Clone WindowCapability to prevent modification of stored WindowCapability in SystemCapabilityManager
-                WindowCapability updatedCaps = (WindowCapability) windowCapability.clone();
+                WindowCapability windowCapabilityCopy = (WindowCapability) windowCapability.clone();
                 // A null windowID is assumed to be the DefaultWindow according to the spec, but that can be hard for developers to check, so set it explicitly.
-                updatedCaps.setWindowID(windowID);
-                return updatedCaps;
+                windowCapabilityCopy.setWindowID(windowID);
+                return windowCapabilityCopy;
             }
         }
         return null;

--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseSystemCapabilityManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseSystemCapabilityManager.java
@@ -176,7 +176,11 @@ abstract class BaseSystemCapabilityManager {
             // Copied from the RAI response, since this parameter is not present in WindowCapability
             DisplayCapabilities displayCapabilitiesOld = (DisplayCapabilities) cachedSystemCapabilities.get(SystemCapabilityType.DISPLAY);
             convertedCapabilities.setScreenParams(displayCapabilitiesOld.getScreenParams());
+            if (displayCapabilitiesOld.getMediaClockFormats() != null) {
+                convertedCapabilities.setMediaClockFormats(displayCapabilitiesOld.getMediaClockFormats());
+            }
         }
+
         return convertedCapabilities;
     }
 
@@ -251,6 +255,7 @@ abstract class BaseSystemCapabilityManager {
         for (WindowCapability windowCapability : display.getWindowCapabilities()) {
             int currentWindowID = windowCapability.getWindowID() != null ? windowCapability.getWindowID() : PredefinedWindows.DEFAULT_WINDOW.getValue();
             if (currentWindowID == windowID) {
+                windowCapability.setWindowID(windowID);
                 return windowCapability;
             }
         }

--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseSystemCapabilityManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseSystemCapabilityManager.java
@@ -173,6 +173,7 @@ abstract class BaseSystemCapabilityManager {
         convertedCapabilities.setGraphicSupported(defaultMainWindow.getImageTypeSupported() != null && defaultMainWindow.getImageTypeSupported().size() > 0);
 
         if (cachedSystemCapabilities.containsKey(SystemCapabilityType.DISPLAY)) {
+            // Copied from the RAI response, since this parameter is not present in WindowCapability
             DisplayCapabilities displayCapabilitiesOld = (DisplayCapabilities) cachedSystemCapabilities.get(SystemCapabilityType.DISPLAY);
             convertedCapabilities.setScreenParams(displayCapabilitiesOld.getScreenParams());
         }

--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseSystemCapabilityManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseSystemCapabilityManager.java
@@ -175,7 +175,6 @@ abstract class BaseSystemCapabilityManager {
         if (cachedSystemCapabilities.containsKey(SystemCapabilityType.DISPLAY)) {
             DisplayCapabilities displayCapabilitiesOld = (DisplayCapabilities) cachedSystemCapabilities.get(SystemCapabilityType.DISPLAY);
             convertedCapabilities.setScreenParams(displayCapabilitiesOld.getScreenParams());
-
         }
         return convertedCapabilities;
     }

--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseSystemCapabilityManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseSystemCapabilityManager.java
@@ -255,6 +255,7 @@ abstract class BaseSystemCapabilityManager {
         for (WindowCapability windowCapability : display.getWindowCapabilities()) {
             int currentWindowID = windowCapability.getWindowID() != null ? windowCapability.getWindowID() : PredefinedWindows.DEFAULT_WINDOW.getValue();
             if (currentWindowID == windowID) {
+                // A null windowID is assumed to be the DefaultWindow according to the spec, but that can be hard for developers to check, so set it explicitly.
                 windowCapability.setWindowID(windowID);
                 return windowCapability;
             }

--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseSystemCapabilityManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseSystemCapabilityManager.java
@@ -172,6 +172,11 @@ abstract class BaseSystemCapabilityManager {
         // if there are imageTypes in the response, we must assume graphics are supported
         convertedCapabilities.setGraphicSupported(defaultMainWindow.getImageTypeSupported() != null && defaultMainWindow.getImageTypeSupported().size() > 0);
 
+        if (cachedSystemCapabilities.containsKey(SystemCapabilityType.DISPLAY)) {
+            DisplayCapabilities displayCapabilitiesOld = (DisplayCapabilities) cachedSystemCapabilities.get(SystemCapabilityType.DISPLAY);
+            convertedCapabilities.setScreenParams(displayCapabilitiesOld.getScreenParams());
+
+        }
         return convertedCapabilities;
     }
 

--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseSystemCapabilityManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseSystemCapabilityManager.java
@@ -255,9 +255,11 @@ abstract class BaseSystemCapabilityManager {
         for (WindowCapability windowCapability : display.getWindowCapabilities()) {
             int currentWindowID = windowCapability.getWindowID() != null ? windowCapability.getWindowID() : PredefinedWindows.DEFAULT_WINDOW.getValue();
             if (currentWindowID == windowID) {
+                // Clone WindowCapability to prevent modification of stored WindowCapability in SystemCapabilityManager
+                WindowCapability updatedCaps = (WindowCapability) windowCapability.clone();
                 // A null windowID is assumed to be the DefaultWindow according to the spec, but that can be hard for developers to check, so set it explicitly.
-                windowCapability.setWindowID(windowID);
-                return windowCapability;
+                updatedCaps.setWindowID(windowID);
+                return updatedCaps;
             }
         }
         return null;


### PR DESCRIPTION
Fixes #1824 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
Unit test were updated in SystemCapabilityManagerTests.java

#### Core Tests
Tested to verify that ScreenParams and MediaClockFormats from SystemCapabilityManager `DisplayCapabilities` matched `DisplayCapabilities` from RAIR.

Test retrieving DefaultMainWindowCapability from SystemCapabilityManager modifying it then retrieving it again from SystemCapabilityManager to verify that it was not modified in the manager. 

Core version / branch / commit hash / module tested against: Manticore v 2.10.0
HMI name / version / branch / commit hash / module tested against: Manticore v 2.10.0

### Summary
When we get the new `DisplayCapability`, we update the old deprecated `DisplayCapabilities` based on the new `DisplayCapability`. When we do that, `ScreenParams`  and MediaClockFormats which are a part of `DisplayCapabilities` don't get set properly.

This pr checks cached DisplayCapabilities for `ScreenParams`  and  `MediaClockFormats` and updates them to the updated capabilities being set in SystemCapabilityManager as well as updates`getWindowCapability` to clone and set the` windowID` property. 


### Changelog
##### Bug Fixes
* Fixes updating `DisplayCapabilities`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
