### PR TITLE
Android 14 Runtime registered broadcast receivers export behavior 

### DIFF
--- a/android/hello_sdl_android/build.gradle
+++ b/android/hello_sdl_android/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
     defaultConfig {
         applicationId "com.sdl.hellosdlandroid"
         minSdkVersion 16
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
         buildConfigField 'String', 'APP_TYPE', '"DEFAULT"'

--- a/android/sdl_android/build.gradle
+++ b/android/sdl_android/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 25
         versionName new File(projectDir.path, ('/../../VERSION')).text.trim()
         buildConfigField "String", "VERSION_NAME", '\"' + versionName + '\"'

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
@@ -37,7 +37,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.graphics.Bitmap;
-import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 
@@ -338,6 +337,7 @@ public class LockScreenManager extends BaseSubManager {
                             new IntentFilter(SDLLockScreenActivity.KEY_LOCKSCREEN_DISMISSED),
                             Context.RECEIVER_NOT_EXPORTED);
                     lockscreenDismissReceiverRegistered = true;
+
                 }
                 LockScreenStatus status = getLockScreenStatus();
                 if (status == LockScreenStatus.REQUIRED || displayMode == LockScreenConfig.DISPLAY_MODE_ALWAYS || (status == LockScreenStatus.OPTIONAL && displayMode == LockScreenConfig.DISPLAY_MODE_OPTIONAL_OR_REQUIRED)) {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
@@ -37,6 +37,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.graphics.Bitmap;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 
@@ -332,9 +333,12 @@ public class LockScreenManager extends BaseSubManager {
             // pass in icon, background color, and custom view
             if (lockScreenEnabled && isApplicationForegrounded && context.get() != null) {
                 if (isLockscreenDismissible && !lockscreenDismissReceiverRegistered) {
-                    context.get().registerReceiver(mLockscreenDismissedReceiver, new IntentFilter(SDLLockScreenActivity.KEY_LOCKSCREEN_DISMISSED));
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                        context.get().registerReceiver(mLockscreenDismissedReceiver, new IntentFilter(SDLLockScreenActivity.KEY_LOCKSCREEN_DISMISSED), Context.RECEIVER_EXPORTED);
+                    } else {
+                        context.get().registerReceiver(mLockscreenDismissedReceiver, new IntentFilter(SDLLockScreenActivity.KEY_LOCKSCREEN_DISMISSED));
+                    }
                     lockscreenDismissReceiverRegistered = true;
-
                 }
                 LockScreenStatus status = getLockScreenStatus();
                 if (status == LockScreenStatus.REQUIRED || displayMode == LockScreenConfig.DISPLAY_MODE_ALWAYS || (status == LockScreenStatus.OPTIONAL && displayMode == LockScreenConfig.DISPLAY_MODE_OPTIONAL_OR_REQUIRED)) {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
@@ -335,7 +335,7 @@ public class LockScreenManager extends BaseSubManager {
                 if (isLockscreenDismissible && !lockscreenDismissReceiverRegistered) {
                     AndroidTools.registerReceiver(context.get(), mLockscreenDismissedReceiver,
                             new IntentFilter(SDLLockScreenActivity.KEY_LOCKSCREEN_DISMISSED),
-                            Context.RECEIVER_NOT_EXPORTED);
+                            Context.RECEIVER_EXPORTED);
                     lockscreenDismissReceiverRegistered = true;
 
                 }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
@@ -378,7 +378,9 @@ public class LockScreenManager extends BaseSubManager {
         if (context.get() != null) {
             LockScreenStatus status = getLockScreenStatus();
             if (status == LockScreenStatus.OFF || (status == LockScreenStatus.OPTIONAL && displayMode != LockScreenConfig.DISPLAY_MODE_OPTIONAL_OR_REQUIRED)) {
-                context.get().sendBroadcast(new Intent(SDLLockScreenActivity.CLOSE_LOCK_SCREEN_ACTION));
+                Intent intent = new Intent(SDLLockScreenActivity.CLOSE_LOCK_SCREEN_ACTION)
+                        .setPackage(context.get().getPackageName());
+                context.get().sendBroadcast(intent);
             }
         }
         lastIntentUsed = null;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
@@ -57,6 +57,7 @@ import com.smartdevicelink.proxy.rpc.enums.LockScreenStatus;
 import com.smartdevicelink.proxy.rpc.enums.PredefinedWindows;
 import com.smartdevicelink.proxy.rpc.enums.RequestType;
 import com.smartdevicelink.proxy.rpc.listeners.OnRPCNotificationListener;
+import com.smartdevicelink.util.AndroidTools;
 import com.smartdevicelink.util.DebugTool;
 
 import java.lang.ref.WeakReference;
@@ -333,11 +334,9 @@ public class LockScreenManager extends BaseSubManager {
             // pass in icon, background color, and custom view
             if (lockScreenEnabled && isApplicationForegrounded && context.get() != null) {
                 if (isLockscreenDismissible && !lockscreenDismissReceiverRegistered) {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                        context.get().registerReceiver(mLockscreenDismissedReceiver, new IntentFilter(SDLLockScreenActivity.KEY_LOCKSCREEN_DISMISSED), Context.RECEIVER_EXPORTED);
-                    } else {
-                        context.get().registerReceiver(mLockscreenDismissedReceiver, new IntentFilter(SDLLockScreenActivity.KEY_LOCKSCREEN_DISMISSED));
-                    }
+                    AndroidTools.registerReceiver(context.get(), mLockscreenDismissedReceiver,
+                            new IntentFilter(SDLLockScreenActivity.KEY_LOCKSCREEN_DISMISSED),
+                            Context.RECEIVER_NOT_EXPORTED);
                     lockscreenDismissReceiverRegistered = true;
                 }
                 LockScreenStatus status = getLockScreenStatus();

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/LockScreenManager.java
@@ -135,7 +135,9 @@ public class LockScreenManager extends BaseSubManager {
     public void dispose() {
         // send broadcast to close lock screen if open
         if (context.get() != null) {
-            context.get().sendBroadcast(new Intent(SDLLockScreenActivity.CLOSE_LOCK_SCREEN_ACTION));
+            Intent intent = new Intent(SDLLockScreenActivity.CLOSE_LOCK_SCREEN_ACTION)
+                    .setPackage(context.get().getPackageName());
+            context.get().sendBroadcast(intent);
             try {
                 context.get().unregisterReceiver(mLockscreenDismissedReceiver);
                 lockscreenDismissReceiverRegistered = false;
@@ -335,7 +337,7 @@ public class LockScreenManager extends BaseSubManager {
                 if (isLockscreenDismissible && !lockscreenDismissReceiverRegistered) {
                     AndroidTools.registerReceiver(context.get(), mLockscreenDismissedReceiver,
                             new IntentFilter(SDLLockScreenActivity.KEY_LOCKSCREEN_DISMISSED),
-                            Context.RECEIVER_EXPORTED);
+                            Context.RECEIVER_NOT_EXPORTED);
                     lockscreenDismissReceiverRegistered = true;
 
                 }
@@ -431,6 +433,7 @@ public class LockScreenManager extends BaseSubManager {
                             intent.putExtra(SDLLockScreenActivity.LOCKSCREEN_DEVICE_LOGO_EXTRA, deviceLogoEnabled);
                             intent.putExtra(SDLLockScreenActivity.LOCKSCREEN_DEVICE_LOGO_BITMAP, deviceLogo);
                             if (context.get() != null) {
+                                intent.setPackage(context.get().getPackageName());
                                 context.get().sendBroadcast(intent);
                             }
                         }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/SDLLockScreenActivity.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/SDLLockScreenActivity.java
@@ -42,7 +42,6 @@ import android.graphics.Color;
 import android.graphics.ColorFilter;
 import android.graphics.ColorMatrixColorFilter;
 import android.graphics.drawable.Drawable;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
@@ -106,6 +105,7 @@ public class SDLLockScreenActivity extends Activity {
         IntentFilter lockscreenFilter = new IntentFilter();
         lockscreenFilter.addAction(CLOSE_LOCK_SCREEN_ACTION);
         lockscreenFilter.addAction(LOCKSCREEN_DEVICE_LOGO_DOWNLOADED);
+
         // register broadcast receivers
         AndroidTools.registerReceiver(this, lockScreenBroadcastReceiver, lockscreenFilter,
                 RECEIVER_NOT_EXPORTED);

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/SDLLockScreenActivity.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/SDLLockScreenActivity.java
@@ -108,7 +108,7 @@ public class SDLLockScreenActivity extends Activity {
 
         // register broadcast receivers
         AndroidTools.registerReceiver(this, lockScreenBroadcastReceiver, lockscreenFilter,
-                RECEIVER_EXPORTED);
+                RECEIVER_NOT_EXPORTED);
     }
 
     @Override
@@ -286,7 +286,9 @@ public class SDLLockScreenActivity extends Activity {
         public boolean onFling(MotionEvent event1, MotionEvent event2,
                                float velocityX, float velocityY) {
             if ((event2.getY() - event1.getY()) > MIN_SWIPE_DISTANCE) {
-                sendBroadcast(new Intent(KEY_LOCKSCREEN_DISMISSED));
+                Intent intent = new Intent(KEY_LOCKSCREEN_DISMISSED)
+                        .setPackage(getPackageName());
+                sendBroadcast(intent);
                 finish();
             }
             return true;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/SDLLockScreenActivity.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/SDLLockScreenActivity.java
@@ -108,7 +108,7 @@ public class SDLLockScreenActivity extends Activity {
 
         // register broadcast receivers
         AndroidTools.registerReceiver(this, lockScreenBroadcastReceiver, lockscreenFilter,
-                RECEIVER_NOT_EXPORTED);
+                RECEIVER_EXPORTED);
     }
 
     @Override

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/SDLLockScreenActivity.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/SDLLockScreenActivity.java
@@ -42,6 +42,7 @@ import android.graphics.Color;
 import android.graphics.ColorFilter;
 import android.graphics.ColorMatrixColorFilter;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
@@ -104,9 +105,12 @@ public class SDLLockScreenActivity extends Activity {
         IntentFilter lockscreenFilter = new IntentFilter();
         lockscreenFilter.addAction(CLOSE_LOCK_SCREEN_ACTION);
         lockscreenFilter.addAction(LOCKSCREEN_DEVICE_LOGO_DOWNLOADED);
-
         // register broadcast receivers
-        registerReceiver(lockScreenBroadcastReceiver, lockscreenFilter);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            registerReceiver(lockScreenBroadcastReceiver, lockscreenFilter, RECEIVER_EXPORTED);
+        } else {
+            registerReceiver(lockScreenBroadcastReceiver, lockscreenFilter);
+        }
     }
 
     @Override

--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/SDLLockScreenActivity.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lockscreen/SDLLockScreenActivity.java
@@ -53,6 +53,7 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.smartdevicelink.R;
+import com.smartdevicelink.util.AndroidTools;
 
 public class SDLLockScreenActivity extends Activity {
 
@@ -106,11 +107,8 @@ public class SDLLockScreenActivity extends Activity {
         lockscreenFilter.addAction(CLOSE_LOCK_SCREEN_ACTION);
         lockscreenFilter.addAction(LOCKSCREEN_DEVICE_LOGO_DOWNLOADED);
         // register broadcast receivers
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            registerReceiver(lockScreenBroadcastReceiver, lockscreenFilter, RECEIVER_EXPORTED);
-        } else {
-            registerReceiver(lockScreenBroadcastReceiver, lockscreenFilter);
-        }
+        AndroidTools.registerReceiver(this, lockScreenBroadcastReceiver, lockscreenFilter,
+                RECEIVER_NOT_EXPORTED);
     }
 
     @Override

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1210,11 +1210,7 @@ public class SdlRouterService extends Service {
 
         IntentFilter filter = new IntentFilter();
         filter.addAction(REGISTER_WITH_ROUTER_ACTION);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            registerReceiver(mainServiceReceiver, filter, RECEIVER_EXPORTED);
-        } else {
-            registerReceiver(mainServiceReceiver, filter);
-        }
+        AndroidTools.registerReceiver(this, mainServiceReceiver, filter, RECEIVER_EXPORTED);
 
         if (!connectAsClient) {
             if (bluetoothAvailable()) {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1210,7 +1210,11 @@ public class SdlRouterService extends Service {
 
         IntentFilter filter = new IntentFilter();
         filter.addAction(REGISTER_WITH_ROUTER_ACTION);
-        registerReceiver(mainServiceReceiver, filter);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            registerReceiver(mainServiceReceiver, filter, RECEIVER_EXPORTED);
+        } else {
+            registerReceiver(mainServiceReceiver, filter);
+        }
 
         if (!connectAsClient) {
             if (bluetoothAvailable()) {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/TransportManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/TransportManager.java
@@ -50,6 +50,7 @@ import com.smartdevicelink.protocol.enums.ControlFrameTags;
 import com.smartdevicelink.transport.enums.TransportType;
 import com.smartdevicelink.transport.utl.SdlDeviceListener;
 import com.smartdevicelink.transport.utl.TransportRecord;
+import com.smartdevicelink.util.AndroidTools;
 import com.smartdevicelink.util.DebugTool;
 
 import java.lang.ref.WeakReference;
@@ -412,7 +413,8 @@ public class TransportManager extends TransportManagerBase {
                 IntentFilter intentFilter = new IntentFilter();
                 intentFilter.addAction(BluetoothDevice.ACTION_ACL_DISCONNECTED);
                 intentFilter.addAction(BluetoothAdapter.ACTION_STATE_CHANGED);
-                contextWeakReference.get().registerReceiver(legacyDisconnectReceiver, intentFilter);
+                AndroidTools.registerReceiver(contextWeakReference.get(),
+                        legacyDisconnectReceiver, intentFilter, Context.RECEIVER_EXPORTED);
             }
         } else {
             new Handler(Looper.myLooper()).postDelayed(new Runnable() {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
@@ -32,6 +32,8 @@
 
 package com.smartdevicelink.util;
 
+import android.annotation.SuppressLint;
+import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
@@ -390,6 +392,29 @@ public class AndroidTools {
         } catch (Resources.NotFoundException ex) {
             DebugTool.logError(TAG, "Failed to find resource: " + ex.getMessage() + " - assume vehicle data is supported");
             return null;
+        }
+    }
+
+    /**
+     * A helper method to handle adding flags to registering a run time broadcast receiver.
+     *
+     * @param context  a context that will be used to register the receiver with
+     * @param receiver the receiver that will be registered
+     * @param filter   the filter that will be use to filter intents sent to the broadcast receiver
+     * @param flags    any flags that should be used to register the receiver. In most cases this
+     *                 will be {@link  Context#RECEIVER_NOT_EXPORTED} or
+     *                 {@link  Context#RECEIVER_EXPORTED}
+     * @see Context#registerReceiver(BroadcastReceiver, IntentFilter)
+     * @see Context#registerReceiver(BroadcastReceiver, IntentFilter, int)
+     */
+    @SuppressLint("UnspecifiedRegisterReceiverFlag")
+    public static void registerReceiver(Context context, BroadcastReceiver receiver, IntentFilter filter, int flags) {
+        if (context != null && receiver != null && filter != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.registerReceiver(receiver, filter, flags);
+            } else {
+                context.registerReceiver(receiver, filter);
+            }
         }
     }
 }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/MediaStreamingStatus.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/MediaStreamingStatus.java
@@ -261,8 +261,8 @@ public class MediaStreamingStatus {
             }
             unregisterBroadcastReceiver();
             //Re-register receiver
-            context.registerReceiver(broadcastReceiver, intentFilter);
-
+            AndroidTools.registerReceiver(context, broadcastReceiver, intentFilter,
+                    Context.RECEIVER_EXPORTED);
         }
 
     }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/ServiceFinder.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/ServiceFinder.java
@@ -75,11 +75,8 @@ public class ServiceFinder {
 
         this.sdlMultiMap = AndroidTools.getSdlEnabledApps(context, packageName);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            this.context.registerReceiver(mainServiceReceiver, new IntentFilter(this.receiverLocation), Context.RECEIVER_EXPORTED);
-        } else {
-            this.context.registerReceiver(mainServiceReceiver, new IntentFilter(this.receiverLocation));
-        }
+        AndroidTools.registerReceiver(this.context, mainServiceReceiver,
+                new IntentFilter(this.receiverLocation), Context.RECEIVER_EXPORTED);
 
         timeoutRunnable = new Runnable() {
             @Override

--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/ServiceFinder.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/ServiceFinder.java
@@ -37,6 +37,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.ResolveInfo;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 
@@ -74,7 +75,11 @@ public class ServiceFinder {
 
         this.sdlMultiMap = AndroidTools.getSdlEnabledApps(context, packageName);
 
-        this.context.registerReceiver(mainServiceReceiver, new IntentFilter(this.receiverLocation));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            this.context.registerReceiver(mainServiceReceiver, new IntentFilter(this.receiverLocation), Context.RECEIVER_EXPORTED);
+        } else {
+            this.context.registerReceiver(mainServiceReceiver, new IntentFilter(this.receiverLocation));
+        }
 
         timeoutRunnable = new Runnable() {
             @Override

--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/ServiceFinder.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/ServiceFinder.java
@@ -37,7 +37,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.ResolveInfo;
-import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 


### PR DESCRIPTION
Fixes #1857

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Unit Tests
No additional unit test were added

#### Core Tests
Note used an integration branch with All Android 14 PRs to test.
Build variants on Android 14 test plan card on trello.

All Test are designed to trigger BroadcastReceivers that I added the export flag behavior.

Test 1:
Install app A
Connect to TDK via Bluetooth
Enable moving on TDK
Observe:  LockScreen in enabled.

Test 2
Add LockScreenConfig to SdlManager builder with enableDismissGesture to true.
Install Hello_Sdl with TCP build variant.
Connect to manticore
Enable DD
Dismiss LockScreen.
Observe: that LockScreen dismisses.

Test 3.
Install App A
Connect to tdk via Bluetooth
Observe App A connect to tdk
Install App B (Note, Before you install App B, unplug the phone from the computer and switch the build variant before deploying to the phone otherwise Android Studio will kill App A as it deploys App B)
Observe: App B connects to tdk.

Core version / branch / commit hash / module tested against: Sync 3 and manticore
HMI name / version / branch / commit hash / module tested against: Sync 3 and manticore

### Summary
This PR updates the gradle files for SDL and Hello SDL to target API level 34, as well as specifies export behavior for runtime-registered broadcasts receivers. 

If a BroadcastReceiver only receives System broadcast, it is not necessary to add the export flag to when we register.

### Changelog
##### Bug Fixes
* Tragets Android 14 and updates context registered broadcast receiver behavior for API 34

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
