### PR TITLE
Fix NPE in TransportBorker 

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/TransportBroker.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/TransportBroker.java
@@ -764,10 +764,10 @@ public class TransportBroker {
      * Method to shut down RouterServiceMessenger
      */
     private void shutDownRouterServiceMessenger() {
-        routerServiceMessenger = null;
         if (routerServiceMessageEmitter != null) {
             routerServiceMessageEmitter.close();
         }
         routerServiceMessageEmitter = null;
+        routerServiceMessenger = null;
     }
 }


### PR DESCRIPTION
Fixes #1881 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Unit Tests
n/a

#### Core Tests
Test 1: (This is from our test plan using test suite and hello_sdl)
1. This test needs two apps (app1 is custom RS, hello_sdl)
2. Use test suite customRS flavor as an app1, start the app, then go to menu and click on "Start Custom RS"
3. Use hello_sdl with multi_sec_off flavor for the second app but do the following changes:
  i.  Change the UUID in MultiplexBluetoothTransport.SERVER_UUID to any other UUID
  ii. Modify the way MainActivity starts the SdlService to manually start the SdlService instead of calling queryForConnectedServices
4. Start hello_sdl and make sure it connects through the custom RS

Test 2: (This is the accidental test I ran when I found the NPE)
1. Run test 1 but have second app use multi_high_bandwidth flavor for hello_sdl
2. Observe that the custom RS is connected, but app hello_sdl does not connect, no NPE in logs

Core version / branch / commit hash / module tested against: Sync 3
HMI name / version / branch / commit hash / module tested against: Sync 3

### Summary
This PR fixes an NPE which can happen if we don't close the `routerServiceMessageEmitter` before we set `routerServiceMessenger` to null in `TransportBroker.shutDownRouterServiceMessenger`

##### Bug Fixes
* Fix NPE in TransportBroker

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
