### PR TITLE
Bugfix/issue 1828 Good text failing

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperationTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperationTest.java
@@ -191,12 +191,12 @@ public class TextAndGraphicUpdateOperationTest {
         mediaTrackField = "dudes";
         title = "dudes";
 
-        textField1Fail = "It is\n";
-        textField2Fail = "Wednesday\n";
-        textField3Fail = "My\n";
-        textField4Fail = "Dudes\n";
-        mediaTrackFieldFail = "dudes\n";
-        titleFail = "dudes\n";
+        textField1Fail = "It is\nbad data";
+        textField2Fail = "Wednesday\nbad data";
+        textField3Fail = "My\nbad data";
+        textField4Fail = "Dudes\nbad data";
+        mediaTrackFieldFail = "dudes\nbad data";
+        titleFail = "dudes\nbad data";
 
         blankArtwork = new SdlArtwork();
         blankArtwork.setType(FileType.GRAPHIC_PNG);

--- a/base/src/main/java/com/smartdevicelink/managers/screen/BaseTextAndGraphicManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/BaseTextAndGraphicManager.java
@@ -87,10 +87,10 @@ abstract class BaseTextAndGraphicManager extends BaseSubManager {
     private MetadataType textField1Type, textField2Type, textField3Type, textField4Type;
     private TemplateConfiguration templateConfiguration;
     TextAndGraphicUpdateOperation updateOperation;
-    private CompletionListener currentOperationListener;
     Queue transactionQueue;
 
     //Constructors
+
     BaseTextAndGraphicManager(@NonNull ISdl internalInterface, @NonNull FileManager fileManager, @NonNull SoftButtonManager softButtonManager) {
         // set class vars
         super(internalInterface);
@@ -166,6 +166,7 @@ abstract class BaseTextAndGraphicManager extends BaseSubManager {
     }
 
     // Upload / Send
+
     protected void update(CompletionListener listener) {
         // check if is batch update
         if (batchingUpdates) {
@@ -173,15 +174,13 @@ abstract class BaseTextAndGraphicManager extends BaseSubManager {
         }
         if (isDirty) {
             isDirty = false;
-            sdlUpdate(true, listener);
+            sdlUpdate(listener);
         } else if (listener != null) {
             listener.onComplete(true);
         }
     }
 
-    private synchronized void sdlUpdate(Boolean supersedePreviousOperations, final CompletionListener listener) {
-
-        currentOperationListener = listener;
+    private synchronized void sdlUpdate(final CompletionListener listener) {
 
         CurrentScreenDataUpdatedListener currentScreenDataUpdateListener = new CurrentScreenDataUpdatedListener() {
             @Override
@@ -197,11 +196,13 @@ abstract class BaseTextAndGraphicManager extends BaseSubManager {
             public void onError(TextAndGraphicState errorState) {
                 // Invalidate data that's different from our current screen data
                 resetFieldsToCurrentScreenData();
-                updatePendingOperationsWithFailedScreenState(errorState);
+                if (errorState != null) {
+                    updatePendingOperationsWithFailedScreenState(errorState);
+                }
             }
         };
 
-        updateOperation = new TextAndGraphicUpdateOperation(internalInterface, fileManager.get(), defaultMainWindowCapability, currentScreenData, currentState(), currentOperationListener, currentScreenDataUpdateListener);
+        updateOperation = new TextAndGraphicUpdateOperation(internalInterface, fileManager.get(), defaultMainWindowCapability, currentScreenData, currentState(), listener, currentScreenDataUpdateListener);
         transactionQueue.add(updateOperation, false);
     }
 
@@ -293,17 +294,19 @@ abstract class BaseTextAndGraphicManager extends BaseSubManager {
 
 
     // Convert to State
+
     TextAndGraphicState currentState() {
         return new TextAndGraphicState(textField1, textField2, textField3, textField4, mediaTrackTextField,
                 title, primaryGraphic, secondaryGraphic, textAlignment, textField1Type, textField2Type, textField3Type, textField4Type, templateConfiguration);
     }
 
     // Getters / Setters
+
     void setTextAlignment(TextAlignment textAlignment) {
         this.textAlignment = textAlignment;
         // If we aren't batching, send the update immediately, if we are, set ourselves as dirty (so we know we should send an update after the batch ends)
         if (!batchingUpdates) {
-            sdlUpdate(true, null);
+            sdlUpdate(null);
         } else {
             isDirty = true;
         }
@@ -316,7 +319,7 @@ abstract class BaseTextAndGraphicManager extends BaseSubManager {
     void setMediaTrackTextField(String mediaTrackTextField) {
         this.mediaTrackTextField = mediaTrackTextField;
         if (!batchingUpdates) {
-            sdlUpdate(true, null);
+            sdlUpdate(null);
         } else {
             isDirty = true;
         }
@@ -329,7 +332,7 @@ abstract class BaseTextAndGraphicManager extends BaseSubManager {
     void setTextField1(String textField1) {
         this.textField1 = textField1;
         if (!batchingUpdates) {
-            sdlUpdate(true, null);
+            sdlUpdate(null);
         } else {
             isDirty = true;
         }
@@ -342,7 +345,7 @@ abstract class BaseTextAndGraphicManager extends BaseSubManager {
     void setTextField2(String textField2) {
         this.textField2 = textField2;
         if (!batchingUpdates) {
-            sdlUpdate(true, null);
+            sdlUpdate(null);
         } else {
             isDirty = true;
         }
@@ -355,7 +358,7 @@ abstract class BaseTextAndGraphicManager extends BaseSubManager {
     void setTextField3(String textField3) {
         this.textField3 = textField3;
         if (!batchingUpdates) {
-            sdlUpdate(true, null);
+            sdlUpdate(null);
         } else {
             isDirty = true;
         }
@@ -368,7 +371,7 @@ abstract class BaseTextAndGraphicManager extends BaseSubManager {
     void setTextField4(String textField4) {
         this.textField4 = textField4;
         if (!batchingUpdates) {
-            sdlUpdate(true, null);
+            sdlUpdate(null);
         } else {
             isDirty = true;
         }
@@ -381,7 +384,7 @@ abstract class BaseTextAndGraphicManager extends BaseSubManager {
     void setTextField1Type(MetadataType textField1Type) {
         this.textField1Type = textField1Type;
         if (!batchingUpdates) {
-            sdlUpdate(true, null);
+            sdlUpdate(null);
         } else {
             isDirty = true;
         }
@@ -394,7 +397,7 @@ abstract class BaseTextAndGraphicManager extends BaseSubManager {
     void setTextField2Type(MetadataType textField2Type) {
         this.textField2Type = textField2Type;
         if (!batchingUpdates) {
-            sdlUpdate(true, null);
+            sdlUpdate(null);
         } else {
             isDirty = true;
         }
@@ -407,7 +410,7 @@ abstract class BaseTextAndGraphicManager extends BaseSubManager {
     void setTextField3Type(MetadataType textField3Type) {
         this.textField3Type = textField3Type;
         if (!batchingUpdates) {
-            sdlUpdate(true, null);
+            sdlUpdate(null);
         } else {
             isDirty = true;
         }
@@ -420,7 +423,7 @@ abstract class BaseTextAndGraphicManager extends BaseSubManager {
     void setTextField4Type(MetadataType textField4Type) {
         this.textField4Type = textField4Type;
         if (!batchingUpdates) {
-            sdlUpdate(true, null);
+            sdlUpdate(null);
         } else {
             isDirty = true;
         }
@@ -433,7 +436,7 @@ abstract class BaseTextAndGraphicManager extends BaseSubManager {
     void setTitle(String title) {
         this.title = title;
         if (!batchingUpdates) {
-            sdlUpdate(true, null);
+            sdlUpdate(null);
         } else {
             isDirty = true;
         }
@@ -446,7 +449,7 @@ abstract class BaseTextAndGraphicManager extends BaseSubManager {
     void setPrimaryGraphic(SdlArtwork primaryGraphic) {
         this.primaryGraphic = primaryGraphic;
         if (!batchingUpdates) {
-            sdlUpdate(true, null);
+            sdlUpdate(null);
         } else {
             isDirty = true;
         }
@@ -459,7 +462,7 @@ abstract class BaseTextAndGraphicManager extends BaseSubManager {
     void setSecondaryGraphic(SdlArtwork secondaryGraphic) {
         this.secondaryGraphic = secondaryGraphic;
         if (!batchingUpdates) {
-            sdlUpdate(true, null);
+            sdlUpdate(null);
         } else {
             isDirty = true;
         }
@@ -477,7 +480,7 @@ abstract class BaseTextAndGraphicManager extends BaseSubManager {
     void changeLayout(TemplateConfiguration templateConfiguration, CompletionListener listener) {
         setTemplateConfiguration(templateConfiguration);
         if (!batchingUpdates) {
-            sdlUpdate(true, listener);
+            sdlUpdate(listener);
         } else {
             isDirty = true;
         }
@@ -540,7 +543,7 @@ abstract class BaseTextAndGraphicManager extends BaseSubManager {
                 updateTransactionQueueSuspended();
                 if (hasData()) {
                     // HAX: Capability updates cannot supersede earlier updates because of the case where a developer batched a `changeLayout` call w/ T&G changes on < 6.0 systems could cause this to come in before the operation completes. That would cause the operation to report a "failure" (because it was superseded by this call) when in fact the operation didn't fail at all and is just being adjusted.
-                    sdlUpdate(false, null);
+                    sdlUpdate(null);
                 }
             }
 

--- a/base/src/main/java/com/smartdevicelink/managers/screen/BaseTextAndGraphicManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/BaseTextAndGraphicManager.java
@@ -242,8 +242,8 @@ abstract class BaseTextAndGraphicManager extends BaseSubManager {
                 continue;
             }
             ((TextAndGraphicUpdateOperation) task).setCurrentScreenData(currentScreenData);
+            ((TextAndGraphicUpdateOperation) task).updateTargetStateWithErrorState(errorState);
         }
-        updateOperation.updateTargetStateWithErrorState(errorState);
     }
 
     interface CurrentScreenDataUpdatedListener {

--- a/base/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperation.java
@@ -1,5 +1,7 @@
 package com.smartdevicelink.managers.screen;
 
+import android.util.Log;
+
 import com.livio.taskmaster.Task;
 import com.smartdevicelink.managers.CompletionListener;
 import com.smartdevicelink.managers.ISdl;
@@ -24,6 +26,7 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Created by Julian Kast on 8/23/20.
@@ -39,6 +42,8 @@ class TextAndGraphicUpdateOperation extends Task {
     private final TextAndGraphicManager.CurrentScreenDataUpdatedListener currentScreenDataUpdateListener;
     private final CompletionListener listener;
     private Show fullShow;
+
+    private boolean errorState;
 
     TextAndGraphicUpdateOperation(ISdl internalInterface, FileManager fileManager, WindowCapability currentCapabilities,
                                   TextAndGraphicState currentScreenData, TextAndGraphicState newState, CompletionListener listener, TextAndGraphicManager.CurrentScreenDataUpdatedListener currentScreenDataUpdateListener) {
@@ -92,6 +97,29 @@ class TextAndGraphicUpdateOperation extends Task {
         }
     }
 
+    void updateTargetStateWithErrorState(TextAndGraphicState errorState){
+        updatedState.setTextField1(errorState.getTextField1().equals(updatedState.getTextField1()) ? currentScreenData.getTextField1() : updatedState.getTextField1());
+        updatedState.setTextField2(errorState.getTextField2().equals(updatedState.getTextField2()) ? currentScreenData.getTextField2() : updatedState.getTextField2());
+        updatedState.setTextField3(errorState.getTextField3().equals(updatedState.getTextField3()) ? currentScreenData.getTextField3() : updatedState.getTextField3());
+        updatedState.setTextField4(errorState.getTextField4().equals(updatedState.getTextField4()) ? currentScreenData.getTextField4() : updatedState.getTextField4());
+
+        updatedState.setMediaTrackTextField(errorState.getMediaTrackTextField().equals(updatedState.getMediaTrackTextField()) ? currentScreenData.getMediaTrackTextField() : updatedState.getMediaTrackTextField());
+
+        updatedState.setTitle(errorState.getTitle().equals(updatedState.getTitle()) ? currentScreenData.getTitle() : updatedState.getTitle());
+
+        updatedState.setPrimaryGraphic(errorState.getPrimaryGraphic().equals(updatedState.getPrimaryGraphic()) ? currentScreenData.getPrimaryGraphic() : updatedState.getPrimaryGraphic());
+        updatedState.setSecondaryGraphic(errorState.getSecondaryGraphic().equals(updatedState.getSecondaryGraphic()) ? currentScreenData.getSecondaryGraphic() : updatedState.getSecondaryGraphic());
+
+        updatedState.setTextAlignment(errorState.getTextAlignment().equals(updatedState.getTextAlignment()) ? currentScreenData.getTextAlignment() : updatedState.getTextAlignment());
+
+        updatedState.setTextField1Type(errorState.getTextField1Type().equals(updatedState.getTextField1Type()) ? currentScreenData.getTextField1Type() : updatedState.getTextField1Type());
+        updatedState.setTextField2Type(errorState.getTextField2Type().equals(updatedState.getTextField2Type()) ? currentScreenData.getTextField2Type() : updatedState.getTextField2Type());
+        updatedState.setTextField3Type(errorState.getTextField3Type().equals(updatedState.getTextField3Type()) ? currentScreenData.getTextField3Type() : updatedState.getTextField3Type());
+        updatedState.setTextField4Type(errorState.getTextField4Type().equals(updatedState.getTextField4Type()) ? currentScreenData.getTextField4Type() : updatedState.getTextField4Type());
+
+        updatedState.setTemplateConfiguration(errorState.getTemplateConfiguration().equals(updatedState.getTemplateConfiguration()) ? currentScreenData.getTemplateConfiguration() : updatedState.getTemplateConfiguration());
+    }
+
     void updateGraphicsAndShow(Show show) {
         if (!shouldUpdatePrimaryImage() && !shouldUpdateSecondaryImage()) {
             DebugTool.logInfo(TAG, "No images to send, sending text");
@@ -129,7 +157,6 @@ class TextAndGraphicUpdateOperation extends Task {
                             finishOperation(success);
                         }
                     });
-
                 }
             });
         }
@@ -144,7 +171,7 @@ class TextAndGraphicUpdateOperation extends Task {
                     updateCurrentScreenDataFromShow(show);
                 } else {
                     DebugTool.logInfo(TAG, "Text and Graphic Show failed");
-                    currentScreenDataUpdateListener.onError();
+                    currentScreenDataUpdateListener.onError(updatedState);
                 }
                 listener.onComplete(response.getSuccess());
 
@@ -154,11 +181,10 @@ class TextAndGraphicUpdateOperation extends Task {
             internalInterface.get().sendRPC(show);
         } else {
             DebugTool.logInfo(TAG, "ISdl is null Text and Graphic update failed");
-            currentScreenDataUpdateListener.onError();
+            currentScreenDataUpdateListener.onError(updatedState);
             finishOperation(false);
             return;
         }
-
     }
 
     @SuppressWarnings("deprecation")
@@ -171,7 +197,7 @@ class TextAndGraphicUpdateOperation extends Task {
                     updateCurrentScreenDataFromSetDisplayLayout(setLayout);
                 } else {
                     DebugTool.logInfo(TAG, "Text and Graphic SetDisplayLayout failed");
-                    currentScreenDataUpdateListener.onError();
+                    currentScreenDataUpdateListener.onError(updatedState);
                 }
                 listener.onComplete(response.getSuccess());
             }
@@ -180,7 +206,7 @@ class TextAndGraphicUpdateOperation extends Task {
             internalInterface.get().sendRPC(setLayout);
         } else {
             DebugTool.logInfo(TAG, "ISdl is null Text and Graphic update failed");
-            currentScreenDataUpdateListener.onError();
+            currentScreenDataUpdateListener.onError(updatedState);
             finishOperation(false);
             return;
         }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperation.java
@@ -202,7 +202,7 @@ class TextAndGraphicUpdateOperation extends Task {
             internalInterface.get().sendRPC(show);
         } else {
             DebugTool.logInfo(TAG, "ISdl is null Text and Graphic update failed");
-            currentScreenDataUpdateListener.onError(null);
+            currentScreenDataUpdateListener.onError(updatedState);
             finishOperation(false);
             return;
         }
@@ -218,7 +218,7 @@ class TextAndGraphicUpdateOperation extends Task {
                     updateCurrentScreenDataFromSetDisplayLayout(setLayout);
                 } else {
                     DebugTool.logInfo(TAG, "Text and Graphic SetDisplayLayout failed");
-                    currentScreenDataUpdateListener.onError(null);
+                    currentScreenDataUpdateListener.onError(updatedState);
                 }
                 listener.onComplete(response.getSuccess());
             }
@@ -227,7 +227,7 @@ class TextAndGraphicUpdateOperation extends Task {
             internalInterface.get().sendRPC(setLayout);
         } else {
             DebugTool.logInfo(TAG, "ISdl is null Text and Graphic update failed");
-            currentScreenDataUpdateListener.onError(null);
+            currentScreenDataUpdateListener.onError(updatedState);
             finishOperation(false);
             return;
         }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperation.java
@@ -97,49 +97,49 @@ class TextAndGraphicUpdateOperation extends Task {
     }
 
     void updateTargetStateWithErrorState(@NonNull TextAndGraphicState errorState){
-        if (currentScreenData.getTextField1() != null) {
-            updatedState.setTextField1(errorState.getTextField1().equals(updatedState.getTextField1()) ? currentScreenData.getTextField1() : updatedState.getTextField1());
+        if (Objects.equals(errorState.getTextField1(), updatedState.getTextField1())){
+            updatedState.setTextField1(currentScreenData.getTextField1());
         }
-        if (currentScreenData.getTextField2() != null) {
-            updatedState.setTextField2(errorState.getTextField2().equals(updatedState.getTextField2()) ? currentScreenData.getTextField2() : updatedState.getTextField2());
+        if (Objects.equals(errorState.getTextField2(), updatedState.getTextField2())){
+            updatedState.setTextField2(currentScreenData.getTextField2());
         }
-        if (currentScreenData.getTextField3() != null) {
-            updatedState.setTextField3(errorState.getTextField3().equals(updatedState.getTextField3()) ? currentScreenData.getTextField3() : updatedState.getTextField3());
+        if (Objects.equals(errorState.getTextField3(), updatedState.getTextField3())){
+            updatedState.setTextField3(currentScreenData.getTextField3());
         }
-        if (currentScreenData.getTextField4() != null) {
-            updatedState.setTextField4(errorState.getTextField4().equals(updatedState.getTextField4()) ? currentScreenData.getTextField4() : updatedState.getTextField4());
+        if (Objects.equals(errorState.getTextField4(), updatedState.getTextField4())){
+            updatedState.setTextField4(currentScreenData.getTextField4());
         }
-        if (currentScreenData.getMediaTrackTextField() != null) {
-            updatedState.setMediaTrackTextField(errorState.getMediaTrackTextField().equals(updatedState.getMediaTrackTextField()) ? currentScreenData.getMediaTrackTextField() : updatedState.getMediaTrackTextField());
+        if (Objects.equals(errorState.getMediaTrackTextField(), updatedState.getMediaTrackTextField())){
+            updatedState.setMediaTrackTextField(currentScreenData.getMediaTrackTextField());
         }
-        if (currentScreenData.getTitle() != null) {
-            updatedState.setTitle(errorState.getTitle().equals(updatedState.getTitle()) ? currentScreenData.getTitle() : updatedState.getTitle());
+        if (Objects.equals(errorState.getTitle(), updatedState.getTitle())){
+            updatedState.setTitle(currentScreenData.getTitle());
         }
-        if (currentScreenData.getPrimaryGraphic() != null) {
-            updatedState.setPrimaryGraphic(errorState.getPrimaryGraphic().equals(updatedState.getPrimaryGraphic()) ? currentScreenData.getPrimaryGraphic() : updatedState.getPrimaryGraphic());
+        if (Objects.equals(errorState.getPrimaryGraphic(), updatedState.getPrimaryGraphic())){
+            updatedState.setPrimaryGraphic(currentScreenData.getPrimaryGraphic());
         }
-        if (currentScreenData.getSecondaryGraphic() != null) {
-            updatedState.setSecondaryGraphic(errorState.getSecondaryGraphic().equals(updatedState.getSecondaryGraphic()) ? currentScreenData.getSecondaryGraphic() : updatedState.getSecondaryGraphic());
+        if (Objects.equals(errorState.getSecondaryGraphic(), updatedState.getSecondaryGraphic())){
+            updatedState.setSecondaryGraphic(currentScreenData.getSecondaryGraphic());
         }
-        if (currentScreenData.getTextAlignment() != null) {
-            updatedState.setTextAlignment(errorState.getTextAlignment().equals(updatedState.getTextAlignment()) ? currentScreenData.getTextAlignment() : updatedState.getTextAlignment());
+        if (Objects.equals(errorState.getTextAlignment(), updatedState.getTextAlignment())){
+            updatedState.setTextAlignment(currentScreenData.getTextAlignment());
         }
-        if (currentScreenData.getTextField1Type() != null) {
-            updatedState.setTextField1Type(errorState.getTextField1Type().equals(updatedState.getTextField1Type()) ? currentScreenData.getTextField1Type() : updatedState.getTextField1Type());
+        if (Objects.equals(errorState.getTextField1Type(), updatedState.getTextField1Type())){
+            updatedState.setTextField1Type(currentScreenData.getTextField1Type());
         }
-        if (currentScreenData.getTextField2Type() != null) {
-            updatedState.setTextField2Type(errorState.getTextField2Type().equals(updatedState.getTextField2Type()) ? currentScreenData.getTextField2Type() : updatedState.getTextField2Type());
+        if (Objects.equals(errorState.getTextField2Type(), updatedState.getTextField2Type())){
+            updatedState.setTextField2Type(currentScreenData.getTextField2Type());
         }
-        if (currentScreenData.getTextField3Type() != null) {
-            updatedState.setTextField3Type(errorState.getTextField3Type().equals(updatedState.getTextField3Type()) ? currentScreenData.getTextField3Type() : updatedState.getTextField3Type());
+        if (Objects.equals(errorState.getTextField3Type(), updatedState.getTextField3Type())){
+            updatedState.setTextField3Type(currentScreenData.getTextField3Type());
         }
-        if (currentScreenData.getTextField4Type() != null) {
-            updatedState.setTextField4Type(errorState.getTextField4Type().equals(updatedState.getTextField4Type()) ? currentScreenData.getTextField4Type() : updatedState.getTextField4Type());
+        if (Objects.equals(errorState.getTextField4Type(), updatedState.getTextField4Type())){
+            updatedState.setTextField4Type(currentScreenData.getTextField4Type());
         }
-        if (currentScreenData.getTemplateConfiguration() != null) {
-            updatedState.setTemplateConfiguration(errorState.getTemplateConfiguration().equals(updatedState.getTemplateConfiguration()) ? currentScreenData.getTemplateConfiguration() : updatedState.getTemplateConfiguration());
+        if (Objects.equals(errorState.getTemplateConfiguration(), updatedState.getTemplateConfiguration())){
+            updatedState.setTemplateConfiguration(currentScreenData.getTemplateConfiguration());
         }
-        }
+    }
 
     void updateGraphicsAndShow(Show show) {
         if (!shouldUpdatePrimaryImage() && !shouldUpdateSecondaryImage()) {

--- a/base/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperation.java
@@ -202,7 +202,7 @@ class TextAndGraphicUpdateOperation extends Task {
             internalInterface.get().sendRPC(show);
         } else {
             DebugTool.logInfo(TAG, "ISdl is null Text and Graphic update failed");
-            currentScreenDataUpdateListener.onError(updatedState);
+            currentScreenDataUpdateListener.onError(null);
             finishOperation(false);
             return;
         }
@@ -218,7 +218,7 @@ class TextAndGraphicUpdateOperation extends Task {
                     updateCurrentScreenDataFromSetDisplayLayout(setLayout);
                 } else {
                     DebugTool.logInfo(TAG, "Text and Graphic SetDisplayLayout failed");
-                    currentScreenDataUpdateListener.onError(updatedState);
+                    currentScreenDataUpdateListener.onError(null);
                 }
                 listener.onComplete(response.getSuccess());
             }
@@ -227,7 +227,7 @@ class TextAndGraphicUpdateOperation extends Task {
             internalInterface.get().sendRPC(setLayout);
         } else {
             DebugTool.logInfo(TAG, "ISdl is null Text and Graphic update failed");
-            currentScreenDataUpdateListener.onError(updatedState);
+            currentScreenDataUpdateListener.onError(null);
             finishOperation(false);
             return;
         }

--- a/base/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperation.java
@@ -1,5 +1,7 @@
 package com.smartdevicelink.managers.screen;
 
+import androidx.annotation.NonNull;
+
 import com.livio.taskmaster.Task;
 import com.smartdevicelink.managers.CompletionListener;
 import com.smartdevicelink.managers.ISdl;
@@ -24,6 +26,7 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 
 /**
@@ -93,28 +96,50 @@ class TextAndGraphicUpdateOperation extends Task {
         }
     }
 
-    void updateTargetStateWithErrorState(TextAndGraphicState errorState){
-        updatedState.setTextField1(errorState.getTextField1().equals(updatedState.getTextField1()) ? currentScreenData.getTextField1() : updatedState.getTextField1());
-        updatedState.setTextField2(errorState.getTextField2().equals(updatedState.getTextField2()) ? currentScreenData.getTextField2() : updatedState.getTextField2());
-        updatedState.setTextField3(errorState.getTextField3().equals(updatedState.getTextField3()) ? currentScreenData.getTextField3() : updatedState.getTextField3());
-        updatedState.setTextField4(errorState.getTextField4().equals(updatedState.getTextField4()) ? currentScreenData.getTextField4() : updatedState.getTextField4());
-
-        updatedState.setMediaTrackTextField(errorState.getMediaTrackTextField().equals(updatedState.getMediaTrackTextField()) ? currentScreenData.getMediaTrackTextField() : updatedState.getMediaTrackTextField());
-
-        updatedState.setTitle(errorState.getTitle().equals(updatedState.getTitle()) ? currentScreenData.getTitle() : updatedState.getTitle());
-
-        updatedState.setPrimaryGraphic(errorState.getPrimaryGraphic().equals(updatedState.getPrimaryGraphic()) ? currentScreenData.getPrimaryGraphic() : updatedState.getPrimaryGraphic());
-        updatedState.setSecondaryGraphic(errorState.getSecondaryGraphic().equals(updatedState.getSecondaryGraphic()) ? currentScreenData.getSecondaryGraphic() : updatedState.getSecondaryGraphic());
-
-        updatedState.setTextAlignment(errorState.getTextAlignment().equals(updatedState.getTextAlignment()) ? currentScreenData.getTextAlignment() : updatedState.getTextAlignment());
-
-        updatedState.setTextField1Type(errorState.getTextField1Type().equals(updatedState.getTextField1Type()) ? currentScreenData.getTextField1Type() : updatedState.getTextField1Type());
-        updatedState.setTextField2Type(errorState.getTextField2Type().equals(updatedState.getTextField2Type()) ? currentScreenData.getTextField2Type() : updatedState.getTextField2Type());
-        updatedState.setTextField3Type(errorState.getTextField3Type().equals(updatedState.getTextField3Type()) ? currentScreenData.getTextField3Type() : updatedState.getTextField3Type());
-        updatedState.setTextField4Type(errorState.getTextField4Type().equals(updatedState.getTextField4Type()) ? currentScreenData.getTextField4Type() : updatedState.getTextField4Type());
-
-        updatedState.setTemplateConfiguration(errorState.getTemplateConfiguration().equals(updatedState.getTemplateConfiguration()) ? currentScreenData.getTemplateConfiguration() : updatedState.getTemplateConfiguration());
-    }
+    void updateTargetStateWithErrorState(@NonNull TextAndGraphicState errorState){
+        if (currentScreenData.getTextField1() != null) {
+            updatedState.setTextField1(errorState.getTextField1().equals(updatedState.getTextField1()) ? currentScreenData.getTextField1() : updatedState.getTextField1());
+        }
+        if (currentScreenData.getTextField2() != null) {
+            updatedState.setTextField2(errorState.getTextField2().equals(updatedState.getTextField2()) ? currentScreenData.getTextField2() : updatedState.getTextField2());
+        }
+        if (currentScreenData.getTextField3() != null) {
+            updatedState.setTextField3(errorState.getTextField3().equals(updatedState.getTextField3()) ? currentScreenData.getTextField3() : updatedState.getTextField3());
+        }
+        if (currentScreenData.getTextField4() != null) {
+            updatedState.setTextField4(errorState.getTextField4().equals(updatedState.getTextField4()) ? currentScreenData.getTextField4() : updatedState.getTextField4());
+        }
+        if (currentScreenData.getMediaTrackTextField() != null) {
+            updatedState.setMediaTrackTextField(errorState.getMediaTrackTextField().equals(updatedState.getMediaTrackTextField()) ? currentScreenData.getMediaTrackTextField() : updatedState.getMediaTrackTextField());
+        }
+        if (currentScreenData.getTitle() != null) {
+            updatedState.setTitle(errorState.getTitle().equals(updatedState.getTitle()) ? currentScreenData.getTitle() : updatedState.getTitle());
+        }
+        if (currentScreenData.getPrimaryGraphic() != null) {
+            updatedState.setPrimaryGraphic(errorState.getPrimaryGraphic().equals(updatedState.getPrimaryGraphic()) ? currentScreenData.getPrimaryGraphic() : updatedState.getPrimaryGraphic());
+        }
+        if (currentScreenData.getSecondaryGraphic() != null) {
+            updatedState.setSecondaryGraphic(errorState.getSecondaryGraphic().equals(updatedState.getSecondaryGraphic()) ? currentScreenData.getSecondaryGraphic() : updatedState.getSecondaryGraphic());
+        }
+        if (currentScreenData.getTextAlignment() != null) {
+            updatedState.setTextAlignment(errorState.getTextAlignment().equals(updatedState.getTextAlignment()) ? currentScreenData.getTextAlignment() : updatedState.getTextAlignment());
+        }
+        if (currentScreenData.getTextField1Type() != null) {
+            updatedState.setTextField1Type(errorState.getTextField1Type().equals(updatedState.getTextField1Type()) ? currentScreenData.getTextField1Type() : updatedState.getTextField1Type());
+        }
+        if (currentScreenData.getTextField2Type() != null) {
+            updatedState.setTextField2Type(errorState.getTextField2Type().equals(updatedState.getTextField2Type()) ? currentScreenData.getTextField2Type() : updatedState.getTextField2Type());
+        }
+        if (currentScreenData.getTextField3Type() != null) {
+            updatedState.setTextField3Type(errorState.getTextField3Type().equals(updatedState.getTextField3Type()) ? currentScreenData.getTextField3Type() : updatedState.getTextField3Type());
+        }
+        if (currentScreenData.getTextField4Type() != null) {
+            updatedState.setTextField4Type(errorState.getTextField4Type().equals(updatedState.getTextField4Type()) ? currentScreenData.getTextField4Type() : updatedState.getTextField4Type());
+        }
+        if (currentScreenData.getTemplateConfiguration() != null) {
+            updatedState.setTemplateConfiguration(errorState.getTemplateConfiguration().equals(updatedState.getTemplateConfiguration()) ? currentScreenData.getTemplateConfiguration() : updatedState.getTemplateConfiguration());
+        }
+        }
 
     void updateGraphicsAndShow(Show show) {
         if (!shouldUpdatePrimaryImage() && !shouldUpdateSecondaryImage()) {

--- a/base/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperation.java
@@ -1,7 +1,5 @@
 package com.smartdevicelink.managers.screen;
 
-import android.util.Log;
-
 import com.livio.taskmaster.Task;
 import com.smartdevicelink.managers.CompletionListener;
 import com.smartdevicelink.managers.ISdl;
@@ -26,7 +24,7 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+
 
 /**
  * Created by Julian Kast on 8/23/20.
@@ -42,8 +40,6 @@ class TextAndGraphicUpdateOperation extends Task {
     private final TextAndGraphicManager.CurrentScreenDataUpdatedListener currentScreenDataUpdateListener;
     private final CompletionListener listener;
     private Show fullShow;
-
-    private boolean errorState;
 
     TextAndGraphicUpdateOperation(ISdl internalInterface, FileManager fileManager, WindowCapability currentCapabilities,
                                   TextAndGraphicState currentScreenData, TextAndGraphicState newState, CompletionListener listener, TextAndGraphicManager.CurrentScreenDataUpdatedListener currentScreenDataUpdateListener) {


### PR DESCRIPTION
Fixes #1828

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, *Java SE, and *Java EE

#### Unit Tests
*Note: This branch has been tested for Android by Chloe, Julian Tested JavaSE

- `testOnShowFailBadDataDoesNotUpdateScreen()` : Tests the show failure branch within the `sendShow` method which notifies the `currentScreenDataUpdateListener` of an `errorState`.
- `testUpdateTargetStateWithErrorStateNullDoesNotUpdateCurrentScreen()`: Tests the `updateTargetStateWithErrorState` method to ensure that fields set to null will not be updated on the current screen.
- `testUpdateTargetStateWithErrorBadDataDoesNotUpdateCurrentScreen()` : Tests the `updateTargetStateWithErrorState` method to ensure that fields set to bad data will not be updated on the current screen.
- `testUpdateTargetStateWithErrorBadDataAndGoodData()` : Tests the `updateTargetStateWithErrorState` method to ensure that fields set to bad data will not be updated on the current screen but fields set with good data will be updated.

#### Core Tests
In Manticore verified that properties in screen manager when set would not fail when one attribute was given bad data

### Summary
- In `TextAndGraphicUpdateOperation:` modified the `sendShow` method to call `currentScreenDataUpdateListener.onError(updatedState)` on failure.
- Modified the `onError` path of the `currentScreenDataUpdateListener` override to call `updatePendingOperationsWithFailedScreenState(errorState)`, passing in an `errorState`.
- In `BaseTextAndGraphicManager`: added in method `updatePendingOperationsWithFailedScreenState `which sends the `errorState` to `updateOperation.updateTargetStateWithErrorState(errorState)`
- In `TextAndGraphicUpdateOperation`: added method `updateTargetStateWithErrorState` that ensures every field is null safe and compares the `errorState` to the `updatedState`. If they are the same, then it sets the `updatedState` to the `currentScreenData `associated with the field to keep the field from being updated with bad data.
- Added unit tests.

### Changelog

##### Enhancements
* Screen data will update even if other fields may have bad data.

##### Bug Fixes
* Screen data will update even if other fields may have bad data.

### Tasks Remaining
- [x] Create fix.
- [x] Add unit tests.
- [x] Code review.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
