### PR TITLE
Bugfix/issue 1867 Bluetooth notification error fix 

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -3909,6 +3909,11 @@ public class SdlRouterService extends Service {
     @TargetApi(11)
     @SuppressLint("NewApi")
     private void notifySppError() {
+        // Check first to see if the RouterService is in the Foreground
+        // This is to prevent the notification appearing in error
+        if (!this.isForeground) {
+            return;
+        }
         Notification.Builder builder;
         if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             builder = new Notification.Builder(getApplicationContext());

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -3912,10 +3912,12 @@ public class SdlRouterService extends Service {
     @TargetApi(11)
     @SuppressLint("NewApi")
     private void notifySppError() {
-        // Check first to see if the RouterService is in the Foreground
-        // This is to prevent the notification appearing in error
-        if (!this.isForeground) {
-            return;
+        synchronized (FOREGROUND_NOTIFICATION_LOCK) {
+            // Check first to see if the RouterService is in the Foreground
+            // This is to prevent the notification appearing in error
+            if (!this.isForeground) {
+                return;
+            }
         }
         Notification.Builder builder;
         if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {


### PR DESCRIPTION
Fixes #1867 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Unit Tests
n/a

#### Core Tests
Test 1
1. Install SDL app to phone
2. Connect to tdk via Bluetooth
3. Observe SDL app connection
4. Disconnect from tdk by clicking on the BT connection and clicking disconnect on the phone.
Repeat steps 2-4 up to 30 times
Observe: 
Bluetooth notification does not appear for too many apps using Bluetooth.

Test 2
1. Install SDL app to phone 
2. Connect to TDK
3. Disconnect Bluetooth from TDK, but leave Bluetooth turned on.
4. Install and run this app https://github.com/shiniwat/consumespp and let it consume all available SPP resources
5. Connect to TDK
Observe:
Bluetooth notification appears for too many apps using Bluetooth


Core version / branch / commit hash / module tested against: Sync 3
HMI name / version / branch / commit hash / module tested against: Sync 3

### Summary
Add a check to see if RouterService is in the Foreground before sending the spp notification.

### Changelog
##### Bug Fixes
* Fixes an issue where the spp notification was being sent to the users in error.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
