### PR TITLE
Android 14 foreground service type required

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,7 +21,7 @@ jobs:
       # For more info, please check out: https://github.com/marketplace/actions/android-emulator-runner
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 34
+        api-level: 29
         script: ./android/gradlew -p ./android :sdl_android:connectedCheck
         
     - name: Hello Sdl Android Tests

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 17
+        java-version: 11
         
     - name: Sdl Android Tests
       # For more info, please check out: https://github.com/marketplace/actions/android-emulator-runner

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,7 +21,7 @@ jobs:
       # For more info, please check out: https://github.com/marketplace/actions/android-emulator-runner
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 29
+        api-level: 34
         script: ./android/gradlew -p ./android :sdl_android:connectedCheck
         
     - name: Hello Sdl Android Tests

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 17
         
     - name: Sdl Android Tests
       # For more info, please check out: https://github.com/marketplace/actions/android-emulator-runner

--- a/android/hello_sdl_android/src/main/AndroidManifest.xml
+++ b/android/hello_sdl_android/src/main/AndroidManifest.xml
@@ -8,11 +8,12 @@
         tools:targetApi="31"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"
         tools:targetApi="33"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE"
+        tools:targetApi="34"/>
     <uses-permission android:name="android.permission.INTERNET" />
     <!-- Required to check if WiFi is enabled -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
 
     <!-- Required to use the USB Accessory mode -->
     <uses-feature android:name="android.hardware.usb.accessory" />

