### PR TITLE
Android 14 add package to PendingIntents in RouterService

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -158,9 +158,7 @@ public class SdlRouterService extends Service {
     public static final String SDL_NOTIFICATION_FAQS_PAGE = "https://smartdevicelink.com/en/guides/android/frequently-asked-questions/sdl-notifications/";
 
     public static final String REGISTER_WITH_ROUTER_ACTION = "com.sdl.android.register";
-
-    public static final String SDL_PACKAGE = "com.smartdevicelink";
-
+    
     /**
      * Message types sent from the BluetoothReadService Handler
      */
@@ -1860,7 +1858,7 @@ public class SdlRouterService extends Service {
             //the developer can use this pendingIntent to start their SdlService from the context of
             //the active RouterService
             Intent pending = new Intent();
-            pending.setPackage(SDL_PACKAGE);
+            pending.setPackage(getPackageName());
             PendingIntent pendingIntent = PendingIntent.getForegroundService(this, (int) System.currentTimeMillis(), pending, PendingIntent.FLAG_MUTABLE | Intent.FILL_IN_COMPONENT);
             startService.putExtra(TransportConstants.PENDING_INTENT_EXTRA, pendingIntent);
         }
@@ -2984,7 +2982,7 @@ public class SdlRouterService extends Service {
             //the developer can use this pendingIntent to start their SdlService from the context of
             //the active RouterService
             Intent pending = new Intent();
-            pending.setPackage(SDL_PACKAGE);
+            pending.setPackage(getPackageName());
             PendingIntent pendingIntent = PendingIntent.getForegroundService(this, (int) System.currentTimeMillis(), pending, PendingIntent.FLAG_MUTABLE | Intent.FILL_IN_COMPONENT);
             pingIntent.putExtra(TransportConstants.PENDING_INTENT_EXTRA, pendingIntent);
         }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -159,6 +159,8 @@ public class SdlRouterService extends Service {
 
     public static final String REGISTER_WITH_ROUTER_ACTION = "com.sdl.android.register";
 
+    public static final String SDL_PACKAGE = "com.smartdevicelink";
+
     /**
      * Message types sent from the BluetoothReadService Handler
      */
@@ -1858,6 +1860,7 @@ public class SdlRouterService extends Service {
             //the developer can use this pendingIntent to start their SdlService from the context of
             //the active RouterService
             Intent pending = new Intent();
+            pending.setPackage(SDL_PACKAGE);
             PendingIntent pendingIntent = PendingIntent.getForegroundService(this, (int) System.currentTimeMillis(), pending, PendingIntent.FLAG_MUTABLE | Intent.FILL_IN_COMPONENT);
             startService.putExtra(TransportConstants.PENDING_INTENT_EXTRA, pendingIntent);
         }
@@ -2978,6 +2981,7 @@ public class SdlRouterService extends Service {
             //the developer can use this pendingIntent to start their SdlService from the context of
             //the active RouterService
             Intent pending = new Intent();
+            pending.setPackage(SDL_PACKAGE);
             PendingIntent pendingIntent = PendingIntent.getForegroundService(this, (int) System.currentTimeMillis(), pending, PendingIntent.FLAG_MUTABLE | Intent.FILL_IN_COMPONENT);
             pingIntent.putExtra(TransportConstants.PENDING_INTENT_EXTRA, pendingIntent);
         }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -158,7 +158,7 @@ public class SdlRouterService extends Service {
     public static final String SDL_NOTIFICATION_FAQS_PAGE = "https://smartdevicelink.com/en/guides/android/frequently-asked-questions/sdl-notifications/";
 
     public static final String REGISTER_WITH_ROUTER_ACTION = "com.sdl.android.register";
-    
+
     /**
      * Message types sent from the BluetoothReadService Handler
      */


### PR DESCRIPTION
Fixes #1861 

This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Unit Tests
n/a

#### Core Tests
Note: Before you install a second and thrid app, unplug the phone from the computer and switch the build variant before deploying app to the phone otherwise Android Studio will kill the app. 
Or you can open each app up on the phone after deploying all three apps.

Test 1
Install 3 apps to the phone
Connect via Bluetooth to TDK
Observe all apps connect.

Test 2
Repeat test 1 but with release build versions of the apps.

Core version / branch / commit hash / module tested against: Sync 3
HMI name / version / branch / commit hash / module tested against: Sync 3

### Summary
This PR adds a package to pending intents in the RouterService to prevent an exception from being thrown in the RouterService.

### Changelog
##### Bug Fixes
* Add Package to pending intent to prevent an exception from being thrown due to API 34 restrictions. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
