### PR TITLE
Bugfix/issue 1812 Android 13 Support

### DIFF
--- a/android/hello_sdl_android/build.gradle
+++ b/android/hello_sdl_android/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     defaultConfig {
         applicationId "com.sdl.hellosdlandroid"
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/android/hello_sdl_android/src/main/AndroidManifest.xml
+++ b/android/hello_sdl_android/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"
         tools:targetApi="31"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"
+        tools:targetApi="33"/>
     <uses-permission android:name="android.permission.INTERNET" />
     <!-- Required to check if WiFi is enabled -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/MainActivity.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/MainActivity.java
@@ -25,9 +25,12 @@ public class MainActivity extends AppCompatActivity {
         if (BuildConfig.TRANSPORT.equals("MULTI") || BuildConfig.TRANSPORT.equals("MULTI_HB")) {
             String[] permissionsNeeded = permissionsNeeded();
             if (permissionsNeeded.length > 0) {
-                requestPermission(permissionsNeeded(), REQUEST_CODE);
-                if (checkBTPermission()) {
-                    return;
+                requestPermission(permissionsNeeded, REQUEST_CODE);
+                for (String permission : permissionsNeeded) {
+                    if (Manifest.permission.BLUETOOTH_CONNECT.equals(permission)) {
+                        // We need to request BLUETOOTH_CONNECT permission to connect to SDL via Bluetooth
+                        return;
+                    }
                 }
             }
 

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/MainActivity.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/MainActivity.java
@@ -81,6 +81,10 @@ public class MainActivity extends AppCompatActivity {
                         } else if (permissions[i].equals(Manifest.permission.POST_NOTIFICATIONS)) {
                             boolean postNotificationGranted =
                                     grantResults[i] == PackageManager.PERMISSION_GRANTED;
+                            if (!postNotificationGranted) {
+                                // User denied permission, Notifications for SDL will not appear
+                                // on Android 13 devices.
+                            }
                         }
                     }
                 }

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/MainActivity.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/MainActivity.java
@@ -23,7 +23,8 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
 
         if (BuildConfig.TRANSPORT.equals("MULTI") || BuildConfig.TRANSPORT.equals("MULTI_HB")) {
-            if (permissionsNeeded().length > 0) {
+            String[] permissionsNeeded = permissionsNeeded();
+            if (permissionsNeeded.length > 0) {
                 requestPermission(permissionsNeeded(), REQUEST_CODE);
                 if (checkBTPermission()) {
                     return;
@@ -54,7 +55,7 @@ public class MainActivity extends AppCompatActivity {
         ActivityCompat.requestPermissions(this, permissions, REQUEST_CODE);
     }
 
-    private String[] permissionsNeeded() {
+    private @NonNull String[] permissionsNeeded() {
         ArrayList<String> result = new ArrayList<>();
         if (checkBTPermission()) {
             result.add(Manifest.permission.BLUETOOTH_CONNECT);

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/MainActivity.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/MainActivity.java
@@ -23,8 +23,8 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
 
         if (BuildConfig.TRANSPORT.equals("MULTI") || BuildConfig.TRANSPORT.equals("MULTI_HB")) {
-            if(permissionsNeeded().length >0){
-                requestPermission(permissionsNeeded(),REQUEST_CODE);
+            if (permissionsNeeded().length > 0) {
+                requestPermission(permissionsNeeded(), REQUEST_CODE);
                 if (checkBTPermission()) {
                     return;
                 }
@@ -39,7 +39,7 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private boolean checkBTPermission() {
-       return Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !checkPermission(Manifest.permission.BLUETOOTH_CONNECT);
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !checkPermission(Manifest.permission.BLUETOOTH_CONNECT);
     }
 
     private boolean checkPNPermission() {
@@ -52,7 +52,6 @@ public class MainActivity extends AppCompatActivity {
 
     private void requestPermission(String[] permissions, int REQUEST_CODE) {
         ActivityCompat.requestPermissions(this, permissions, REQUEST_CODE);
-
     }
 
     private String[] permissionsNeeded() {

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/MainActivity.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/MainActivity.java
@@ -1,18 +1,17 @@
 package com.sdl.hellosdlandroid;
 
+import android.Manifest;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
-
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
-
-import static android.Manifest.permission.BLUETOOTH_CONNECT;
+import java.util.ArrayList;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -23,12 +22,14 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-
         if (BuildConfig.TRANSPORT.equals("MULTI") || BuildConfig.TRANSPORT.equals("MULTI_HB")) {
-            if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !checkPermission()) {
-                requestPermission();
-                return;
+            if(permissionsNeeded().length >0){
+                requestPermission(permissionsNeeded(),REQUEST_CODE);
+                if (checkBTPermission()) {
+                    return;
+                }
             }
+
             //If we are connected to a module we want to start our SdlService
             SdlReceiver.queryForConnectedService(this);
         } else if (BuildConfig.TRANSPORT.equals("TCP")){
@@ -37,12 +38,32 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
-    private boolean checkPermission() {
-        return PackageManager.PERMISSION_GRANTED == ContextCompat.checkSelfPermission(getApplicationContext(), BLUETOOTH_CONNECT);
+    private boolean checkBTPermission() {
+       return Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !checkPermission(Manifest.permission.BLUETOOTH_CONNECT);
     }
 
-    private void requestPermission() {
-        ActivityCompat.requestPermissions(this, new String[]{BLUETOOTH_CONNECT}, REQUEST_CODE);
+    private boolean checkPNPermission() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && !checkPermission(Manifest.permission.POST_NOTIFICATIONS);
+    }
+
+    private boolean checkPermission(String permission) {
+        return PackageManager.PERMISSION_GRANTED == ContextCompat.checkSelfPermission(getApplicationContext(), permission);
+    }
+
+    private void requestPermission(String[] permissions, int REQUEST_CODE) {
+        ActivityCompat.requestPermissions(this, permissions, REQUEST_CODE);
+
+    }
+
+    private String[] permissionsNeeded() {
+        ArrayList<String> result = new ArrayList<>();
+        if (checkBTPermission()) {
+            result.add(Manifest.permission.BLUETOOTH_CONNECT);
+        }
+        if (checkPNPermission()) {
+            result.add(Manifest.permission.POST_NOTIFICATIONS);
+        }
+        return (result.toArray(new String[result.size()]));
     }
 
     @Override
@@ -50,11 +71,17 @@ public class MainActivity extends AppCompatActivity {
         switch (requestCode) {
             case REQUEST_CODE:
                 if (grantResults.length > 0) {
-
-                    boolean btConnectGranted = grantResults[0] == PackageManager.PERMISSION_GRANTED;
-
-                    if (btConnectGranted) {
-                        SdlReceiver.queryForConnectedService(this);
+                    for (int i = 0; i < grantResults.length; i++) {
+                        if (permissions[i].equals(Manifest.permission.BLUETOOTH_CONNECT)) {
+                            boolean btConnectGranted =
+                                    grantResults[i] == PackageManager.PERMISSION_GRANTED;
+                            if (btConnectGranted) {
+                                SdlReceiver.queryForConnectedService(this);
+                            }
+                        } else if (permissions[i].equals(Manifest.permission.POST_NOTIFICATIONS)) {
+                            boolean postNotificationGranted =
+                                    grantResults[i] == PackageManager.PERMISSION_GRANTED;
+                        }
                     }
                 }
                 break;

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/MainActivity.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/MainActivity.java
@@ -39,12 +39,20 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
-    private boolean checkBTPermission() {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !checkPermission(Manifest.permission.BLUETOOTH_CONNECT);
+    /**
+     * Boolean method that checks API level and check to see if we need to request BLUETOOTH_CONNECT permission
+     * @return false if we need to request BLUETOOTH_CONNECT permission
+     */
+    private boolean hasBTPermission() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? checkPermission(Manifest.permission.BLUETOOTH_CONNECT) : true;
     }
 
-    private boolean checkPNPermission() {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && !checkPermission(Manifest.permission.POST_NOTIFICATIONS);
+    /**
+     * Boolean method that checks API level and check to see if we need to request POST_NOTIFICATIONS permission
+     * @return false if we need to request POST_NOTIFICATIONS permission
+     */
+    private boolean hasPNPermission() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU ? checkPermission(Manifest.permission.POST_NOTIFICATIONS) : true;
     }
 
     private boolean checkPermission(String permission) {
@@ -57,10 +65,10 @@ public class MainActivity extends AppCompatActivity {
 
     private @NonNull String[] permissionsNeeded() {
         ArrayList<String> result = new ArrayList<>();
-        if (checkBTPermission()) {
+        if (!hasBTPermission()) {
             result.add(Manifest.permission.BLUETOOTH_CONNECT);
         }
-        if (checkPNPermission()) {
+        if (!hasPNPermission()) {
             result.add(Manifest.permission.POST_NOTIFICATIONS);
         }
         return (result.toArray(new String[result.size()]));

--- a/android/sdl_android/build.gradle
+++ b/android/sdl_android/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 23
         versionName new File(projectDir.path, ('/../../VERSION')).text.trim()
         buildConfigField "String", "VERSION_NAME", '\"' + versionName + '\"'


### PR DESCRIPTION
Fixes #1812 

This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Unit Tests
n/a
#### Core Tests
POST_NOTIFICATIONS TESTS 

**1 app API 33 on Android 13 device**

Test 1:
1. App request POST_NOTIFICATIONS permission.
2. Accept permission
3. Connect to core

Results: Notifications appear and the app works as expected

Test 2:
1. App request POST_NOTIFICATIONS permission.
2. Click Don't Allow for permission.
4. Connect to core

Results: Notifications do not appear and the app works as expected

Test 3:
1. App request POST_NOTIFICATIONS permission.
2. Swipe away the request to allow notifications.
3. Connect to core

Results: Notifications do not appear and the app works as expected

Test 4:
1. App does not request POST_NOTIFICATIONS permission.
2. Connect to core

Results: Notifications do not appear and the app works as expected

**1 app API 31 on Android 13 device**

Test 5:
1. Connect to core
2. Accept Post Notification permission(Automatically sent by android)

Results: Notifications appear and the app works as expected

Test 6:
1. Connect to core
2. Click Don't Allow for Post Notification permission(Automatically sent by android)

Results: Notifications do not appear and the app works as expected

Test 7:
1. Connect to core
2. Swip away the request to allow notifications(Automatically sent by android).

Results: Notifications do not appear and the app works as expected


**App 1 API 33, App 2 API 31 on Android 13 device**

Test 8:
1. Accept notification permission for App 1.
2. Connects to core
3. Accept notification permissions for App 2 (Note Automatically sent by android you have to open app to view dialog to accept/deny permissions)

Results: Notifications appear and the app works as expected

Test 9:
1. Install in order App 2 then App 1 
2. Accept notification permission for App 1
3. Connects to core
5. Deny permission for App 2 

Results: Notifications appear for App 1 and RouterScervice but not for App 2. Apps work as expected

Test 10
1. Install App 1 
2. Deny notification permission
3. Connect to core
4. Disconnects from core
6. Install App 2
7. Connects to core
8. Accepts notification permission

Expected Results: No notifications for App 1 and RouterService, App 2 has 1 notification. Apps work as expected.

Observed behavior: No Notifications at all until you disconnect and reconnect to core then App 2 has 1 notification. Outside of that sdl still works fine.

Core version / branch / commit hash / module tested against: Sync 3.0
HMI name / version / branch / commit hash / module tested against: Sync 3.0

### Summary
This Pr makes updates to target API 33 as well as update `hello_sdl_android` to demonstrate how to request `POST_NOTIFICATIONS` permission added in Android 13.

There is one issue with test 10 where no notification appears when one should, but after a disconnect and reconnect it works itself out and the behavior of SDL is not altered outside of displayed notifications.

Notifications are still required, but they do not have to be displayed if they don't have the proper permissions. Another major downside to this is if you accidentally dismiss the `BLUETOOTH_CONNECT` permission and the `POST_NOTIFICATIONS` it does not give the user any sense of what they did wrong, but that should work itself out after the app gets closed and opened again.


### Changelog
##### Bug Fixes
* Demonstrate requesting `POST_NOTIFICATIONS` permission

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
