### PR TITLE
Prevent exceptions being thrown for remaining startForegroundService calls

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -600,7 +600,12 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver {
         return false;
     }
 
-    private static void handleStartServiceException(Exception e) {
+    /**
+     * Convenience method to log details on the specific exception that occurred while attempting to
+     * start a foreground service.
+     * @param e the exception that occurred
+     */
+    protected static void handleStartServiceException(Exception e) {
         if (e instanceof SecurityException) {
             DebugTool.logError(TAG, "Security exception, process is bad");
             return;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterStatusProvider.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterStatusProvider.java
@@ -136,7 +136,7 @@ public class SdlRouterStatusProvider {
         } else {
             bindingIntent.putExtra(FOREGROUND_EXTRA, true);
             SdlBroadcastReceiver.setForegroundExceptionHandler(); //Prevent ANR in case the OS takes too long to start the service
-            try{
+            try {
                 context.startForegroundService(bindingIntent);
             } catch (SecurityException | IllegalStateException e) {
                 SdlBroadcastReceiver.handleStartServiceException(e);

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterStatusProvider.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterStatusProvider.java
@@ -136,11 +136,21 @@ public class SdlRouterStatusProvider {
         } else {
             bindingIntent.putExtra(FOREGROUND_EXTRA, true);
             SdlBroadcastReceiver.setForegroundExceptionHandler(); //Prevent ANR in case the OS takes too long to start the service
-            context.startForegroundService(bindingIntent);
+            try{
+                context.startForegroundService(bindingIntent);
+            } catch (SecurityException | IllegalStateException e) {
+                SdlBroadcastReceiver.handleStartServiceException(e);
+            }
 
         }
         bindingIntent.setAction(TransportConstants.BIND_REQUEST_TYPE_STATUS);
-        return context.bindService(bindingIntent, routerConnection, Context.BIND_AUTO_CREATE);
+        boolean didBind = false;
+        try {
+            didBind = context.bindService(bindingIntent, routerConnection, Context.BIND_AUTO_CREATE);
+        } catch (SecurityException | IllegalStateException e) {
+            SdlBroadcastReceiver.handleStartServiceException(e);
+        }
+        return didBind;
     }
 
     private void unBindFromService() {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/USBAccessoryAttachmentActivity.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/USBAccessoryAttachmentActivity.java
@@ -202,8 +202,8 @@ public class USBAccessoryAttachmentActivity extends Activity {
 
                         }
 
-                    } catch (SecurityException e) {
-                        DebugTool.logError(TAG, "Security exception, process is bad");
+                    } catch (SecurityException | IllegalStateException e) {
+                        SdlBroadcastReceiver.handleStartServiceException(e);
                     }
                 } else {
                     if (usbAccessory != null) {


### PR DESCRIPTION
Fixes #1829 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, ~Java SE, and Java EE~ (as this only affected Android classes)

#### Unit Tests
N/A as these exceptions occur on random Android devices and are not easily reproducible outside of adding logic to make it happen.

#### Core Tests
N/A This only occurs because of Android having a bug when starting foreground services and isn't related to Core or the IVI directly.

### Summary
Searched the project for any calls to `startForegroundService` and surrounded them with a try/catch. If an exception occurs it is passed to a method to handle it by logging out the reason for the exception.

### Changelog

##### Bug Fixes
* Prevent exceptions being thrown for Android's inability to properly time starting foreground services based on when the OS can start them instead of the time at which the `startForegroundService` is called initially. 


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
