### PR TITLE
Update integration validator with latest permissions and checks for exported

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/IntegrationValidator.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/IntegrationValidator.java
@@ -170,6 +170,10 @@ public class IntegrationValidator {
                         int j = 0;
                         for (ResolveInfo sdlReceiver : sdlReceivers) {
                             if (receiver.name.equals(sdlReceiver.activityInfo.name)) {
+                                if (!receiver.exported) {
+                                    retVal.successful = false;
+                                    retVal.resultText = "This application has not marked its SdlBroadcastReceiver as exported";
+                                }
                                 return retVal;
                             }
                         }
@@ -193,6 +197,11 @@ public class IntegrationValidator {
             if (info.serviceInfo.metaData == null || !info.serviceInfo.metaData.containsKey(context.getString(R.string.sdl_router_service_version_name))) {
                 retVal.successful = false;
                 retVal.resultText = "This application has not specified its metadata tags for the SdlRouterService.";
+            }
+
+            if (!info.serviceInfo.exported) {
+                retVal.successful = false;
+                retVal.resultText = "This application has not marked its SdlRouterService as exported.";
             }
         } else {
             retVal.successful = false;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/IntegrationValidator.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/IntegrationValidator.java
@@ -114,6 +114,15 @@ public class IntegrationValidator {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             permissionList.add(Manifest.permission.FOREGROUND_SERVICE);
         }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            permissionList.add(Manifest.permission.BLUETOOTH_CONNECT);
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            permissionList.add(Manifest.permission.POST_NOTIFICATIONS);
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            permissionList.add(Manifest.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE);
+        }
         try {
             PackageInfo packageInfo = context.getPackageManager().getPackageInfo(context.getApplicationContext().getPackageName(), PackageManager.GET_PERMISSIONS);
             String[] permissionInfos = packageInfo.requestedPermissions;


### PR DESCRIPTION
Fixes #1874 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Unit Tests
N/A

#### Core Tests
N/A

### Summary
This PR updates the `IntegrationValidator` to include some of the newly required permissions over the last couple of Android OS updates. It also added checks to ensure that the `SdlRouterService` is exported for the app along with the app's extension of the `SdlBroadcastReceiver`.

### Changelog

##### Enhancements
* Add checks for missing permissions
* Add checks for exported flags being set to try for SDL components

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
