### PR TITLE
`SdlRouterService` change PendingIntents getForegroundService to getService

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1858,7 +1858,7 @@ public class SdlRouterService extends Service {
             //the developer can use this pendingIntent to start their SdlService from the context of
             //the active RouterService
             Intent pending = new Intent();
-            PendingIntent pendingIntent = PendingIntent.getForegroundService(this, (int) System.currentTimeMillis(), pending, PendingIntent.FLAG_MUTABLE | Intent.FILL_IN_COMPONENT);
+            PendingIntent pendingIntent = PendingIntent.getService(this, (int) System.currentTimeMillis(), pending, PendingIntent.FLAG_MUTABLE | Intent.FILL_IN_COMPONENT);
             startService.putExtra(TransportConstants.PENDING_INTENT_EXTRA, pendingIntent);
         }
 
@@ -2978,7 +2978,7 @@ public class SdlRouterService extends Service {
             //the developer can use this pendingIntent to start their SdlService from the context of
             //the active RouterService
             Intent pending = new Intent();
-            PendingIntent pendingIntent = PendingIntent.getForegroundService(this, (int) System.currentTimeMillis(), pending, PendingIntent.FLAG_MUTABLE | Intent.FILL_IN_COMPONENT);
+            PendingIntent pendingIntent = PendingIntent.getService(this, (int) System.currentTimeMillis(), pending, PendingIntent.FLAG_MUTABLE | Intent.FILL_IN_COMPONENT);
             pingIntent.putExtra(TransportConstants.PENDING_INTENT_EXTRA, pendingIntent);
         }
 


### PR DESCRIPTION
Fixes #1854 

This PR is **[not ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
- [ ] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [ ] I have tested Android, Java SE, and Java EE

#### Unit Tests
[Describe the unit tests and behaviors added in this PR]

#### Core Tests
[List of tests performed against Core and behaviors verified]

Core version / branch / commit hash / module tested against: [INSERT]
HMI name / version / branch / commit hash / module tested against: [INSERT]

### Summary
This PR changes how SdlService is started from the RS via a Pending Intent from getForegroundService to getService. 

We can make this change because the RS is already in the Foreground at this point, we still need SdlService to enter the foreground as Android will still shut down the service after a time if the app is not in the Foreground. |

This will help with the issue of the `RemoteServiceException$ForegroundServiceDidNotStartInTimeException` that has been seen in SDL apps that are not able to enter the foreground in the 5-second time allotment by Android if a phone is to slow or bogged down.

### Changelog
##### Bug Fixes
* [Bug Fix Info]

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
