### PR TITLE
Fix SDLLockScreenActivityEspressoTest for newer devices

### DIFF
--- a/android/sdl_android/build.gradle
+++ b/android/sdl_android/build.gradle
@@ -23,8 +23,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
     lintOptions {
         abortOnError false

--- a/android/sdl_android/build.gradle
+++ b/android/sdl_android/build.gradle
@@ -51,9 +51,9 @@ dependencies {
     annotationProcessor 'androidx.lifecycle:lifecycle-compiler:2.2.0'
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:3.0.0'
-    androidTestImplementation 'org.mockito:mockito-core:3.0.0'
-    androidTestImplementation 'org.mockito:mockito-android:3.0.0'
+    testImplementation 'org.mockito:mockito-core:5.7.0'
+    androidTestImplementation 'org.mockito:mockito-core:5.7.0'
+    androidTestImplementation 'org.mockito:mockito-android:5.7.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.5.1'

--- a/android/sdl_android/src/androidTest/AndroidManifest.xml
+++ b/android/sdl_android/src/androidTest/AndroidManifest.xml
@@ -16,7 +16,7 @@
 
     <application android:debuggable="true">
         <uses-library android:name="android.test.runner" />
-        <activity android:name=".managers.lockscreen.SDLLockScreenActivity" />
+        <activity android:name="com.smartdevicelink.managers.lockscreen.SDLLockScreenActivity" />
     </application>
 
 </manifest>


### PR DESCRIPTION
Fixes #1876 

This PR is **[not ready]** for review.

### Risk
This PR makes **[no / minor / major]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
All unit test were ran with this PR

#### Core Tests
Took Hello SDL through some basic test due to Gradle changes

Core version / branch / commit hash / module tested against: Sync 3
HMI name / version / branch / commit hash / module tested against: Sync 3

### Summary


### Changelog
##### Breaking Changes
* NEED TO ADD

##### Bug Fixes
*  Fix SDLLockScreenActivityEspressoTest test for newer devices

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
