### PR TITLE
Clean LifecycleManager before closing

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -167,6 +167,7 @@ public class LifecycleManager extends BaseLifecycleManager {
             DebugTool.logInfo(TAG, "notifying RPC session ended, but potential primary transport available");
             cycle(SdlDisconnectedReason.PRIMARY_TRANSPORT_CYCLE_REQUEST);
         } else {
+            clean(false);
             onClose(info, null, null);
         }
     }


### PR DESCRIPTION
Fixes #1865 

This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Unit Tests
n/a

#### Core Tests
Tested connecting hello sdl using mulit_high_bandwidthDebug build and observed no service connecting leak.

Core version / branch / commit hash / module tested against: Sync 3
HMI name / version / branch / commit hash / module tested against: Sync 3

### Summary
This PR adds a missing call to clean up the LifecycelManager before closing it.

### Changelog
##### Bug Fixes
* This PR fixes the service connection leak seen with high_bandwidth app builds.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
