### PR TITLE
Remove only app logic for device listener start

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -332,16 +332,15 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver {
                             DebugTool.logInfo(TAG, ": This app's package: " + myPackage);
                             DebugTool.logInfo(TAG, ": Router service app's package: " + routerService.getPackageName());
                             if (myPackage != null && myPackage.equalsIgnoreCase(routerService.getPackageName())) {
-                                //If the device is not null the listener should start as well as the
-                                //case where this app was installed after BT connected and is the
-                                //only SDL app installed on the device. (Rare corner case)
-                                if (device != null || sdlAppInfoList.size() == 1) {
-                                    SdlDeviceListener sdlDeviceListener = getSdlDeviceListener(context, device);
-                                    if (!sdlDeviceListener.isRunning()) {
-                                        sdlDeviceListener.start();
-                                    }
+                                //If this app should be hosting the RS it's time to start the device
+                                //listener. If the BT device is not null and has already connected,
+                                //this app's RS will be started immediately. Otherwise the device
+                                //listener will act as a gate keeper to prevent unnecessary notifications.
+                                SdlDeviceListener sdlDeviceListener = getSdlDeviceListener(context, device);
+                                if (!sdlDeviceListener.isRunning()) {
+                                    sdlDeviceListener.start();
                                 } else {
-                                    DebugTool.logInfo(TAG, "Not starting device listener, bluetooth device is null and other SDL apps installed.");
+                                    DebugTool.logInfo(TAG, "Device listener is already running");
                                 }
                             } else if (isPreAndroid12RSOnDevice) {
                                 //If the RS app has the BLUETOOTH_CONNECT permission that means it

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -336,11 +336,15 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver {
                                 //listener. If the BT device is not null and has already connected,
                                 //this app's RS will be started immediately. Otherwise the device
                                 //listener will act as a gate keeper to prevent unnecessary notifications.
-                                SdlDeviceListener sdlDeviceListener = getSdlDeviceListener(context, device);
-                                if (!sdlDeviceListener.isRunning()) {
-                                    sdlDeviceListener.start();
+                                if (device != null || AndroidTools.isBluetoothDeviceConnected()) {
+                                    SdlDeviceListener sdlDeviceListener = getSdlDeviceListener(context, device);
+                                    if (!sdlDeviceListener.isRunning()) {
+                                        sdlDeviceListener.start();
+                                    } else {
+                                        DebugTool.logInfo(TAG, "Device listener is already running");
+                                    }
                                 } else {
-                                    DebugTool.logInfo(TAG, "Device listener is already running");
+                                    DebugTool.logInfo(TAG, "No bluetooth device and no device connected");
                                 }
                             } else if (isPreAndroid12RSOnDevice) {
                                 //If the RS app has the BLUETOOTH_CONNECT permission that means it

--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
@@ -33,6 +33,8 @@
 package com.smartdevicelink.util;
 
 import android.annotation.SuppressLint;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothProfile;
 import android.content.BroadcastReceiver;
 import android.Manifest;
 import android.content.ComponentName;
@@ -470,5 +472,29 @@ public class AndroidTools {
         }
         return checkPermission(context,
                 Manifest.permission.BLUETOOTH_CONNECT) || hasUsbAccessoryPermission(context);
+    }
+
+    /**
+     * A method that will check to see if there is a bluetooth device possibly connected. It will
+     * only check the headset and A2DP profiles. This is only to be used as a check for starting
+     * the SdlDeviceListener and not a direct start of the router service.
+     * @return if a bluetooth device is connected
+     */
+    @SuppressLint("MissingPermission")
+    public static boolean isBluetoothDeviceConnected() {
+        try {
+            BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+            if (bluetoothAdapter != null && bluetoothAdapter.isEnabled()) {
+                int headsetState = bluetoothAdapter.getProfileConnectionState(BluetoothProfile.HEADSET);
+                int a2dpState = bluetoothAdapter.getProfileConnectionState(BluetoothProfile.A2DP);
+                return headsetState == BluetoothAdapter.STATE_CONNECTING
+                        || headsetState == BluetoothAdapter.STATE_CONNECTED
+                        || a2dpState == BluetoothAdapter.STATE_CONNECTING
+                        || a2dpState == BluetoothAdapter.STATE_CONNECTED;
+            }
+        } catch (Exception e) {
+            DebugTool.logError(TAG, "Unable to check for connected bluetooth device", e);
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Fixes #1878 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Unit Tests
N/A

#### Core Tests

###### Test 1
1. Connect BT with a device with an SDL app installed
2. Allow the RS service to timeout for the connection
3. Open the app again and select "Find new apps"
4. Observe RS notification appears

###### Test 2
1. Install another app with HelloSdl on device
2. Connect over BT with IVI
3. Redeploy HelloSdl
4. Observe the router service is taken down and SDL connection is lost
6. Wait a few seconds
7. Observe the router service starts back up and IVI connects to it (Might have to use Find New Apps)

###### Test 3
1. Ensure no BT device is connected
2. Install HelloSdl
3. Observe the device listener is not started

Test should also include tests from #1384 and #1685 (except test Multiple apps, one installed after BT connection, non SDL device is now invalid)

Core version / branch / commit hash / module tested against: Ford TDK
HMI name / version / branch / commit hash / module tested against: Ford TDK

### Summary
This PR changes a limitation to the waking up the router service process where it would only start the SdlDeviceListener if there was a supplied BT device or if it was the only SDL app installed. This PR will allow the device lisetener to start any time as long as there is a BT device supplied from the broadcast receiver or if a BT device is connected using the headset or A2DP profiles. This is to increase the ability to to connect to IVIs without the need to always disconnect BT and reconnect. 

### Changelog

##### Enhancements
* Update limitations for when to start the device listener. 


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
