### PR TITLE
Add pending intent to ping intents

### DIFF
--- a/android/sdl_android/src/main/res/values/sdl.xml
+++ b/android/sdl_android/src/main/res/values/sdl.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="sdl_router_service_version_name" translatable="false">sdl_router_version</string>
 
-    <integer name="sdl_router_service_version_value">16</integer>
+    <integer name="sdl_router_service_version_value">17</integer>
 
     <string name="sdl_router_service_is_custom_name" translatable="false">sdl_custom_router</string>
     <string name="sdl_oem_vehicle_type_filter_name" translatable="false">sdl_oem_vehicle_type</string>


### PR DESCRIPTION
Fixes #1843 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
N/A

#### Core Tests
- Installed app after RS was already connected and ensured that that app connected through SDL
- Additionally, can test my killing HelloSdl while RS connected using a button on screen and adding the following logic:

```java
        findViewById(R.id.helloSdlButton).setOnClickListener(new View.OnClickListener() {
            @Override
            public void onClick(View v) {
                try {
                    android.os.Process.killProcess(android.os.Process.myPid());
                } catch (Exception e) {
                    e.printStackTrace();
                }
            }
        });
```

After this occurs the app will be restarted and connect through the pings sent out by the RS.


Core version: SYNC 3
HMI name: SYNC 3

### Summary
Ensured the `PendingIntent` object was contained in the intents that were sent out during pings and transport status requests. 

### Changelog

##### Bug Fixes
* `PendingIntent` to start apps' `SdlService` classes is now included in ping style broadcasts from `SdlRouterService`.
* Increased `SdlRouterService` version number.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
