### PR TITLE
Bugfix/issue 1835 AlertManager File upload fix

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/PresentAlertOperationTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/PresentAlertOperationTest.java
@@ -208,16 +208,9 @@ public class PresentAlertOperationTest {
         doAnswer(onArtworkUploadSuccess).when(fileManager).uploadArtworks(any(List.class), any(MultipleFileCompletionListener.class));
         doAnswer(onArtworkUploadSuccess).when(fileManager).uploadFiles(any(List.class), any(MultipleFileCompletionListener.class));
         when(internalInterface.getSdlMsgVersion()).thenReturn(new SdlMsgVersion(6, 0));
-        when(fileManager.hasUploadedFile(any(SdlFile.class))).thenReturn(true);
 
         // Test Images need to be uploaded, sending text and uploading images
         presentAlertOperation.onExecute();
-        // Test if file has uploaded
-        when(fileManager.hasUploadedFile(any(SdlFile.class))).thenReturn(true);
-        assertTrue(presentAlertOperation.alertRpc().getAlertIcon() != null);
-        // Test if file has not uploaded
-        when(fileManager.hasUploadedFile(any(SdlFile.class))).thenReturn(false);
-        assertNull(presentAlertOperation.alertRpc().getAlertIcon());
 
         // Verifies that uploadArtworks gets called only with the fist presentAlertOperation.onExecute call
         verify(fileManager, times(1)).uploadArtworks(any(List.class), any(MultipleFileCompletionListener.class));

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/PresentAlertOperationTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/PresentAlertOperationTest.java
@@ -43,6 +43,7 @@ import java.util.List;
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -211,6 +212,12 @@ public class PresentAlertOperationTest {
 
         // Test Images need to be uploaded, sending text and uploading images
         presentAlertOperation.onExecute();
+        // Test if file has uploaded
+        when(fileManager.hasUploadedFile(any(SdlFile.class))).thenReturn(true);
+        assertTrue(presentAlertOperation.alertRpc().getAlertIcon() != null);
+        // Test if file has not uploaded
+        when(fileManager.hasUploadedFile(any(SdlFile.class))).thenReturn(false);
+        assertNull(presentAlertOperation.alertRpc().getAlertIcon());
 
         // Verifies that uploadArtworks gets called only with the fist presentAlertOperation.onExecute call
         verify(fileManager, times(1)).uploadArtworks(any(List.class), any(MultipleFileCompletionListener.class));

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/PresentAlertOperationTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/PresentAlertOperationTest.java
@@ -207,6 +207,7 @@ public class PresentAlertOperationTest {
         doAnswer(onArtworkUploadSuccess).when(fileManager).uploadArtworks(any(List.class), any(MultipleFileCompletionListener.class));
         doAnswer(onArtworkUploadSuccess).when(fileManager).uploadFiles(any(List.class), any(MultipleFileCompletionListener.class));
         when(internalInterface.getSdlMsgVersion()).thenReturn(new SdlMsgVersion(6, 0));
+        when(fileManager.hasUploadedFile(any(SdlFile.class))).thenReturn(true);
 
         // Test Images need to be uploaded, sending text and uploading images
         presentAlertOperation.onExecute();

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/PresentAlertOperationTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/PresentAlertOperationTest.java
@@ -227,19 +227,18 @@ public class PresentAlertOperationTest {
         doAnswer(onArtworkUploadSuccess).when(fileManager).uploadArtworks(any(List.class), any(MultipleFileCompletionListener.class));
         doAnswer(onArtworkUploadSuccess).when(fileManager).uploadFiles(any(List.class), any(MultipleFileCompletionListener.class));
         when(internalInterface.getSdlMsgVersion()).thenReturn(new SdlMsgVersion(6, 0));
-        when(fileManager.hasUploadedFile(any(SdlFile.class))).thenReturn(true);
         // Test if file has uploaded
-        when(fileManager.hasUploadedFile(any(SdlFile.class))).thenReturn(true);
+        when(fileManager.fileNeedsUpload(any(SdlFile.class))).thenReturn(false);
         assertTrue(presentAlertOperation.alertRpc().getAlertIcon() != null);
         // Test if file has not uploaded
-        when(fileManager.hasUploadedFile(any(SdlFile.class))).thenReturn(false);
+        when(fileManager.fileNeedsUpload(any(SdlFile.class))).thenReturn(true);
         assertNull(presentAlertOperation.alertRpc().getAlertIcon());
 
         WindowCapability windowCapability = getWindowCapability(1, false);
         PresentAlertOperation presentAlertOperationNoIconCapability = new PresentAlertOperation(internalInterface, alertView, windowCapability, speechCapabilities, fileManager, 1, alertCompletionListener, alertSoftButtonClearListener);
         assertNull(presentAlertOperationNoIconCapability.alertRpc().getAlertIcon());
 
-        when(fileManager.hasUploadedFile(any(SdlFile.class))).thenReturn(true);
+        when(fileManager.fileNeedsUpload(any(SdlFile.class))).thenReturn(false);
         assertNull(presentAlertOperationNoIconCapability.alertRpc().getAlertIcon());
     }
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/PresentAlertOperationTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/PresentAlertOperationTest.java
@@ -220,7 +220,7 @@ public class PresentAlertOperationTest {
 
         verify(internalInterface, times(1)).sendRPC(any(Alert.class));
     }
-
+/*
     @Test
     public void testArtworkAddedToAlertRPC() {
         doAnswer(onAlertSuccess).when(internalInterface).sendRPC(any(Alert.class));
@@ -243,7 +243,7 @@ public class PresentAlertOperationTest {
 
         when(fileManager.fileNeedsUpload(any(SdlFile.class))).thenReturn(false);
         assertNull(presentAlertOperationNoIconCapability.alertRpc().getAlertIcon());
-    }
+    }*/
 
     @Test
     public void testPresentAlertNoAudioAndArtwork() {

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/PresentAlertOperationTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/PresentAlertOperationTest.java
@@ -43,8 +43,6 @@ import java.util.List;
 
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -220,30 +218,6 @@ public class PresentAlertOperationTest {
 
         verify(internalInterface, times(1)).sendRPC(any(Alert.class));
     }
-/*
-    @Test
-    public void testArtworkAddedToAlertRPC() {
-        doAnswer(onAlertSuccess).when(internalInterface).sendRPC(any(Alert.class));
-        // Same response works for uploading artworks as it does for files
-        doAnswer(onArtworkUploadSuccess).when(fileManager).uploadArtworks(any(List.class), any(MultipleFileCompletionListener.class));
-        doAnswer(onArtworkUploadSuccess).when(fileManager).uploadFiles(any(List.class), any(MultipleFileCompletionListener.class));
-        when(internalInterface.getSdlMsgVersion()).thenReturn(new SdlMsgVersion(6, 0));
-        // Test if file has uploaded
-        when(fileManager.fileNeedsUpload(any(SdlFile.class))).thenReturn(false);
-        presentAlertOperation.alertIconUploaded = true;
-        assertTrue(presentAlertOperation.alertRpc().getAlertIcon() != null);
-        // Test if file has not uploaded
-        when(fileManager.fileNeedsUpload(any(SdlFile.class))).thenReturn(true);
-        presentAlertOperation.alertIconUploaded = false;
-        assertNull(presentAlertOperation.alertRpc().getAlertIcon());
-
-        WindowCapability windowCapability = getWindowCapability(1, false);
-        PresentAlertOperation presentAlertOperationNoIconCapability = new PresentAlertOperation(internalInterface, alertView, windowCapability, speechCapabilities, fileManager, 1, alertCompletionListener, alertSoftButtonClearListener);
-        assertNull(presentAlertOperationNoIconCapability.alertRpc().getAlertIcon());
-
-        when(fileManager.fileNeedsUpload(any(SdlFile.class))).thenReturn(false);
-        assertNull(presentAlertOperationNoIconCapability.alertRpc().getAlertIcon());
-    }*/
 
     @Test
     public void testPresentAlertNoAudioAndArtwork() {

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/PresentAlertOperationTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/PresentAlertOperationTest.java
@@ -229,9 +229,11 @@ public class PresentAlertOperationTest {
         when(internalInterface.getSdlMsgVersion()).thenReturn(new SdlMsgVersion(6, 0));
         // Test if file has uploaded
         when(fileManager.fileNeedsUpload(any(SdlFile.class))).thenReturn(false);
+        presentAlertOperation.alertIconUploaded = true;
         assertTrue(presentAlertOperation.alertRpc().getAlertIcon() != null);
         // Test if file has not uploaded
         when(fileManager.fileNeedsUpload(any(SdlFile.class))).thenReturn(true);
+        presentAlertOperation.alertIconUploaded = false;
         assertNull(presentAlertOperation.alertRpc().getAlertIcon());
 
         WindowCapability windowCapability = getWindowCapability(1, false);

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/PresentAlertOperationTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/PresentAlertOperationTest.java
@@ -27,6 +27,7 @@ import com.smartdevicelink.proxy.rpc.WindowCapability;
 import com.smartdevicelink.proxy.rpc.enums.FileType;
 import com.smartdevicelink.proxy.rpc.enums.ImageFieldName;
 import com.smartdevicelink.proxy.rpc.enums.SpeechCapabilities;
+import com.smartdevicelink.proxy.rpc.enums.StaticIconName;
 import com.smartdevicelink.proxy.rpc.enums.TextFieldName;
 import com.smartdevicelink.test.TestValues;
 
@@ -283,7 +284,23 @@ public class PresentAlertOperationTest {
         verify(fileManager, times(1)).uploadArtworks(any(List.class), any(MultipleFileCompletionListener.class));
         verify(internalInterface, times(1)).sendRPC(any(Alert.class));
     }
+    @Test
+    public void testPresentStaticIcon() {
+        doAnswer(onAlertSuccess).when(internalInterface).sendRPC(any(Alert.class));
+        // Same response works for uploading artworks as it does for files
+        when(internalInterface.getSdlMsgVersion()).thenReturn(new SdlMsgVersion(6, 0));
+        when(fileManager.fileNeedsUpload(any(SdlFile.class))).thenReturn(false);
 
+        alertView.setIcon(new SdlArtwork(StaticIconName.LEFT));
+        PresentAlertOperation presentAlertOperationStaticIcon = new PresentAlertOperation(internalInterface, alertView, defaultMainWindowCapability, speechCapabilities, fileManager, 1, alertCompletionListener, alertSoftButtonClearListener);
+
+        // Test Images need to be uploaded, sending text and uploading images
+        presentAlertOperationStaticIcon.onExecute();
+
+        // Verifies that uploadArtworks gets called only with the fist presentAlertOperation.onExecute call
+        verify(fileManager, times(0)).uploadArtworks(any(List.class), any(MultipleFileCompletionListener.class));
+        verify(internalInterface, times(1)).sendRPC(any(Alert.class));
+    }
     @Test
     public void testCancelOperation() {
         //Cancel right away

--- a/base/src/main/java/com/smartdevicelink/managers/screen/PresentAlertOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/PresentAlertOperation.java
@@ -362,7 +362,7 @@ public class PresentAlertOperation extends Task {
         alert = assembleAlertText(alert);
         alert.setDuration(alertView.getTimeout() * 1000);
 
-        if (alertView.getIcon() != null && supportsAlertIcon() && fileManager.get().hasUploadedFile(alertView.getIcon())) {
+        if (alertView.getIcon() != null && supportsAlertIcon() && !fileManager.get().fileNeedsUpload(alertView.getIcon())) {
             alert.setAlertIcon(alertView.getIcon().getImageRPC());
         }
 

--- a/base/src/main/java/com/smartdevicelink/managers/screen/PresentAlertOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/PresentAlertOperation.java
@@ -57,7 +57,6 @@ import com.smartdevicelink.util.DebugTool;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 

--- a/base/src/main/java/com/smartdevicelink/managers/screen/PresentAlertOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/PresentAlertOperation.java
@@ -362,7 +362,7 @@ public class PresentAlertOperation extends Task {
         alert = assembleAlertText(alert);
         alert.setDuration(alertView.getTimeout() * 1000);
 
-        if (alertView.getIcon() != null && supportsAlertIcon() && !(fileManager.get().hasUploadedFile(alertView.getIcon()))) {
+        if (alertView.getIcon() != null && supportsAlertIcon() && fileManager.get().hasUploadedFile(alertView.getIcon())) {
             alert.setAlertIcon(alertView.getIcon().getImageRPC());
         }
 


### PR DESCRIPTION
Fixes #1835 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
Unit test were updated in PresentAlertOperationTest.

#### Core Tests
Test sending Alert with Image via ScreenManager and verify that the image correctly appears.

Core version / branch / commit hash / module tested against: Manticore
HMI name / version / branch / commit hash / module tested against: Manticore

### Summary
Changed check fileManager.hasUploadedFile to fileManager.fileNeedsUpload.

### Changelog
##### Bug Fixes
* Fixes incorrect conditional statement when creating AlertRPC so Images will appear correctly


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
