### PR TITLE
Fix case for UncaughtExceptionHandler in SdlBroadcastReceiver for RemoteServiceException

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -129,6 +129,7 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver {
 
         if (action.equalsIgnoreCase(TransportConstants.ACTION_USB_ACCESSORY_ATTACHED)) {
             DebugTool.logInfo(TAG, "Usb connected");
+            setForegroundExceptionHandler();
             intent.setAction(null);
             onSdlEnabled(context, intent);
             return;
@@ -189,6 +190,7 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver {
                                         finalIntent.putExtra(UsbManager.EXTRA_ACCESSORY, (Parcelable) null);
                                     }
                                 }
+                                setForegroundExceptionHandler();
                                 onSdlEnabled(finalContext, finalIntent);
                             }
 
@@ -421,7 +423,7 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver {
                 public void uncaughtException(Thread t, Throwable e) {
                     if (e != null
                             && e instanceof AndroidRuntimeException
-                            && ("android.app.RemoteServiceException".equals(e.getClass().getName()) || "android.app.ForegroundServiceDidNotStartInTimeException".equals(e.getClass().getName())) //android.app.RemoteServiceException is a private class
+                            && ("android.app.RemoteServiceException".equals(e.getClass().getName()) || e.getClass().getName().contains("ForegroundService")) //android.app.RemoteServiceException is a private class
                             && e.getMessage() != null
                             && (e.getMessage().contains("SdlRouterService") || e.getMessage().contains(serviceName))) {
                         DebugTool.logInfo(TAG, "Handling failed startForegroundService call");


### PR DESCRIPTION
Fixes #1848 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Core Tests
Two apps, App A and App B.
App A is a normal SDL app.
App B is modified so that it will not enter the foreground when SdlService is started.

Install app A, connect to TDK
Install app B

Observe: 
UncaughtExceptionHandler catches `RemoteServiceException$ForegroundServiceDidNotStartInTimeException: Context.startForegroundService() did not then call Service.startForeground():`

The exception still hits and the app still crashes.

Tested using Sync 3

### Summary
Fix UncaughtExceptionHandler in SdlBroadcastReceiver to catch  `RemoteServiceException$ForegroundServiceDidNotStartInTimeException: Context.startForegroundService() did not then call Service.startForeground():`

The handler does catch it, but only after the exception hits, the app still crashes and gets an ANR. It does not seem possible to prevent that with how Android is operating 

### Changelog
##### Bug Fixes
* Fix UncaughtExceptionHandler in SdlBroadcastReceiver to catch  `RemoteServiceException$ForegroundServiceDidNotStartInTimeException: Context.startForegroundService() did not then call Service.startForeground():`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
