### PR TITLE
Update current screen data in T&G manager with template config

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperationTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperationTest.java
@@ -1013,7 +1013,6 @@ public class TextAndGraphicUpdateOperationTest {
                 mediaTrackField, title, testArtwork3, testArtwork4, textAlignment, textField1Type, textField2Type, textField3Type, textField4Type, configuration);
         textAndGraphicUpdateOperation = new TextAndGraphicUpdateOperation(internalInterface, fileManager, defaultMainWindowCapability, currentScreenData, textsAndGraphicsState, listener, currentScreenDataUpdatedListener);
         textAndGraphicUpdateOperation.onExecute();
-        assertEquals(textAndGraphicUpdateOperation.getCurrentScreenData().getTemplateConfiguration().getStore(), configuration.getStore());
 
         // Verifies that uploadArtworks does not get called because a sendShow failed with text and layout change
         verify(fileManager, times(0)).uploadArtworks(any(List.class), any(MultipleFileCompletionListener.class));

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperationTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperationTest.java
@@ -69,7 +69,7 @@ public class TextAndGraphicUpdateOperationTest {
     private CompletionListener listener;
     private TextAndGraphicManager.CurrentScreenDataUpdatedListener currentScreenDataUpdatedListener;
     private SdlArtwork blankArtwork;
-    private TemplateConfiguration configuration, configurationFail;
+    private TemplateConfiguration configuration, configurationFail, configurationOld;
     ISdl internalInterface;
     FileManager fileManager;
 
@@ -246,7 +246,7 @@ public class TextAndGraphicUpdateOperationTest {
         configuration = new TemplateConfiguration();
         configuration.setTemplate(PredefinedLayout.GRAPHIC_WITH_TEXT.toString());
 
-        TemplateConfiguration configurationOld = new TemplateConfiguration();
+        configurationOld = new TemplateConfiguration();
         configurationOld.setTemplate(PredefinedLayout.TEXT_WITH_GRAPHIC.toString());
         configurationFail = new TemplateConfiguration();
         configurationFail.setTemplate("failConfiguration");
@@ -1081,7 +1081,7 @@ public class TextAndGraphicUpdateOperationTest {
         TestCase.assertNull(textAndGraphicUpdateOperation.getCurrentScreenData().getTextField2Type());
         TestCase.assertNull(textAndGraphicUpdateOperation.getCurrentScreenData().getTextField3Type());
         TestCase.assertNull(textAndGraphicUpdateOperation.getCurrentScreenData().getTextField4Type());
-        assertEquals(configuration, textAndGraphicUpdateOperation.getCurrentScreenData().getTemplateConfiguration());
+        assertEquals(configurationOld, textAndGraphicUpdateOperation.getCurrentScreenData().getTemplateConfiguration());
     }
 
     @Test
@@ -1121,7 +1121,7 @@ public class TextAndGraphicUpdateOperationTest {
         TestCase.assertNull(textAndGraphicUpdateOperation.getCurrentScreenData().getTextField2Type());
         TestCase.assertNull(textAndGraphicUpdateOperation.getCurrentScreenData().getTextField3Type());
         TestCase.assertNull(textAndGraphicUpdateOperation.getCurrentScreenData().getTextField4Type());
-        assertEquals(configuration, textAndGraphicUpdateOperation.getCurrentScreenData().getTemplateConfiguration());
+        assertEquals(configurationOld, textAndGraphicUpdateOperation.getCurrentScreenData().getTemplateConfiguration());
     }
 
     @Test
@@ -1161,7 +1161,7 @@ public class TextAndGraphicUpdateOperationTest {
         TestCase.assertNull(textAndGraphicUpdateOperation.getCurrentScreenData().getTextField2Type());
         TestCase.assertNull(textAndGraphicUpdateOperation.getCurrentScreenData().getTextField3Type());
         TestCase.assertNull(textAndGraphicUpdateOperation.getCurrentScreenData().getTextField4Type());
-        assertEquals(configuration, textAndGraphicUpdateOperation.getCurrentScreenData().getTemplateConfiguration());
+        assertEquals(configurationOld, textAndGraphicUpdateOperation.getCurrentScreenData().getTemplateConfiguration());
     }
 
     @Test
@@ -1201,6 +1201,6 @@ public class TextAndGraphicUpdateOperationTest {
         TestCase.assertNull(textAndGraphicUpdateOperation.getCurrentScreenData().getTextField2Type());
         TestCase.assertNull(textAndGraphicUpdateOperation.getCurrentScreenData().getTextField3Type());
         TestCase.assertNull(textAndGraphicUpdateOperation.getCurrentScreenData().getTextField4Type());
-        assertEquals(configuration, textAndGraphicUpdateOperation.getCurrentScreenData().getTemplateConfiguration());
+        assertEquals(configurationOld, textAndGraphicUpdateOperation.getCurrentScreenData().getTemplateConfiguration());
     }
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperationTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperationTest.java
@@ -228,6 +228,9 @@ public class TextAndGraphicUpdateOperationTest {
         configuration = new TemplateConfiguration();
         configuration.setTemplate(PredefinedLayout.GRAPHIC_WITH_TEXT.toString());
 
+        TemplateConfiguration configurationOld = new TemplateConfiguration();
+        configurationOld.setTemplate(PredefinedLayout.TEXT_WITH_GRAPHIC.toString());
+
         currentScreenData = new TextAndGraphicState();
         currentScreenData.setTextField1("Old");
         currentScreenData.setTextField2("Text");
@@ -236,7 +239,7 @@ public class TextAndGraphicUpdateOperationTest {
 
         currentScreenData.setPrimaryGraphic(testArtwork1);
         currentScreenData.setSecondaryGraphic(testArtwork2);
-        currentScreenData.setTemplateConfiguration(configuration);
+        currentScreenData.setTemplateConfiguration(configurationOld);
 
         currentScreenDataUpdatedListener = new TextAndGraphicManager.CurrentScreenDataUpdatedListener() {
             @Override

--- a/base/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicUpdateOperation.java
@@ -586,6 +586,9 @@ class TextAndGraphicUpdateOperation extends Task {
         if (show.getSecondaryGraphic() != null) {
             currentScreenData.setSecondaryGraphic(updatedState.getSecondaryGraphic());
         }
+        if (show.getTemplateConfiguration() != null) {
+            currentScreenData.setTemplateConfiguration(updatedState.getTemplateConfiguration());
+        }
         if (currentScreenDataUpdateListener != null) {
             currentScreenDataUpdateListener.onUpdate(currentScreenData);
         }


### PR DESCRIPTION
Fixes #1833 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
I updated existing unit test in TextAndGraphicUpdateOperationTest

#### Core Tests
Tested updating the template and check currentScreenData in BaseTextAndGraphicManager after the update.

Core version / branch / commit hash / module tested against: Manticore
HMI name / version / branch / commit hash / module tested against: Manticore

### Summary
This PR  adds a missing check in`TextAndGraphicUpdateOperation`  that would check for a template config after an update and add that to `currentScreenData` for the `TextAndGraphicManager`.  

### Changelog
##### Bug Fixes
* Adds a missing check in`TextAndGraphicUpdateOperation`  that would check for a template config after an update and add that to `currentScreenData` for the `TextAndGraphicManager`.  

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