--- a/android/hello_sdl_android/src/main/AndroidManifest.xml
+++ b/android/hello_sdl_android/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <!-- Required to check if WiFi is enabled -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
 
     <!-- Required to use the USB Accessory mode -->
     <uses-feature android:name="android.hardware.usb.accessory" />

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
@@ -102,7 +102,10 @@ public class SdlReceiver extends SdlBroadcastReceiver {
      */
     private void requestUsbAccessory(Context context) {
         UsbManager manager = (UsbManager) context.getSystemService(Context.USB_SERVICE);
-        if (manager.getAccessoryList() == null) {
+        UsbAccessory[] accessoryList = manager.getAccessoryList();
+        if (accessoryList == null || accessoryList.length == 0) {
+            startSdlServiceIntent = null;
+            pendingIntentToStartService = null;
             return;
         }
         PendingIntent mPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_PERMISSION), PendingIntent.FLAG_IMMUTABLE);

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
@@ -15,7 +15,6 @@ import com.smartdevicelink.transport.TransportConstants;
 import com.smartdevicelink.util.AndroidTools;
 import com.smartdevicelink.util.DebugTool;
 
-
 public class SdlReceiver extends SdlBroadcastReceiver {
     private static final String TAG = "SdlBroadcastReceiver";
 

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
@@ -35,7 +35,7 @@ public class SdlReceiver extends SdlBroadcastReceiver {
             PendingIntent pendingIntent = (PendingIntent) intent.getParcelableExtra(TransportConstants.PENDING_INTENT_EXTRA);
             if (pendingIntent != null) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                    if (!AndroidTools.ServicePermissionUtil.hasForegroundServiceTypePermission(context)) {
+                    if (!AndroidTools.hasForegroundServiceTypePermission(context)) {
                         requestUsbAccessory(context);
                         storedIntent = intent;
                         storedContext = context;
@@ -82,7 +82,7 @@ public class SdlReceiver extends SdlBroadcastReceiver {
         public void onReceive(Context context, Intent intent) {
             String action = intent.getAction();
             if (ACTION_USB_PERMISSION.equals(action) && storedContext != null && storedIntent != null && pendingIntent != null) {
-                if (AndroidTools.ServicePermissionUtil.hasForegroundServiceTypePermission(storedContext)) {
+                if (AndroidTools.hasForegroundServiceTypePermission(storedContext)) {
                     try {
                         pendingIntent.send(storedContext, 0, storedIntent);
                     } catch (PendingIntent.CanceledException e) {

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
@@ -44,8 +44,7 @@ public class SdlReceiver extends SdlBroadcastReceiver {
                 }
                 try {
                     pendingIntent.send(context, 0, intent);
-                    context.unregisterReceiver(this);
-                } catch (Exception e) {
+                } catch (PendingIntent.CanceledException e) {
                     e.printStackTrace();
                 }
             }
@@ -83,7 +82,8 @@ public class SdlReceiver extends SdlBroadcastReceiver {
                 if (AndroidTools.hasForegroundServiceTypePermission(context)) {
                     try {
                         pendingIntentToStartService.send(context, 0, startSdlServiceIntent);
-                    } catch (PendingIntent.CanceledException e) {
+                        context.unregisterReceiver(this);
+                    } catch (Exception e) {
                         e.printStackTrace();
                     }
                 }

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
@@ -77,7 +77,6 @@ public class SdlReceiver extends SdlBroadcastReceiver {
     }
 
     private final BroadcastReceiver usbPermissionReceiver = new BroadcastReceiver() {
-
         public void onReceive(Context context, Intent intent) {
             String action = intent.getAction();
             if (ACTION_USB_PERMISSION.equals(action) && context != null && startSdlServiceIntent != null && pendingIntentToStartService != null) {

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
@@ -22,7 +22,6 @@ public class SdlReceiver extends SdlBroadcastReceiver {
 
     private static final String ACTION_USB_PERMISSION = "com.android.example.USB_PERMISSION";
     private PendingIntent pendingIntent;
-    private WeakReference<Context> cachedContext;
     private Intent cachedIntent;
 
     @Override
@@ -40,7 +39,6 @@ public class SdlReceiver extends SdlBroadcastReceiver {
                     if (!AndroidTools.hasForegroundServiceTypePermission(context)) {
                         requestUsbAccessory(context);
                         cachedIntent = intent;
-                        cachedContext = new WeakReference<>(context);
                         this.pendingIntent = pendingIntent;
                         DebugTool.logInfo(TAG, "Permission missing for ForegroundServiceType connected device." + context);
                         return;
@@ -83,10 +81,10 @@ public class SdlReceiver extends SdlBroadcastReceiver {
 
         public void onReceive(Context context, Intent intent) {
             String action = intent.getAction();
-            if (ACTION_USB_PERMISSION.equals(action) && cachedContext != null && cachedContext.get() != null && cachedIntent != null && pendingIntent != null) {
-                if (AndroidTools.hasForegroundServiceTypePermission(cachedContext.get())) {
+            if (ACTION_USB_PERMISSION.equals(action) && context != null && cachedIntent != null && pendingIntent != null) {
+                if (AndroidTools.hasForegroundServiceTypePermission(context)) {
                     try {
-                        pendingIntent.send(cachedContext.get(), 0, cachedIntent);
+                        pendingIntent.send(context, 0, cachedIntent);
                     } catch (PendingIntent.CanceledException e) {
                         e.printStackTrace();
                     }

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
@@ -45,7 +45,8 @@ public class SdlReceiver extends SdlBroadcastReceiver {
                 }
                 try {
                     pendingIntent.send(context, 0, intent);
-                } catch (PendingIntent.CanceledException e) {
+                    context.unregisterReceiver(this);
+                } catch (Exception e) {
                     e.printStackTrace();
                 }
             }

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
@@ -76,7 +76,7 @@ public class SdlReceiver extends SdlBroadcastReceiver {
         return SdlService.class.getSimpleName();
     }
 
-    private final BroadcastReceiver mUsbReceiver = new BroadcastReceiver() {
+    private final BroadcastReceiver usbPermissionReceiver = new BroadcastReceiver() {
 
         public void onReceive(Context context, Intent intent) {
             String action = intent.getAction();
@@ -108,7 +108,7 @@ public class SdlReceiver extends SdlBroadcastReceiver {
         PendingIntent mPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_PERMISSION), PendingIntent.FLAG_IMMUTABLE);
         IntentFilter filter = new IntentFilter(ACTION_USB_PERMISSION);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            context.registerReceiver(mUsbReceiver, filter, Context.RECEIVER_EXPORTED);
+            context.registerReceiver(usbPermissionReceiver, filter, Context.RECEIVER_EXPORTED);
         }
         for (final UsbAccessory usbAccessory : manager.getAccessoryList()) {
             manager.requestPermission(usbAccessory, mPermissionIntent);

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
@@ -15,14 +15,13 @@ import com.smartdevicelink.transport.TransportConstants;
 import com.smartdevicelink.util.AndroidTools;
 import com.smartdevicelink.util.DebugTool;
 
-import java.lang.ref.WeakReference;
 
 public class SdlReceiver extends SdlBroadcastReceiver {
     private static final String TAG = "SdlBroadcastReceiver";
 
     private static final String ACTION_USB_PERMISSION = "com.android.example.USB_PERMISSION";
-    private PendingIntent pendingIntent;
-    private Intent cachedIntent;
+    private PendingIntent pendingIntentToStartService;
+    private Intent startSdlServiceIntent;
 
     @Override
     public void onSdlEnabled(Context context, Intent intent) {
@@ -38,8 +37,8 @@ public class SdlReceiver extends SdlBroadcastReceiver {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
                     if (!AndroidTools.hasForegroundServiceTypePermission(context)) {
                         requestUsbAccessory(context);
-                        cachedIntent = intent;
-                        this.pendingIntent = pendingIntent;
+                        startSdlServiceIntent = intent;
+                        this.pendingIntentToStartService = pendingIntent;
                         DebugTool.logInfo(TAG, "Permission missing for ForegroundServiceType connected device." + context);
                         return;
                     }
@@ -81,10 +80,10 @@ public class SdlReceiver extends SdlBroadcastReceiver {
 
         public void onReceive(Context context, Intent intent) {
             String action = intent.getAction();
-            if (ACTION_USB_PERMISSION.equals(action) && context != null && cachedIntent != null && pendingIntent != null) {
+            if (ACTION_USB_PERMISSION.equals(action) && context != null && startSdlServiceIntent != null && pendingIntentToStartService != null) {
                 if (AndroidTools.hasForegroundServiceTypePermission(context)) {
                     try {
-                        pendingIntent.send(context, 0, cachedIntent);
+                        pendingIntentToStartService.send(context, 0, startSdlServiceIntent);
                     } catch (PendingIntent.CanceledException e) {
                         e.printStackTrace();
                     }

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
@@ -110,10 +110,11 @@ public class SdlReceiver extends SdlBroadcastReceiver {
         }
         PendingIntent mPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_PERMISSION), PendingIntent.FLAG_IMMUTABLE);
         IntentFilter filter = new IntentFilter(ACTION_USB_PERMISSION);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            context.registerReceiver(usbPermissionReceiver, filter, Context.RECEIVER_EXPORTED);
-        }
-        for (final UsbAccessory usbAccessory : manager.getAccessoryList()) {
+
+        AndroidTools.registerReceiver(context, usbPermissionReceiver, filter,
+                Context.RECEIVER_EXPORTED);
+
+        for (final UsbAccessory usbAccessory : accessoryList) {
             manager.requestPermission(usbAccessory, mPermissionIntent);
         }
     }

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
@@ -76,6 +76,7 @@ public class SdlReceiver extends SdlBroadcastReceiver {
     public String getSdlServiceName() {
         return SdlService.class.getSimpleName();
     }
+
     private final BroadcastReceiver mUsbReceiver = new BroadcastReceiver() {
 
         public void onReceive(Context context, Intent intent) {

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
@@ -32,12 +32,12 @@ public class SdlReceiver extends SdlBroadcastReceiver {
         // We will check the intent for a pendingIntent parcelable extra
         // This pendingIntent allows us to start the SdlService from the context of the active router service which is in the foreground
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            storedIntent = intent;
             PendingIntent pendingIntent = (PendingIntent) intent.getParcelableExtra(TransportConstants.PENDING_INTENT_EXTRA);
             if (pendingIntent != null) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
                     if (!AndroidTools.ServicePermissionUtil.hasForegroundServiceTypePermission(context)) {
                         requestUsbAccessory(context);
+                        storedIntent = intent;
                         storedContext = context;
                         this.pendingIntent = pendingIntent;
                         DebugTool.logInfo(TAG, "Permission missing for ForegroundServiceType connected device." + context);
@@ -93,6 +93,14 @@ public class SdlReceiver extends SdlBroadcastReceiver {
         }
     };
 
+    /**
+     * Request permission from USB Accessory if USB accessory is not null.
+     * If the user has not granted the BLUETOOTH_CONNECT permission,
+     * we can request the USB Accessory permission to satisfy the requirements for
+     * FOREGROUND_SERVICE_CONNECTED_DEVICE and can start our service and allow
+     * it to enter the foreground. FOREGROUND_SERVICE_CONNECTED_DEVICE is a requirement
+     * in Android 14
+     */
     private void requestUsbAccessory(Context context) {
         UsbManager manager = (UsbManager) context.getSystemService(Context.USB_SERVICE);
         if (manager.getAccessoryList() == null) {

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlService.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlService.java
@@ -104,18 +104,25 @@ public class SdlService extends Service {
     @SuppressLint("NewApi")
     public void enterForeground() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationChannel channel = new NotificationChannel(APP_ID, "SdlService", NotificationManager.IMPORTANCE_DEFAULT);
-            NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-            if (notificationManager != null) {
-                notificationManager.createNotificationChannel(channel);
-                Notification.Builder builder = new Notification.Builder(this, channel.getId())
-                        .setContentTitle("Connected through SDL")
-                        .setSmallIcon(R.drawable.ic_sdl);
-                if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    builder.setForegroundServiceBehavior(Notification.FOREGROUND_SERVICE_IMMEDIATE);
+            try {
+                NotificationChannel channel = new NotificationChannel(APP_ID, "SdlService", NotificationManager.IMPORTANCE_DEFAULT);
+                NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+                if (notificationManager != null) {
+                    notificationManager.createNotificationChannel(channel);
+                    Notification.Builder builder = new Notification.Builder(this, channel.getId())
+                            .setContentTitle("Connected through SDL")
+                            .setSmallIcon(R.drawable.ic_sdl);
+                    if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        builder.setForegroundServiceBehavior(Notification.FOREGROUND_SERVICE_IMMEDIATE);
+                    }
+                    Notification serviceNotification = builder.build();
+                    startForeground(FOREGROUND_SERVICE_ID, serviceNotification);
                 }
-                Notification serviceNotification = builder.build();
-                startForeground(FOREGROUND_SERVICE_ID, serviceNotification);
+            } catch (Exception e) {
+                // This should only catch for TCP connections on Android 14+ due to needing
+                // permissions for ForegroundServiceType ConnectedDevice that don't make sense for
+                // a TCP connection
+                DebugTool.logError(TAG, "Unable to start service in foreground", e);
             }
         }
     }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1175,7 +1175,14 @@ public class SdlRouterService extends Service {
     }
 
     /**
-     * The method will attempt to start up the next router service in line based on the sorting criteria of best router service.
+     * The method will attempt to start up the next router service in line based on the sorting
+     * criteria of best router service.
+     * If a ParcelFileDescriptor is not null, we pass it along to the next RouterService to give
+     * it a chane to connected via AOA. This only happens on Android 14 and above when the app
+     * selected to host the RouterService does not satisfy the requirements for permission
+     * FOREGROUND_SERVICE_CONNECTED_DEVICE. By passing along the usbPfd, it will give the next
+     * RouterService selected a chance to connect.
+     * @param usbPfd a ParcelFileDescriptor used for AOA connections.
      */
     protected void deployNextRouterService(ParcelFileDescriptor usbPfd) {
         List<SdlAppInfo> sdlAppInfoList = AndroidTools.querySdlAppInfo(getApplicationContext(), new SdlAppInfo.BestRouterComparator(), null);

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1200,7 +1200,7 @@ public class SdlRouterService extends Service {
                         try {
                             startForegroundService(serviceIntent);
                             if (usbPfd != null) {
-                                UsbTransferProvider usbTransferProvider = new UsbTransferProvider(getApplicationContext(), nextUp.getRouterServiceComponentName(), usbPfd, new UsbTransferProvider.UsbTransferCallback() {
+                                new UsbTransferProvider(getApplicationContext(), nextUp.getRouterServiceComponentName(), usbPfd, new UsbTransferProvider.UsbTransferCallback() {
                                     @Override
                                     public void onUsbTransferUpdate(boolean success) {
                                         closeSelf();

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -918,6 +918,7 @@ public class SdlRouterService extends Service {
                     break;
             }
         }
+
         private void closeUSBAccessoryAttachmentActivity(Message msg) {
             if (msg.replyTo != null) {
                 Message message = Message.obtain();

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -864,7 +864,7 @@ public class SdlRouterService extends Service {
                     if (parcelFileDescriptor != null) {
                         // Added requirements with Android 14, Checking if we have proper permission to enter the foreground for Foreground service type connectedDevice.
                         // If we do not have permission to enter the Foreground, we pass off hosting the RouterService to another app.
-                        if (!AndroidTools.ServicePermissionUtil.hasForegroundServiceTypePermission(service.getApplicationContext()))  {
+                        if (!AndroidTools.ServicePermissionUtil.hasForegroundServiceTypePermission(service.getApplicationContext())) {
                             service.deployNextRouterService(parcelFileDescriptor);
                             closeUSBAccessoryAttachmentActivity(msg);
                             return;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -866,7 +866,7 @@ public class SdlRouterService extends Service {
                         // If we do not have permission to enter the Foreground, we pass off hosting the RouterService to another app.
                         if (!AndroidTools.ServicePermissionUtil.hasForegroundServiceTypePermission(service.getApplicationContext())) {
                             service.deployNextRouterService(parcelFileDescriptor);
-                            closeUSBAccessoryAttachmentActivity(msg);
+                            acknowledgeUSBAccessoryReceived(msg);
                             return;
                         }
 
@@ -908,7 +908,7 @@ public class SdlRouterService extends Service {
 
 
                     }
-                    closeUSBAccessoryAttachmentActivity(msg);
+                    acknowledgeUSBAccessoryReceived(msg);
 
                     break;
                 case TransportConstants.ALT_TRANSPORT_CONNECTED:
@@ -919,7 +919,7 @@ public class SdlRouterService extends Service {
             }
         }
 
-        private void closeUSBAccessoryAttachmentActivity(Message msg) {
+        private void acknowledgeUSBAccessoryReceived(Message msg) {
             if (msg.replyTo != null) {
                 Message message = Message.obtain();
                 message.what = TransportConstants.ROUTER_USB_ACC_RECEIVED;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -864,7 +864,7 @@ public class SdlRouterService extends Service {
                     if (parcelFileDescriptor != null) {
                         // Added requirements with Android 14, Checking if we have proper permission to enter the foreground for Foreground service type connectedDevice.
                         // If we do not have permission to enter the Foreground, we pass off hosting the RouterService to another app.
-                        if (!AndroidTools.ServicePermissionUtil.hasForegroundServiceTypePermission(service.getApplicationContext())) {
+                        if (!AndroidTools.hasForegroundServiceTypePermission(service.getApplicationContext())) {
                             service.deployNextRouterService(parcelFileDescriptor);
                             acknowledgeUSBAccessoryReceived(msg);
                             return;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1202,7 +1202,6 @@ public class SdlRouterService extends Service {
                                 UsbTransferProvider usbTransferProvider = new UsbTransferProvider(getApplicationContext(), nextUp.getRouterServiceComponentName(), usbPfd, new UsbTransferProvider.UsbTransferCallback() {
                                     @Override
                                     public void onUsbTransferUpdate(boolean success) {
-                                        Log.i(TAG, "onUsbTransferUpdate: " + success);
                                         closeSelf();
                                     }
                                 });

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -2664,15 +2664,11 @@ public class SdlRouterService extends Service {
      * This method is used to check for the newest version of this class to make sure the latest and greatest is up and running.
      */
     private void startAltTransportTimer() {
-        if (Looper.myLooper() == null) {
-            Looper.prepare();
-        }
-
         if (altTransportTimerHandler != null && altTransportTimerRunnable != null) {
             altTransportTimerHandler.removeCallbacks(altTransportTimerRunnable);
         }
 
-        altTransportTimerHandler = new Handler(Looper.myLooper());
+        altTransportTimerHandler = new Handler(Looper.getMainLooper());
         altTransportTimerRunnable = new Runnable() {
             public void run() {
                 altTransportTimerHandler = null;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/UsbTransferProvider.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/UsbTransferProvider.java
@@ -179,6 +179,7 @@ public class UsbTransferProvider {
     }
 
     public void cancel() {
+        context = null;
         if (isBound) {
             unBindFromService();
         }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/UsbTransferProvider.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/UsbTransferProvider.java
@@ -40,6 +40,7 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.hardware.usb.UsbAccessory;
 import android.hardware.usb.UsbManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
@@ -193,7 +194,12 @@ public class UsbTransferProvider {
         Intent bindingIntent = new Intent();
         bindingIntent.setClassName(this.routerService.getPackageName(), this.routerService.getClassName());//This sets an explicit intent
         //Quickly make sure it's just up and running
-        context.startService(bindingIntent);
+        bindingIntent.setAction(TransportConstants.BIND_REQUEST_TYPE_ALT_TRANSPORT);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            context.startService(bindingIntent);
+        } else {
+            context.startForegroundService(bindingIntent);
+        }
         bindingIntent.setAction(TransportConstants.BIND_REQUEST_TYPE_USB_PROVIDER);
         return context.bindService(bindingIntent, routerConnection, Context.BIND_AUTO_CREATE);
     }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/UsbTransferProvider.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/UsbTransferProvider.java
@@ -179,10 +179,10 @@ public class UsbTransferProvider {
     }
 
     public void cancel() {
-        context = null;
         if (isBound) {
             unBindFromService();
         }
+        context = null;
     }
 
     private boolean bindToService() {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/UsbTransferProvider.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/UsbTransferProvider.java
@@ -131,7 +131,7 @@ public class UsbTransferProvider {
 
     }
 
-    public UsbTransferProvider(Context context, ComponentName service, ParcelFileDescriptor usbPfd, UsbTransferCallback callback) {
+    protected UsbTransferProvider(Context context, ComponentName service, ParcelFileDescriptor usbPfd, UsbTransferCallback callback) {
         if (context == null || service == null || usbPfd == null) {
             throw new IllegalStateException("Supplied params are not correct. Context == null? " + (context == null) + " ComponentName == null? " + (service == null) + " Usb PFD == null? " + usbPfd);
         }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/UsbTransferProvider.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/UsbTransferProvider.java
@@ -130,6 +130,26 @@ public class UsbTransferProvider {
 
     }
 
+    public UsbTransferProvider(Context context, ComponentName service, ParcelFileDescriptor usbPfd, UsbTransferCallback callback) {
+        if (context == null || service == null || usbPfd == null) {
+            throw new IllegalStateException("Supplied params are not correct. Context == null? " + (context == null) + " ComponentName == null? " + (service == null) + " Usb PFD == null? " + usbPfd);
+        }
+        if (usbPfd.getFileDescriptor() != null && usbPfd.getFileDescriptor().valid()) {
+            this.context = context;
+            this.routerService = service;
+            this.callback = callback;
+            this.clientMessenger = new Messenger(new ClientHandler(this));
+            this.usbPfd = usbPfd;
+            checkIsConnected();
+        } else {
+            DebugTool.logError(TAG, "Unable to open accessory");
+            clientMessenger = null;
+            if (callback != null) {
+                callback.onUsbTransferUpdate(false);
+            }
+        }
+    }
+
     @SuppressLint("NewApi")
     private ParcelFileDescriptor getFileDescriptor(UsbAccessory accessory, Context context) {
         if (AndroidTools.isUSBCableConnected(context)) {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
@@ -398,6 +398,9 @@ public class AndroidTools {
     }
 
     public static boolean hasUsbAccessoryPermission(Context context) {
+        if (context == null) {
+            return false;
+        }
         UsbManager manager = (UsbManager) context.getSystemService(Context.USB_SERVICE);
         if (manager == null || manager.getAccessoryList() == null) {
             return false;
@@ -411,6 +414,9 @@ public class AndroidTools {
     }
 
     public static boolean checkPermission(Context applicationContext, String permission) {
+        if (applicationContext == null) {
+            return false;
+        }
         return PackageManager.PERMISSION_GRANTED == ContextCompat.checkSelfPermission(applicationContext, permission);
     }
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
@@ -447,22 +447,22 @@ public class AndroidTools {
 
     /**
      * Helper method used to check permission passed in.
-     * @param applicationContext Context used to check permission
+     * @param context Context used to check permission
      * @param permission String representing permission that is being checked.
      * @return true if app has permission.
      */
-    public static boolean checkPermission(Context applicationContext, String permission) {
-        if (applicationContext == null) {
+    public static boolean checkPermission(Context context, String permission) {
+        if (context == null) {
             return false;
         }
-        return PackageManager.PERMISSION_GRANTED == ContextCompat.checkSelfPermission(applicationContext, permission);
+        return PackageManager.PERMISSION_GRANTED == ContextCompat.checkSelfPermission(context, permission);
     }
 
     /**
      * A helper method used for Android 14 or greater to check if app has necessary permissions
-     * to enter the foreground.
+     * to have a service enter the foreground.
      * @param context context used to check permissions.
-     * @return true if app has permission to enter foreground or if Android version < 14
+     * @return true if app has permission to have a service enter foreground or if Android version < 14
      */
     public static boolean hasForegroundServiceTypePermission(Context context) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
@@ -400,6 +400,9 @@ public class AndroidTools {
     public static class ServicePermissionUtil {
         public static boolean hasUsbAccessoryPermission(Context context) {
             UsbManager manager = (UsbManager) context.getSystemService(Context.USB_SERVICE);
+            if (manager == null || manager.getAccessoryList() == null) {
+                return false;
+            }
             for (final UsbAccessory usbAccessory : manager.getAccessoryList()) {
                 if (manager.hasPermission(usbAccessory)) {
                     return true;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
@@ -402,7 +402,7 @@ public class AndroidTools {
      * We need UsbAccessory permission if we are plugged in via AOA and do not have BLUETOOTH_CONNECT
      * permission for our service to enter the foreground on Android UPSIDE_DOWN_CAKE and greater
      * @param context a context that will be used to check the permission.
-     * @return true if connected via AOA and we have UsbAccessory permission
+     * @return true if connected via AOA and we have UsbAccessory permission.
      */
     public static boolean hasUsbAccessoryPermission(Context context) {
         if (context == null) {
@@ -420,6 +420,12 @@ public class AndroidTools {
         return false;
     }
 
+    /**
+     * Helper method used to check permission passed in.
+     * @param applicationContext Context used to check permission
+     * @param permission String representing permission that is being checked.
+     * @return true if app has permission.
+     */
     public static boolean checkPermission(Context applicationContext, String permission) {
         if (applicationContext == null) {
             return false;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
@@ -433,9 +433,13 @@ public class AndroidTools {
         return PackageManager.PERMISSION_GRANTED == ContextCompat.checkSelfPermission(applicationContext, permission);
     }
 
+    /**
+     * A helper method used for Android 14 or greater to check if app has necessary permissions
+     * to enter the foreground.
+     * @param context context used to check permissions.
+     * @return true if app has permission to enter foreground or if Android version < 14
+     */
     public static boolean hasForegroundServiceTypePermission(Context context) {
-        // if Build is less than Android 14, we don't need either permission to enter the
-        // foreground.
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             return true;
         }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
@@ -397,6 +397,13 @@ public class AndroidTools {
         }
     }
 
+    /**
+     * A helper method is used to see if this app has permission for UsbAccessory.
+     * We need UsbAccessory permission if we are plugged in via AOA and do not have BLUETOOTH_CONNECT
+     * permission for our service to enter the foreground on Android UPSIDE_DOWN_CAKE and greater
+     * @param context a context that will be used to check the permission.
+     * @return true if connected via AOA and we have UsbAccessory permission
+     */
     public static boolean hasUsbAccessoryPermission(Context context) {
         if (context == null) {
             return false;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
@@ -397,30 +397,30 @@ public class AndroidTools {
         }
     }
 
-    public static class ServicePermissionUtil {
-        public static boolean hasUsbAccessoryPermission(Context context) {
-            UsbManager manager = (UsbManager) context.getSystemService(Context.USB_SERVICE);
-            if (manager == null || manager.getAccessoryList() == null) {
-                return false;
-            }
-            for (final UsbAccessory usbAccessory : manager.getAccessoryList()) {
-                if (manager.hasPermission(usbAccessory)) {
-                    return true;
-                }
-            }
+    public static boolean hasUsbAccessoryPermission(Context context) {
+        UsbManager manager = (UsbManager) context.getSystemService(Context.USB_SERVICE);
+        if (manager == null || manager.getAccessoryList() == null) {
             return false;
         }
-
-        public static boolean checkPermission(Context applicationContext, String permission) {
-            return PackageManager.PERMISSION_GRANTED == ContextCompat.checkSelfPermission(applicationContext, permission);
-        }
-
-        public static boolean hasForegroundServiceTypePermission(Context context) {
-            // if Build is less than Android 14, we don't need either permission to enter the foreground.
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        for (final UsbAccessory usbAccessory : manager.getAccessoryList()) {
+            if (manager.hasPermission(usbAccessory)) {
                 return true;
             }
-            return ServicePermissionUtil.checkPermission(context, Manifest.permission.BLUETOOTH_CONNECT) || ServicePermissionUtil.hasUsbAccessoryPermission(context);
         }
+        return false;
+    }
+
+    public static boolean checkPermission(Context applicationContext, String permission) {
+        return PackageManager.PERMISSION_GRANTED == ContextCompat.checkSelfPermission(applicationContext, permission);
+    }
+
+    public static boolean hasForegroundServiceTypePermission(Context context) {
+        // if Build is less than Android 14, we don't need either permission to enter the
+        // foreground.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            return true;
+        }
+        return checkPermission(context,
+                Manifest.permission.BLUETOOTH_CONNECT) || hasUsbAccessoryPermission(context);
     }
 }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
@@ -32,6 +32,7 @@
 
 package com.smartdevicelink.util;
 
+import android.Manifest;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
@@ -47,10 +48,13 @@ import android.content.res.Resources;
 import android.content.res.XmlResourceParser;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.hardware.usb.UsbAccessory;
+import android.hardware.usb.UsbManager;
 import android.os.BatteryManager;
 import android.os.Build;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
 
 import com.smartdevicelink.marshal.JsonRPCMarshaller;
 import com.smartdevicelink.proxy.rpc.VehicleType;
@@ -390,6 +394,30 @@ public class AndroidTools {
         } catch (Resources.NotFoundException ex) {
             DebugTool.logError(TAG, "Failed to find resource: " + ex.getMessage() + " - assume vehicle data is supported");
             return null;
+        }
+    }
+
+    public static class ServicePermissionUtil {
+        public static boolean hasUsbAccessoryPermission(Context context) {
+            UsbManager manager = (UsbManager) context.getSystemService(Context.USB_SERVICE);
+            for (final UsbAccessory usbAccessory : manager.getAccessoryList()) {
+                if (manager.hasPermission(usbAccessory)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public static boolean checkPermission(Context applicationContext, String permission) {
+            return PackageManager.PERMISSION_GRANTED == ContextCompat.checkSelfPermission(applicationContext, permission);
+        }
+
+        public static boolean hasForegroundServiceTypePermission(Context context) {
+            // if Build is less than Android 14, we don't need either permission to enter the foreground.
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                return true;
+            }
+            return ServicePermissionUtil.checkPermission(context, Manifest.permission.BLUETOOTH_CONNECT) || ServicePermissionUtil.hasUsbAccessoryPermission(context);
         }
     }
 }


### PR DESCRIPTION
Fixes #1859 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Unit Tests
Unit tests were run on the integration branch. CI check failed due to needing the app to target API 34.

#### Core Tests
Note: Before you install a second and third app, unplug the phone from the computer and switch the build variant before deploying the app to the phone otherwise Android Studio will kill the app.

Apps A, B and C.
Test 1:
Install App A
Accept BT permission
Install App B
Deny BT permission
Connect to TDK via AOA
Select App A to receive intent
Allow App B to connect when prompted
Observe: App B pass hosting the RS to app A and both apps connect.

Test 2:
Install App A
Deny BT permission
Install App B
Deny BT permission
Connect to TDK via AOA
Select App A to receive intent
Allow App B to connect when prompted
Observe App B passed hosting the RS to app A and both apps connect.

Test 3:
Install App A
Deny BT permission
Install App B
Deny BT permission
Install App C 
Deny BT permission
Connect to TDK via AOA
Select App A to receive intent
Allow App C to connect when prompted
Allow App B to connect if you're prompted.(not 100%)
Observe App C passed hosting the RS to App B who passed to App A and Apps A and C are connected. App B may not connect.

Core version / branch / commit hash / module tested against: Sync 3
HMI name / version / branch / commit hash / module tested against: Sync 3

### Summary
This pr adds the foreground service type of connectedDevice to our library. This is a requirement for Android 14.
With this addition, we are required to have either the Bluetooth Connect permission or call UsbManager.requestPermission() to have our service enter the foreground. if the connection is AOA and an app selected to host the RouterService does not have either permission, we will try to pass hosting the RouterService off to another app.

I also add the ability to be able to request the usb permission in SdlReceiver.onSdlEnabled in the event that 

### Changelog
##### Bug Fixes
* Fixed the library to allow for it to target Android 14 and be able to enter the foreground

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
