### PR TITLE
Fix NPE in SdlRouterService

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -2939,6 +2939,9 @@ public class SdlRouterService extends Service {
         long currentPriority = -Long.MAX_VALUE, peekWeight;
         synchronized (REGISTERED_APPS_LOCK) {
             PacketWriteTask peekTask;
+            if (registeredApps == null) {
+                return null;
+            }
             for (RegisteredApp app : registeredApps.values()) {
                 peekTask = app.peekNextTask(transportType);
                 if (peekTask != null) {


### PR DESCRIPTION
Fixes #1869 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Unit Tests
n/a

#### Core Tests
I tested manually setting the HashMap registerApps to null just before the spot where the NPE was hitting and connecting to a Sync 3 tdk.

### Summary
This PR adds a null check in the RouterService to prevent an NPE from appearing for a partner app.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
