### PR TITLE
Add logic to handle RAI response failure

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/lifecycle/BaseLifecycleManager.java
@@ -407,7 +407,15 @@ abstract class BaseLifecycleManager {
                         //We have begun
                         DebugTool.logInfo(TAG, "RAI Response");
                         BaseLifecycleManager.this.raiResponse = (RegisterAppInterfaceResponse) message;
-                        SdlMsgVersion rpcVersion = ((RegisterAppInterfaceResponse) message).getSdlMsgVersion();
+                        if (!BaseLifecycleManager.this.raiResponse.getSuccess()) {
+                            String info = "App registration was not successful, result = " + BaseLifecycleManager.this.raiResponse.getResultCode();
+                            DebugTool.logError(TAG, info);
+                            clean(false);
+                            onClose(info, null, SdlDisconnectedReason.SDL_REGISTRATION_ERROR);
+                            return;
+                        }
+                        
+                        SdlMsgVersion rpcVersion = BaseLifecycleManager.this.raiResponse.getSdlMsgVersion();
                         if (rpcVersion != null) {
                             BaseLifecycleManager.this.rpcSpecVersion = new Version(rpcVersion.getMajorVersion(), rpcVersion.getMinorVersion(), rpcVersion.getPatchVersion());
                         } else {


### PR DESCRIPTION
Fixes #1872 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
N/A

#### Core Tests

1. Install base version of Hello SDL (no security)
2. Change package name and SDL app ID in gradle, sync build
3. Install modified Hello SDL
4. Connect to IVI
5. Observe one of the apps connect and the other properly closes because of a duplicate name error

Core version / branch / commit hash / module tested against: Ford TDK Gen3
HMI name / version / branch / commit hash / module tested against:  Ford TDK Gen3

### Summary
This PR simply adds a check to make sure the`RegisterAppInterface` response RPC was successful. In the case that it is not, it will clean the LCM and close the instance. This allows the app to close its service class as well and be prepared for the next connection. While the test is not a real world situation, it shows what will happen during a failure which can occur if the IVI does not unregister the app fast enough during transport switching scenarios (BT to BT & USB to only USB)

### Changelog
##### Bug Fixes
* Added check for unsuccessful app registration with IVI

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
