### PR TITLE
Bugfix/issue 1802 Unregister apps when audio output becomes unavailable

### DIFF
--- a/android/hello_sdl_android/build.gradle
+++ b/android/hello_sdl_android/build.gradle
@@ -8,6 +8,8 @@ android {
         targetSdkVersion 31
         versionCode 1
         versionName "1.0"
+        buildConfigField 'String', 'APP_TYPE', '"DEFAULT"'
+        buildConfigField 'String', 'REQUIRE_AUDIO_OUTPUT', '"FALSE"'
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
@@ -41,6 +43,13 @@ android {
         tcp {
             buildConfigField 'String', 'TRANSPORT', '"TCP"'
             buildConfigField 'String', 'SECURITY', '"OFF"'
+        }
+        requiresAudioOutput {
+            buildConfigField 'String', 'TRANSPORT', '"MULTI"'
+            buildConfigField 'String', 'SECURITY', '"OFF"'
+            buildConfigField 'String', 'APP_TYPE', '"MEDIA"'
+            buildConfigField 'String', 'REQUIRE_AUDIO_OUTPUT', '"TRUE"'
+
         }
     }
     lintOptions {

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlService.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlService.java
@@ -162,6 +162,9 @@ public class SdlService extends Service {
                     securityLevel = MultiplexTransportConfig.FLAG_MULTI_SECURITY_OFF;
                 }
                 transport = new MultiplexTransportConfig(this, APP_ID, securityLevel);
+                if (BuildConfig.REQUIRE_AUDIO_OUTPUT.equals("TRUE") ) {
+                    ((MultiplexTransportConfig)transport).setRequiresAudioSupport(true);
+                }
             } else if (BuildConfig.TRANSPORT.equals("TCP")) {
                 transport = new TCPTransportConfig(TCP_PORT, DEV_MACHINE_IP_ADDRESS, true);
             } else if (BuildConfig.TRANSPORT.equals("MULTI_HB")) {
@@ -172,7 +175,8 @@ public class SdlService extends Service {
 
             // The app type to be used
             Vector<AppHMIType> appType = new Vector<>();
-            appType.add(AppHMIType.DEFAULT);
+            appType.add(AppHMIType.valueForString(BuildConfig.APP_TYPE));
+
 
             // The manager listener helps you know when certain events that pertain to the SDL Manager happen
             // Here we will listen for ON_HMI_STATUS and ON_COMMAND notifications


### PR DESCRIPTION
Fixes #1802 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.
_Note: method added to library scoped class and therefore no API was added._

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
N/A These tests need to be ran manually.

#### ~Core~ IVI Tests

1. Set test app to Media using multiplexing (new HelloSdl build flavor: requiresAudioSupport)
2. Turn off bluetooth adapter on phone
3. Connect AOA through multiplexing, observe test app did not register
4. Turn on bluetooth and allow phone to connect to IVI
5. If app does not register automatically, open the manually and observe it did register
6. Turn off bluetooth adapter, observe app unregisters and is removed on the IVI apps screen

IVI Info: Sync Gen3

### Summary
This PR addresses the issue of apps not unregistering when they require audio support, it is initially given, and then is removed. Previously it would stop the session but not unregister which on some IVIs means the app icon will still be visible to the user. These changes are the simplest in terms of scope and lowest of risk. The alternatives were either a little more messy or created a much larger risk across the entire Java Suite.

##### Alternatives:
   1. Create a new constructor that takes in an audio streaming status callback
   2. Add a new method in the ISdlSessionListener for a required shutdown to the LCM or only that an UnregisterAppInterface message was sent. (This would affect Java SE/EE libs)


### Changelog

##### Bug Fixes
* Apps will now unregister from the IVI when the previously available audio output is no longer available.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
